### PR TITLE
feat: enhance dark mode with system preference detection and smooth t…

### DIFF
--- a/apps/frontend/src/app/[locale]/layout.tsx
+++ b/apps/frontend/src/app/[locale]/layout.tsx
@@ -32,24 +32,19 @@ export default async function LocaleLayout({
 
   return (
     <html lang={locale} suppressHydrationWarning>
-      <body className="bg-white dark:bg-gray-950 text-gray-900 dark:text-gray-100 transition-colors flex flex-col min-h-screen">
+      <body className="bg-white dark:bg-gray-950 text-gray-900 dark:text-gray-100 transition-colors duration-200 flex flex-col min-h-screen">
         <NextIntlClientProvider messages={messages}>
-          <ClientProviders>
-            {/* Skip-to-content — first focusable element on every page */}
-            <a href="#main-content" className="skip-link">
-              Skip to main content
-            </a>
-            {children}
-          </ClientProviders>
           <ThemeProvider>
-            <a href="#main-content" className="skip-link">
-              Skip to main content
-            </a>
-            <Navbar />
-            <div id="main-content" tabIndex={-1} className="flex-1">
-              {children}
-            </div>
-            <Footer />
+            <ClientProviders>
+              <a href="#main-content" className="skip-link">
+                Skip to main content
+              </a>
+              <Navbar />
+              <div id="main-content" tabIndex={-1} className="flex-1">
+                {children}
+              </div>
+              <Footer />
+            </ClientProviders>
           </ThemeProvider>
         </NextIntlClientProvider>
       </body>

--- a/apps/frontend/src/app/globals.css
+++ b/apps/frontend/src/app/globals.css
@@ -24,3 +24,12 @@
   outline: 2px solid #2563eb;
   outline-offset: 2px;
 }
+
+/* Smooth theme transitions */
+*,
+*::before,
+*::after {
+  transition-property: background-color, border-color, color;
+  transition-duration: 200ms;
+  transition-timing-function: ease;
+}

--- a/apps/frontend/src/app/layout.tsx
+++ b/apps/frontend/src/app/layout.tsx
@@ -32,7 +32,7 @@ export const metadata: Metadata = {
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
-    <html lang="en">
+    <html lang="en" suppressHydrationWarning>
       <body className="antialiased">
         {children}
         <NetworkStatus />

--- a/apps/frontend/src/components/ClientProviders.tsx
+++ b/apps/frontend/src/components/ClientProviders.tsx
@@ -1,22 +1,7 @@
 'use client';
 
-import { ThemeProvider } from '@/components/ThemeProvider';
 import { AuthProvider } from '@/lib/auth-context';
-import { Navbar } from '@/components/Navbar';
 
-interface ClientProvidersProps {
-  children: React.ReactNode;
-}
-
-export function ClientProviders({ children }: ClientProvidersProps) {
-  return (
-    <AuthProvider>
-      <ThemeProvider>
-        <Navbar />
-        <div id="main-content" tabIndex={-1}>
-          {children}
-        </div>
-      </ThemeProvider>
-    </AuthProvider>
-  );
+export function ClientProviders({ children }: { children: React.ReactNode }) {
+  return <AuthProvider>{children}</AuthProvider>;
 }


### PR DESCRIPTION
                                                                                                                    
  - next-themes installed (^0.4.6)                                                                                    
  - ThemeProvider.tsx — defaultTheme="system" + enableSystem handles OS detection; storageKey="brainstorm-theme"      
   handles localStorage persistence                                                                                   
  - ThemeToggle.tsx — mounted guard prevents hydration flash, sun/moon icons, useTheme hook                           
  - tailwind.config.js — darkMode: 'class' set                                                                        
  - layout/Navbar.tsx — ThemeToggle already in both desktop and mobile menus                                          
                                                                                                                      
  What was broken and fixed:                                                                                          
                                                                                                                      
  ┌───────────────────────┬──────────────────────────────────────────────────────────────────────────┬────────────────
  ────────────────────────────────────────────────────┐                                                               
  │ File                  │ Problem                                                                  │ Fix            
                                                                  │                                                   
  ├───────────────────────┼──────────────────────────────────────────────────────────────────────────┼────────────────
  ────────────────────────────────────────────────────┤                                                               
  │ `[locale]/layout.tsx` │ `children` rendered twice; `ThemeProvider` only wrapped part of the tree │ `ThemeProvider`
  now wraps `Navbar + children + Footer` as one tree │                                                                
  │ `ClientProviders.tsx` │ Had its own `ThemeProvider` + old `Navbar` causing double providers      │ Stripped to    
  just `AuthProvider`                                    │                                                            
  │ `layout.tsx` (root)   │ Missing `suppressHydrationWarning` on `<html>`                           │ Added —        
  prevents next-themes hydration mismatch warning                                        │                            
  │ `globals.css`         │ No global transition styles                                              │ Added          
  `transition-property: background-color, border-color, color` on `*` for smooth switching │                          
  └───────────────────────┴──────────────────────────────────────────────────────────────────────────┴────────────────
  ────────────────────────────────────────────────────────────────────────────────┘     closes #228