### PR TITLE
Feature/57 analytics completion events

### DIFF
--- a/contracts/analytics/README.md
+++ b/contracts/analytics/README.md
@@ -1,0 +1,68 @@
+# Analytics Contract
+
+Tracks student course progress on-chain and emits Soroban events for off-chain indexers.
+
+## Functions
+
+| Function | Auth | Description |
+|---|---|---|
+| `initialize(admin)` | admin | One-time setup, stores admin address |
+| `set_admin(new_admin)` | current admin | Transfer admin role |
+| `get_admin()` | — | Read current admin |
+| `record_progress(caller, student, course_id, progress_pct)` | caller (student or admin) | Record/update progress (0–100) |
+| `get_progress(student, course_id)` | — | Read a student's progress record |
+
+## Events
+
+All events use the contract address as the emitting address.
+
+### `("analytics", "prog_upd")`
+
+Emitted on **every** `record_progress` call.
+
+**Topics:**
+```
+topic[0]: Symbol("analytics")
+topic[1]: Symbol("prog_upd")
+```
+
+**Data:**
+```
+(student: Address, course_id: Symbol, progress_pct: u32)
+```
+
+---
+
+### `("analytics", "completed")`
+
+Emitted **only** when `progress_pct == 100`.
+
+**Topics:**
+```
+topic[0]: Symbol("analytics")
+topic[1]: Symbol("completed")
+```
+
+**Data:**
+```
+(student: Address, course_id: Symbol)
+```
+
+## Storage
+
+| Key | Type | Storage | Description |
+|---|---|---|---|
+| `Admin` | `Address` | Instance | Contract administrator |
+| `Progress(Address, Symbol)` | `ProgressRecord` | Persistent | Per-student per-course record |
+
+## ProgressRecord Schema
+
+```rust
+pub struct ProgressRecord {
+    pub student: Address,
+    pub course_id: Symbol,
+    pub progress_pct: u32,   // 0–100
+    pub completed: bool,     // true when progress_pct == 100
+    pub timestamp: u64,      // ledger timestamp at last update
+}
+```

--- a/contracts/analytics/src/lib.rs
+++ b/contracts/analytics/src/lib.rs
@@ -1,5 +1,5 @@
 #![no_std]
-use soroban_sdk::{contract, contractimpl, contracttype, Address, Env, Symbol};
+use soroban_sdk::{contract, contractimpl, contracttype, symbol_short, Address, Env, Symbol};
 
 #[contracttype]
 pub struct ProgressRecord {
@@ -75,7 +75,21 @@ impl AnalyticsContract {
 
         env.storage()
             .persistent()
-            .set(&DataKey::Progress(student, course_id), &record);
+            .set(&DataKey::Progress(student.clone(), course_id.clone()), &record);
+
+        // Always emit progress_updated
+        env.events().publish(
+            (symbol_short!("analytics"), symbol_short!("prog_upd")),
+            (student.clone(), course_id.clone(), progress_pct),
+        );
+
+        // Emit completed only when 100%
+        if progress_pct == 100 {
+            env.events().publish(
+                (symbol_short!("analytics"), symbol_short!("completed")),
+                (student, course_id),
+            );
+        }
     }
 
     /// Get a student's progress for a course.
@@ -93,8 +107,8 @@ impl AnalyticsContract {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use soroban_sdk::testutils::Address as _;
-    use soroban_sdk::{symbol_short, Env};
+    use soroban_sdk::testutils::{Address as _, Events};
+    use soroban_sdk::{symbol_short, Env, FromVal, Symbol};
 
     fn setup() -> (Env, AnalyticsContractClient<'static>, Address, Address) {
         let env = Env::default();
@@ -213,5 +227,54 @@ mod tests {
         let (_, client, _, student) = setup();
         let course = symbol_short!("UNKNOWN");
         assert!(client.get_progress(&student, &course).is_none());
+    }
+
+    // ---- events -------------------------------------------------------------
+
+    fn has_event(env: &Env, topic1: &str, topic2: &str) -> bool {
+        let t1 = Symbol::new(env, topic1);
+        let t2 = Symbol::new(env, topic2);
+        env.events().all().iter().any(|e| {
+            let topics = e.1;
+            if topics.len() < 2 {
+                return false;
+            }
+            let s0 = Symbol::from_val(env, &topics.get(0).unwrap());
+            let s1 = Symbol::from_val(env, &topics.get(1).unwrap());
+            s0 == t1 && s1 == t2
+        })
+    }
+
+    #[test]
+    fn test_progress_updated_event_emitted() {
+        let (env, client, _, student) = setup();
+        let course = symbol_short!("RUST101");
+        client.record_progress(&student, &student, &course, &50);
+        assert!(has_event(&env, "analytics", "prog_upd"), "progress_updated event not found");
+    }
+
+    #[test]
+    fn test_completed_event_emitted_at_100() {
+        let (env, client, _, student) = setup();
+        let course = symbol_short!("RUST101");
+        client.record_progress(&student, &student, &course, &100);
+        assert!(has_event(&env, "analytics", "completed"), "completed event not found");
+    }
+
+    #[test]
+    fn test_completed_event_not_emitted_below_100() {
+        let (env, client, _, student) = setup();
+        let course = symbol_short!("RUST101");
+        client.record_progress(&student, &student, &course, &99);
+        assert!(!has_event(&env, "analytics", "completed"), "completed event should not fire below 100");
+    }
+
+    #[test]
+    fn test_both_events_emitted_at_100() {
+        let (env, client, _, student) = setup();
+        let course = symbol_short!("RUST101");
+        client.record_progress(&student, &student, &course, &100);
+        assert!(has_event(&env, "analytics", "prog_upd"), "progress_updated event missing");
+        assert!(has_event(&env, "analytics", "completed"), "completed event missing");
     }
 }


### PR DESCRIPTION
closes #57
- Emit (\"analytics\", \"prog_upd\") on every record_progress call
- Emit (\"analytics\", \"completed\") when progress_pct == 100
- Add contracts/analytics/README.md documenting event schema
- 4 new tests: prog_upd emitted, completed at 100, not below 100, both at 100