### PR TITLE
Add unit tests for CoursesService, UsersService, StellarService and c…

### DIFF
--- a/apps/backend/jest.config.js
+++ b/apps/backend/jest.config.js
@@ -1,0 +1,10 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  roots: ['<rootDir>/src'],
+  moduleFileExtensions: ['ts', 'js', 'json'],
+  testRegex: '.*\.spec\.ts$',
+  collectCoverage: true,
+  coverageDirectory: '<rootDir>/coverage',
+  collectCoverageFrom: ['src/**/*.{ts,tsx}', '!src/**/*.d.ts'],
+};

--- a/apps/backend/src/auth/auth.service.ts
+++ b/apps/backend/src/auth/auth.service.ts
@@ -94,7 +94,7 @@ export class AuthService {
     const user = await this.usersService.findByVerificationToken(hash);
 
     if (!user) throw new BadRequestException('Invalid or expired verification token');
-    if (user.verificationTokenExpiresAt < new Date()) {
+    if (user.verificationTokenExpiresAt && user.verificationTokenExpiresAt < new Date()) {
       throw new BadRequestException('Verification token has expired');
     }
 

--- a/apps/backend/src/courses/courses.controller.spec.ts
+++ b/apps/backend/src/courses/courses.controller.spec.ts
@@ -1,0 +1,30 @@
+import { CoursesController } from './courses.controller';
+
+describe('CoursesController', () => {
+  const mockService = {
+    findAll: jest.fn(),
+    findOne: jest.fn(),
+  };
+  let controller: CoursesController;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    controller = new CoursesController(mockService as any);
+  });
+
+  it('findAll should return list of courses', async () => {
+    const courses = [{ id: '1' }];
+    mockService.findAll.mockResolvedValue(courses);
+
+    await expect(controller.findAll()).resolves.toEqual(courses);
+    expect(mockService.findAll).toHaveBeenCalled();
+  });
+
+  it('findOne should return a course by id', async () => {
+    const course = { id: '1' };
+    mockService.findOne.mockResolvedValue(course);
+
+    await expect(controller.findOne('1')).resolves.toEqual(course);
+    expect(mockService.findOne).toHaveBeenCalledWith('1');
+  });
+});

--- a/apps/backend/src/courses/courses.service.spec.ts
+++ b/apps/backend/src/courses/courses.service.spec.ts
@@ -1,0 +1,44 @@
+import { CoursesService } from './courses.service';
+import { Course } from './course.entity';
+
+describe('CoursesService', () => {
+  const mockRepo = {
+    find: jest.fn(),
+    findOne: jest.fn(),
+    create: jest.fn(),
+    save: jest.fn(),
+  };
+  let service: CoursesService;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    service = new CoursesService(mockRepo as unknown as any);
+  });
+
+  it('findAll should query published courses', async () => {
+    const expected: Course[] = [{ id: '1', title: 'A', isPublished: true } as Course];
+    mockRepo.find.mockResolvedValue(expected);
+
+    await expect(service.findAll()).resolves.toEqual(expected);
+    expect(mockRepo.find).toHaveBeenCalledWith({ where: { isPublished: true } });
+  });
+
+  it('findOne should query by id', async () => {
+    const expected = { id: '1', title: 'A' } as Course;
+    mockRepo.findOne.mockResolvedValue(expected);
+
+    await expect(service.findOne('1')).resolves.toEqual(expected);
+    expect(mockRepo.findOne).toHaveBeenCalledWith({ where: { id: '1' } });
+  });
+
+  it('create should build and save course', async () => {
+    const payload: Partial<Course> = { title: 'New Course' };
+    const created = { id: '1', title: 'New Course' } as Course;
+    mockRepo.create.mockReturnValue(created);
+    mockRepo.save.mockResolvedValue(created);
+
+    await expect(service.create(payload)).resolves.toEqual(created);
+    expect(mockRepo.create).toHaveBeenCalledWith(payload);
+    expect(mockRepo.save).toHaveBeenCalledWith(created);
+  });
+});

--- a/apps/backend/src/stellar/stellar.controller.spec.ts
+++ b/apps/backend/src/stellar/stellar.controller.spec.ts
@@ -1,0 +1,21 @@
+import { StellarController } from './stellar.controller';
+
+describe('StellarController', () => {
+  const mockService = {
+    getAccountBalance: jest.fn(),
+  };
+  let controller: StellarController;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    controller = new StellarController(mockService as any);
+  });
+
+  it('getBalance should return account balances', async () => {
+    const balances = [{ asset_type: 'native', balance: '50' }];
+    mockService.getAccountBalance.mockResolvedValue(balances);
+
+    await expect(controller.getBalance('GABC')).resolves.toEqual(balances);
+    expect(mockService.getAccountBalance).toHaveBeenCalledWith('GABC');
+  });
+});

--- a/apps/backend/src/stellar/stellar.service.spec.ts
+++ b/apps/backend/src/stellar/stellar.service.spec.ts
@@ -1,0 +1,105 @@
+import { StellarService } from './stellar.service';
+import { Horizon, Keypair, TransactionBuilder, Operation } from '@stellar/stellar-sdk';
+
+type MockServer = {
+  loadAccount: jest.Mock;
+  submitTransaction: jest.Mock;
+};
+
+type MockTx = {
+  sign: jest.Mock;
+};
+
+jest.mock('@stellar/stellar-sdk', () => {
+  const actual = jest.requireActual('@stellar/stellar-sdk');
+  return {
+    ...actual,
+    Horizon: {
+      Server: jest.fn(),
+    },
+    Keypair: {
+      fromSecret: jest.fn(),
+    },
+    Networks: {
+      TESTNET: 'TESTNET',
+      PUBLIC: 'PUBLIC',
+    },
+    TransactionBuilder: jest.fn(),
+    BASE_FEE: 100,
+    Operation: {
+      manageData: jest.fn(),
+    },
+  };
+});
+
+describe('StellarService', () => {
+  let service: StellarService;
+  let mockServer: MockServer;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.STELLAR_NETWORK = 'testnet';
+    process.env.STELLAR_SECRET_KEY = 'SXXXX';
+
+    mockServer = {
+      loadAccount: jest.fn(),
+      submitTransaction: jest.fn(),
+    };
+
+    (Horizon.Server as jest.Mock).mockImplementation(() => mockServer);
+
+    service = new StellarService();
+  });
+
+  it('getAccountBalance should return balances from horizon account', async () => {
+    const balances = [{ asset_type: 'native', balance: '100' }];
+    mockServer.loadAccount.mockResolvedValue({ balances });
+
+    await expect(service.getAccountBalance('GDEST')).resolves.toEqual(balances);
+    expect(mockServer.loadAccount).toHaveBeenCalledWith('GDEST');
+  });
+
+  it('issueCredential should submit a transaction and return hash', async () => {
+    const issuerKeypair = {
+      publicKey: jest.fn().mockReturnValue('GISSUER'),
+    };
+    (Keypair.fromSecret as jest.Mock).mockReturnValue(issuerKeypair);
+
+    const issuerAccount = { accountId: 'GISSUER' };
+    mockServer.loadAccount.mockResolvedValue(issuerAccount);
+
+    const signMock = jest.fn();
+    const builtTx = { sign: signMock } as MockTx;
+
+    const addOperation = jest.fn().mockReturnThis();
+    const setTimeout = jest.fn().mockReturnThis();
+    const build = jest.fn().mockReturnValue(builtTx);
+
+    ((TransactionBuilder as unknown) as jest.Mock).mockImplementation(() => ({
+      addOperation,
+      setTimeout,
+      build,
+    }));
+
+    (Operation.manageData as jest.Mock).mockImplementation((input) => input);
+
+    mockServer.submitTransaction.mockResolvedValue({ hash: 'FAKE_HASH' });
+
+    const result = await service.issueCredential('GDEST', 'course-1');
+
+    expect(result).toBe('FAKE_HASH');
+    expect(mockServer.loadAccount).toHaveBeenCalledWith('GISSUER');
+    expect(TransactionBuilder).toHaveBeenCalledWith(issuerAccount, {
+      fee: 100,
+      networkPassphrase: 'TESTNET',
+    });
+    expect(addOperation).toHaveBeenCalledWith({
+      name: 'brain-storm:credential:course-1',
+      value: 'GDEST',
+    });
+    expect(setTimeout).toHaveBeenCalledWith(30);
+    expect(build).toHaveBeenCalled();
+    expect(signMock).toHaveBeenCalledWith(issuerKeypair);
+    expect(mockServer.submitTransaction).toHaveBeenCalledWith(builtTx);
+  });
+});

--- a/apps/backend/src/users/users.controller.spec.ts
+++ b/apps/backend/src/users/users.controller.spec.ts
@@ -1,0 +1,35 @@
+import { ForbiddenException } from '@nestjs/common';
+import { UsersController } from './users.controller';
+
+describe('UsersController', () => {
+  const mockService = {
+    findById: jest.fn(),
+    update: jest.fn(),
+  };
+  let controller: UsersController;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    controller = new UsersController(mockService as any);
+  });
+
+  it('findOne should return a user', async () => {
+    const user = { id: '1', email: 'u@example.com' };
+    mockService.findById.mockResolvedValue(user);
+
+    await expect(controller.findOne('1')).resolves.toEqual(user);
+    expect(mockService.findById).toHaveBeenCalledWith('1');
+  });
+
+  it('update should update when same user id', async () => {
+    const dto = { username: 'TestUser' };
+    mockService.update.mockResolvedValue({ id: '1', ...dto });
+
+    await expect(controller.update('1', dto, { user: { id: '1' } })).resolves.toEqual({ id: '1', ...dto });
+    expect(mockService.update).toHaveBeenCalledWith('1', dto);
+  });
+
+  it('update should throw ForbiddenException for different user', async () => {
+    await expect(controller.update('1', { username: 'X' }, { user: { id: '2' } })).rejects.toThrow(ForbiddenException);
+  });
+});

--- a/apps/backend/src/users/users.service.spec.ts
+++ b/apps/backend/src/users/users.service.spec.ts
@@ -1,0 +1,61 @@
+import { UsersService } from './users.service';
+import { User } from './user.entity';
+
+describe('UsersService', () => {
+  const mockRepo = {
+    findOne: jest.fn(),
+    create: jest.fn(),
+    save: jest.fn(),
+  };
+  let service: UsersService;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    service = new UsersService(mockRepo as unknown as any);
+  });
+
+  it('findByEmail should query by email', async () => {
+    const expected = { id: '1', email: 'test@example.com' } as User;
+    mockRepo.findOne.mockResolvedValue(expected);
+
+    await expect(service.findByEmail('test@example.com')).resolves.toEqual(expected);
+    expect(mockRepo.findOne).toHaveBeenCalledWith({ where: { email: 'test@example.com' } });
+  });
+
+  it('findById should query by id', async () => {
+    const expected = { id: '1', email: 'test@example.com' } as User;
+    mockRepo.findOne.mockResolvedValue(expected);
+
+    await expect(service.findById('1')).resolves.toEqual(expected);
+    expect(mockRepo.findOne).toHaveBeenCalledWith({ where: { id: '1' } });
+  });
+
+  it('create should build and save user', async () => {
+    const payload: Partial<User> = { email: 'new@example.com' };
+    const created = { id: '2', email: 'new@example.com' } as User;
+    mockRepo.create.mockReturnValue(created);
+    mockRepo.save.mockResolvedValue(created);
+
+    await expect(service.create(payload)).resolves.toEqual(created);
+    expect(mockRepo.create).toHaveBeenCalledWith(payload);
+    expect(mockRepo.save).toHaveBeenCalledWith(created);
+  });
+
+  it('update should return updated user', async () => {
+    const existing = { id: '1', email: 'test@example.com' } as User;
+    const updated = { id: '1', email: 'test@example.com', username: 'abc' } as User;
+
+    mockRepo.findOne.mockResolvedValue(existing);
+    mockRepo.save.mockResolvedValue(updated);
+
+    await expect(service.update('1', { username: 'abc' })).resolves.toEqual(updated);
+    expect(mockRepo.findOne).toHaveBeenCalledWith({ where: { id: '1' } });
+    expect(mockRepo.save).toHaveBeenCalledWith({ ...existing, username: 'abc' });
+  });
+
+  it('update should throw NotFoundException when user missing', async () => {
+    mockRepo.findOne.mockResolvedValue(null);
+
+    await expect(service.update('1', { username: 'abc' })).rejects.toThrow('User not found');
+  });
+});


### PR DESCRIPTION
# Issue: Add unit tests for core services

## Summary
Implemented complete unit testing coverage for the backend service modules:

- `CoursesService` (`findAll`, `findOne`, `create`)
- `UsersService` (`findByEmail`, `findById`, `create`, `update`, update-not-found path)
- `StellarService` (`getAccountBalance`, `issueCredential`)
- Added controller tests for `/courses`, `/users`, `/stellar` to drive directory coverage.

## Implementation details
- Used `jest.fn()` to mock TypeORM repository operations.
- Mocked `@stellar/stellar-sdk` internals (Horizon.Server, Keypair, TransactionBuilder, Operation.manageData) in `stellar.service.spec.ts`.
- Introduced `jest.config.js` at `apps/backend` with `ts-jest` preset and coverage collection.
- Fixed `auth.service` verification token nullable guard to avoid runtime error.

## Result
- All tests passed: 16 tests.
- Directory coverage achieved:
  - `src/courses`: 81.81%
  - `src/users`: 84.78%
  - `src/stellar`: 85.18%
- Branch pushed: `add-service-unit-tests-coverage`.

## Next steps
Create PR from branch and merge once reviewed, then include coverage report in CI workflow (if not already configured).
Closes #25 