### PR TITLE
Backend: Auth — implement email verification flow

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,6 +21,13 @@ REDIS_PORT=6379
 
 # Email
 EMAIL_ENABLED=false
+EMAIL_HOST=smtp.example.com
+EMAIL_PORT=587
+EMAIL_SECURE=false
+EMAIL_USER=your_email_user
+EMAIL_PASS=your_email_password
+EMAIL_FROM="Brain Storm" <no-reply@brainstorm.app>
+FRONTEND_URL=http://localhost:3001
 
 # Frontend
 NEXT_PUBLIC_API_URL=http://localhost:3000

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -23,13 +23,17 @@
     "bcrypt": "^5.1.0",
     "@stellar/stellar-sdk": "^12.0.0",
     "class-validator": "^0.14.0",
-    "class-transformer": "^0.5.0"
+    "class-transformer": "^0.5.0",
+    "nodemailer": "^6.9.0",
+    "nodemailer": "*",
+    "@types/nodemailer": "*"
   },
   "devDependencies": {
     "@nestjs/cli": "^10.0.0",
     "@types/node": "^20.0.0",
     "typescript": "^5.4.0",
     "jest": "^29.0.0",
-    "@types/jest": "^29.0.0"
+    "@types/jest": "^29.0.0",
+    "@types/nodemailer": "^6.4.0"
   }
 }

--- a/apps/backend/src/auth/auth.controller.ts
+++ b/apps/backend/src/auth/auth.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Post } from '@nestjs/common';
+import { Body, Controller, Get, Post, Query } from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
 import { AuthService } from './auth.service';
 import { IsEmail, IsString, MinLength } from 'class-validator';
@@ -6,6 +6,10 @@ import { IsEmail, IsString, MinLength } from 'class-validator';
 class AuthDto {
   @IsEmail() email: string;
   @IsString() @MinLength(8) password: string;
+}
+
+class ResendVerificationDto {
+  @IsEmail() email: string;
 }
 
 @ApiTags('auth')
@@ -21,5 +25,15 @@ export class AuthController {
   @Post('login')
   login(@Body() dto: AuthDto) {
     return this.authService.login(dto.email, dto.password);
+  }
+
+  @Get('verify')
+  verifyEmail(@Query('token') token: string) {
+    return this.authService.verifyEmail(token);
+  }
+
+  @Post('resend-verification')
+  resendVerification(@Body() dto: ResendVerificationDto) {
+    return this.authService.resendVerification(dto.email);
   }
 }

--- a/apps/backend/src/auth/auth.module.ts
+++ b/apps/backend/src/auth/auth.module.ts
@@ -2,12 +2,14 @@ import { Module } from '@nestjs/common';
 import { JwtModule } from '@nestjs/jwt';
 import { PassportModule } from '@nestjs/passport';
 import { UsersModule } from '../users/users.module';
+import { MailModule } from '../mail/mail.module';
 import { AuthService } from './auth.service';
 import { AuthController } from './auth.controller';
 
 @Module({
   imports: [
     UsersModule,
+    MailModule,
     PassportModule,
     JwtModule.register({
       secret: process.env.JWT_SECRET || 'dev_secret',

--- a/apps/backend/src/auth/auth.service.ts
+++ b/apps/backend/src/auth/auth.service.ts
@@ -1,19 +1,42 @@
-import { Injectable, UnauthorizedException } from '@nestjs/common';
+import {
+  Injectable,
+  UnauthorizedException,
+  ForbiddenException,
+  BadRequestException,
+  NotFoundException,
+} from '@nestjs/common';
 import { JwtService } from '@nestjs/jwt';
 import { UsersService } from '../users/users.service';
+import { MailService } from '../mail/mail.service';
 import * as bcrypt from 'bcrypt';
+import * as crypto from 'crypto';
 
 @Injectable()
 export class AuthService {
   constructor(
     private usersService: UsersService,
     private jwtService: JwtService,
+    private mailService: MailService,
   ) {}
 
   async register(email: string, password: string) {
+    const existing = await this.usersService.findByEmail(email);
+    if (existing) throw new BadRequestException('Email already in use');
+
     const passwordHash = await bcrypt.hash(password, 10);
-    const user = await this.usersService.create({ email, passwordHash });
-    return this.signToken(user.id, user.email);
+    const { token, hash, expiresAt } = this.generateVerificationToken();
+
+    const user = await this.usersService.create({
+      email,
+      passwordHash,
+      isVerified: false,
+      verificationToken: hash,
+      verificationTokenExpiresAt: expiresAt,
+    });
+
+    await this.mailService.sendVerificationEmail(user.email, token);
+
+    return { message: 'Registration successful. Please verify your email.' };
   }
 
   async login(email: string, password: string) {
@@ -21,7 +44,54 @@ export class AuthService {
     if (!user || !(await bcrypt.compare(password, user.passwordHash))) {
       throw new UnauthorizedException('Invalid credentials');
     }
+    if (!user.isVerified) {
+      throw new ForbiddenException('Please verify your email before logging in');
+    }
     return this.signToken(user.id, user.email);
+  }
+
+  async verifyEmail(token: string) {
+    const hash = this.hashToken(token);
+    const user = await this.usersService.findByVerificationToken(hash);
+
+    if (!user) throw new BadRequestException('Invalid or expired verification token');
+    if (user.verificationTokenExpiresAt < new Date()) {
+      throw new BadRequestException('Verification token has expired');
+    }
+
+    await this.usersService.update(user.id, {
+      isVerified: true,
+      verificationToken: null,
+      verificationTokenExpiresAt: null,
+    });
+
+    return { message: 'Email verified successfully. You can now log in.' };
+  }
+
+  async resendVerification(email: string) {
+    const user = await this.usersService.findByEmail(email);
+    if (!user) throw new NotFoundException('User not found');
+    if (user.isVerified) throw new BadRequestException('Email is already verified');
+
+    const { token, hash, expiresAt } = this.generateVerificationToken();
+    await this.usersService.update(user.id, {
+      verificationToken: hash,
+      verificationTokenExpiresAt: expiresAt,
+    });
+
+    await this.mailService.sendVerificationEmail(user.email, token);
+    return { message: 'Verification email resent.' };
+  }
+
+  private generateVerificationToken() {
+    const token = crypto.randomBytes(32).toString('hex');
+    const hash = this.hashToken(token);
+    const expiresAt = new Date(Date.now() + 24 * 60 * 60 * 1000); // 24h
+    return { token, hash, expiresAt };
+  }
+
+  private hashToken(token: string) {
+    return crypto.createHash('sha256').update(token).digest('hex');
   }
 
   private signToken(userId: string, email: string) {

--- a/apps/backend/src/mail/mail.module.ts
+++ b/apps/backend/src/mail/mail.module.ts
@@ -1,0 +1,8 @@
+import { Module } from '@nestjs/common';
+import { MailService } from './mail.service';
+
+@Module({
+  providers: [MailService],
+  exports: [MailService],
+})
+export class MailModule {}

--- a/apps/backend/src/mail/mail.service.ts
+++ b/apps/backend/src/mail/mail.service.ts
@@ -1,0 +1,38 @@
+import { Injectable, Logger } from '@nestjs/common';
+import * as nodemailer from 'nodemailer';
+
+@Injectable()
+export class MailService {
+  private readonly logger = new Logger(MailService.name);
+  private transporter: nodemailer.Transporter;
+
+  constructor() {
+    this.transporter = nodemailer.createTransport({
+      host: process.env.EMAIL_HOST,
+      port: parseInt(process.env.EMAIL_PORT || '587'),
+      secure: process.env.EMAIL_SECURE === 'true',
+      auth: {
+        user: process.env.EMAIL_USER,
+        pass: process.env.EMAIL_PASS,
+      },
+    });
+  }
+
+  async sendVerificationEmail(to: string, token: string) {
+    const frontendUrl = process.env.FRONTEND_URL || 'http://localhost:3001';
+    const verifyUrl = `${frontendUrl}/auth/verify?token=${token}`;
+
+    if (process.env.EMAIL_ENABLED !== 'true') {
+      this.logger.log(`[DEV] Verification link for ${to}: ${verifyUrl}`);
+      return;
+    }
+
+    await this.transporter.sendMail({
+      from: process.env.EMAIL_FROM || '"Brain Storm" <no-reply@brainstorm.app>',
+      to,
+      subject: 'Verify your email',
+      html: `<p>Click the link below to verify your email. It expires in 24 hours.</p>
+             <a href="${verifyUrl}">${verifyUrl}</a>`,
+    });
+  }
+}

--- a/apps/backend/src/users/user.entity.ts
+++ b/apps/backend/src/users/user.entity.ts
@@ -17,6 +17,15 @@ export class User {
   @Column({ default: 'student' })
   role: string;
 
+  @Column({ default: false })
+  isVerified: boolean;
+
+  @Column({ nullable: true, type: 'varchar' })
+  verificationToken: string | null;
+
+  @Column({ nullable: true, type: 'timestamp' })
+  verificationTokenExpiresAt: Date | null;
+
   @CreateDateColumn()
   createdAt: Date;
 }

--- a/apps/backend/src/users/users.service.ts
+++ b/apps/backend/src/users/users.service.ts
@@ -11,6 +11,10 @@ export class UsersService {
     return this.repo.findOne({ where: { email } });
   }
 
+  findByVerificationToken(hash: string) {
+    return this.repo.findOne({ where: { verificationToken: hash } });
+  }
+
   findById(id: string) {
     return this.repo.findOne({ where: { id } });
   }


### PR DESCRIPTION
closes #2 


feat: add email verification flow
feat(auth): implement production-grade email verification flow

- Block JWT issuance on registration; return success message instead
- Generate cryptographically secure random token (SHA-256 hashed before storage)
- Store token hash + 24h expiry on User entity (verificationToken, verificationTokenExpiresAt)
- Add isVerified flag to User entity; default false
- Create MailModule/MailService using Nodemailer with console fallback when EMAIL_ENABLED=false
- Send verification email with link to GET /auth/verify?token=<raw-token>
- Implement GET /auth/verify: validates token hash + expiry, marks user verified, clears token
- Block login for unverified users with 403 and descriptive error message
- Add POST /auth/resend-verification: regenerates token and resends email
- Add findByVerificationToken() to UsersService
- Add EMAIL_HOST, EMAIL_PORT, EMAIL_SECURE, EMAIL_USER, EMAIL_PASS, EMAIL_FROM, FRONTEND_URL to .env.example
- Add nodemailer + @types/nodemailer to package.json
