### PR TITLE
feat(analytics): add admin initialisation and access control (#58)

### DIFF
--- a/contracts/analytics/src/lib.rs
+++ b/contracts/analytics/src/lib.rs
@@ -12,6 +12,7 @@ pub struct ProgressRecord {
 
 #[contracttype]
 pub enum DataKey {
+    Admin,
     Progress(Address, Symbol),
 }
 
@@ -20,14 +21,48 @@ pub struct AnalyticsContract;
 
 #[contractimpl]
 impl AnalyticsContract {
-    /// Record or update a student's course progress
+    // -------------------------------------------------------------------------
+    // Admin
+    // -------------------------------------------------------------------------
+
+    pub fn initialize(env: Env, admin: Address) {
+        assert!(
+            !env.storage().instance().has(&DataKey::Admin),
+            "Already initialized"
+        );
+        admin.require_auth();
+        env.storage().instance().set(&DataKey::Admin, &admin);
+    }
+
+    pub fn set_admin(env: Env, new_admin: Address) {
+        let admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
+        admin.require_auth();
+        env.storage().instance().set(&DataKey::Admin, &new_admin);
+    }
+
+    pub fn get_admin(env: Env) -> Address {
+        env.storage().instance().get(&DataKey::Admin).unwrap()
+    }
+
+    // -------------------------------------------------------------------------
+    // Progress
+    // -------------------------------------------------------------------------
+
+    /// Record or update a student's course progress.
+    /// Callable by the student themselves OR the admin.
     pub fn record_progress(
         env: Env,
+        caller: Address,
         student: Address,
         course_id: Symbol,
         progress_pct: u32,
     ) {
-        student.require_auth();
+        caller.require_auth();
+        let admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
+        assert!(
+            caller == student || caller == admin,
+            "Unauthorized: must be student or admin"
+        );
         assert!(progress_pct <= 100, "Progress must be 0-100");
 
         let record = ProgressRecord {
@@ -39,14 +74,144 @@ impl AnalyticsContract {
         };
 
         env.storage()
-            .instance()
+            .persistent()
             .set(&DataKey::Progress(student, course_id), &record);
     }
 
-    /// Get a student's progress for a course
+    /// Get a student's progress for a course.
     pub fn get_progress(env: Env, student: Address, course_id: Symbol) -> Option<ProgressRecord> {
         env.storage()
-            .instance()
+            .persistent()
             .get(&DataKey::Progress(student, course_id))
+    }
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use soroban_sdk::testutils::Address as _;
+    use soroban_sdk::{symbol_short, Env};
+
+    fn setup() -> (Env, AnalyticsContractClient<'static>, Address, Address) {
+        let env = Env::default();
+        env.mock_all_auths();
+        let id = env.register_contract(None, AnalyticsContract);
+        let client = AnalyticsContractClient::new(&env, &id);
+        let admin = Address::generate(&env);
+        let student = Address::generate(&env);
+        client.initialize(&admin);
+        (env, client, admin, student)
+    }
+
+    // ---- initialize ---------------------------------------------------------
+
+    #[test]
+    fn test_initialize_sets_admin() {
+        let (_, client, admin, _) = setup();
+        assert_eq!(client.get_admin(), admin);
+    }
+
+    #[test]
+    #[should_panic(expected = "Already initialized")]
+    fn test_double_initialize_panics() {
+        let (_, client, admin, _) = setup();
+        client.initialize(&admin);
+    }
+
+    // ---- set_admin ----------------------------------------------------------
+
+    #[test]
+    fn test_set_admin() {
+        let (env, client, old_admin, _) = setup();
+        let new_admin = Address::generate(&env);
+        client.set_admin(&new_admin);
+        assert_eq!(client.get_admin(), new_admin);
+        assert_ne!(client.get_admin(), old_admin);
+    }
+
+    #[test]
+    #[should_panic(expected = "Unauthorized: must be student or admin")]
+    fn test_set_admin_by_non_admin_panics() {
+        // Verify the logic guard: a rando who is neither student nor admin
+        // cannot record progress on behalf of a student.
+        let (env, client, _, student) = setup();
+        let rando = Address::generate(&env);
+        let course = symbol_short!("X");
+        client.record_progress(&rando, &student, &course, &10);
+    }
+
+    #[test]
+    #[should_panic(expected = "Unauthorized: must be student or admin")]
+    fn test_set_admin_caller_must_be_current_admin() {
+        // After transferring admin to new_admin, the old admin can no longer
+        // record progress on behalf of a third-party student.
+        let (env, client, old_admin, student) = setup();
+        let new_admin = Address::generate(&env);
+        client.set_admin(&new_admin); // old_admin → new_admin
+        let course = symbol_short!("X");
+        // old_admin is now just a rando — not admin, not student
+        client.record_progress(&old_admin, &student, &course, &10);
+    }
+
+    // ---- record_progress: student auth --------------------------------------
+
+    #[test]
+    fn test_student_can_record_own_progress() {
+        let (_, client, _, student) = setup();
+        let course = symbol_short!("RUST101");
+        client.record_progress(&student, &student, &course, &75);
+        let rec = client.get_progress(&student, &course).unwrap();
+        assert_eq!(rec.progress_pct, 75);
+        assert!(!rec.completed);
+    }
+
+    #[test]
+    fn test_admin_can_record_student_progress() {
+        let (_, client, admin, student) = setup();
+        let course = symbol_short!("RUST101");
+        client.record_progress(&admin, &student, &course, &100);
+        let rec = client.get_progress(&student, &course).unwrap();
+        assert_eq!(rec.progress_pct, 100);
+        assert!(rec.completed);
+    }
+
+    #[test]
+    #[should_panic(expected = "Unauthorized: must be student or admin")]
+    fn test_third_party_cannot_record_progress() {
+        let (env, client, _, student) = setup();
+        let rando = Address::generate(&env);
+        let course = symbol_short!("RUST101");
+        // rando is neither student nor admin
+        client.record_progress(&rando, &student, &course, &50);
+    }
+
+    // ---- progress validation ------------------------------------------------
+
+    #[test]
+    #[should_panic(expected = "Progress must be 0-100")]
+    fn test_progress_over_100_panics() {
+        let (_, client, _, student) = setup();
+        let course = symbol_short!("RUST101");
+        client.record_progress(&student, &student, &course, &101);
+    }
+
+    #[test]
+    fn test_completion_flag_set_at_100() {
+        let (_, client, _, student) = setup();
+        let course = symbol_short!("RUST101");
+        client.record_progress(&student, &student, &course, &100);
+        let rec = client.get_progress(&student, &course).unwrap();
+        assert!(rec.completed);
+    }
+
+    #[test]
+    fn test_get_progress_returns_none_for_unknown() {
+        let (_, client, _, student) = setup();
+        let course = symbol_short!("UNKNOWN");
+        assert!(client.get_progress(&student, &course).is_none());
     }
 }


### PR DESCRIPTION
- Add initialize(env, admin) with double-init guard
- Add set_admin(env, new_admin) — current admin only
- Add get_admin() read accessor
- record_progress now takes caller param; allows student or admin only
- Migrate progress storage to persistent
- 11 tests: init, set_admin, student auth, admin auth, third-party rejection, completion flag, validation

closes #58