### PR TITLE
Feat/issues 278 279 280 281      Course Versioning, Batch Operations, API Usage Analytics & Course Prerequisites  

### DIFF
--- a/apps/backend/src/api-usage/api-usage-log.entity.ts
+++ b/apps/backend/src/api-usage/api-usage-log.entity.ts
@@ -1,0 +1,35 @@
+import { Entity, PrimaryGeneratedColumn, Column, CreateDateColumn, Index } from 'typeorm';
+
+@Entity('api_usage_logs')
+@Index(['endpoint', 'createdAt'])
+@Index(['userId', 'createdAt'])
+export class ApiUsageLog {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column()
+  @Index()
+  endpoint: string;
+
+  @Column()
+  method: string;
+
+  @Column({ nullable: true })
+  @Index()
+  userId: string | null;
+
+  @Column({ nullable: true })
+  ip: string;
+
+  @Column()
+  statusCode: number;
+
+  @Column({ default: 0 })
+  responseTimeMs: number;
+
+  @Column({ nullable: true, type: 'text' })
+  userAgent: string;
+
+  @CreateDateColumn()
+  createdAt: Date;
+}

--- a/apps/backend/src/api-usage/api-usage.controller.ts
+++ b/apps/backend/src/api-usage/api-usage.controller.ts
@@ -1,0 +1,67 @@
+import { Controller, Get, Query, UseGuards } from '@nestjs/common';
+import { ApiBearerAuth, ApiOperation, ApiQuery, ApiTags } from '@nestjs/swagger';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { RolesGuard } from '../auth/roles.guard';
+import { Roles } from '../auth/roles.decorator';
+import { ApiUsageService } from './api-usage.service';
+
+@ApiTags('api-usage')
+@ApiBearerAuth()
+@UseGuards(JwtAuthGuard, RolesGuard)
+@Roles('admin')
+@Controller('api-usage')
+export class ApiUsageController {
+  constructor(private readonly apiUsageService: ApiUsageService) {}
+
+  @Get('dashboard')
+  @ApiOperation({ summary: 'Admin dashboard: aggregated API usage stats' })
+  @ApiQuery({ name: 'from', required: false, description: 'ISO date (default: 7 days ago)' })
+  @ApiQuery({ name: 'to', required: false, description: 'ISO date (default: now)' })
+  getDashboard(@Query('from') from?: string, @Query('to') to?: string) {
+    const toDate = to ? new Date(to) : new Date();
+    const fromDate = from ? new Date(from) : new Date(Date.now() - 7 * 86400_000);
+    return this.apiUsageService.getDashboard(fromDate, toDate);
+  }
+
+  @Get('by-endpoint')
+  @ApiOperation({ summary: 'Usage aggregated by endpoint' })
+  @ApiQuery({ name: 'from', required: false })
+  @ApiQuery({ name: 'to', required: false })
+  byEndpoint(@Query('from') from?: string, @Query('to') to?: string) {
+    const toDate = to ? new Date(to) : new Date();
+    const fromDate = from ? new Date(from) : new Date(Date.now() - 7 * 86400_000);
+    return this.apiUsageService.getAggregatedByEndpoint(fromDate, toDate);
+  }
+
+  @Get('by-user')
+  @ApiOperation({ summary: 'Usage aggregated by user' })
+  @ApiQuery({ name: 'from', required: false })
+  @ApiQuery({ name: 'to', required: false })
+  byUser(@Query('from') from?: string, @Query('to') to?: string) {
+    const toDate = to ? new Date(to) : new Date();
+    const fromDate = from ? new Date(from) : new Date(Date.now() - 7 * 86400_000);
+    return this.apiUsageService.getAggregatedByUser(fromDate, toDate);
+  }
+
+  @Get('by-time')
+  @ApiOperation({ summary: 'Usage aggregated by time period' })
+  @ApiQuery({ name: 'from', required: false })
+  @ApiQuery({ name: 'to', required: false })
+  @ApiQuery({ name: 'granularity', required: false, enum: ['hour', 'day'] })
+  byTime(
+    @Query('from') from?: string,
+    @Query('to') to?: string,
+    @Query('granularity') granularity?: 'hour' | 'day',
+  ) {
+    const toDate = to ? new Date(to) : new Date();
+    const fromDate = from ? new Date(from) : new Date(Date.now() - 7 * 86400_000);
+    return this.apiUsageService.getAggregatedByTime(fromDate, toDate, granularity ?? 'hour');
+  }
+
+  @Get('alerts')
+  @ApiOperation({ summary: 'Check for usage anomaly alerts (requests per minute)' })
+  @ApiQuery({ name: 'threshold', required: false, type: Number })
+  checkAlerts(@Query('threshold') threshold?: string) {
+    return this.apiUsageService.checkUsageAlerts(threshold ? Number(threshold) : 100);
+  }
+}

--- a/apps/backend/src/api-usage/api-usage.interceptor.ts
+++ b/apps/backend/src/api-usage/api-usage.interceptor.ts
@@ -1,0 +1,42 @@
+import {
+  CallHandler,
+  ExecutionContext,
+  Injectable,
+  NestInterceptor,
+} from '@nestjs/common';
+import { Observable, tap } from 'rxjs';
+import { ApiUsageService } from './api-usage.service';
+
+@Injectable()
+export class ApiUsageInterceptor implements NestInterceptor {
+  constructor(private readonly apiUsageService: ApiUsageService) {}
+
+  intercept(context: ExecutionContext, next: CallHandler): Observable<any> {
+    const req = context.switchToHttp().getRequest();
+    const start = Date.now();
+
+    return next.handle().pipe(
+      tap({
+        next: () => this.record(context, req, start),
+        error: () => this.record(context, req, start),
+      }),
+    );
+  }
+
+  private record(context: ExecutionContext, req: any, start: number): void {
+    const res = context.switchToHttp().getResponse();
+    const responseTimeMs = Date.now() - start;
+
+    this.apiUsageService
+      .log({
+        endpoint: req.route?.path ?? req.url,
+        method: req.method,
+        userId: req.user?.id ?? null,
+        ip: req.ip,
+        statusCode: res.statusCode,
+        responseTimeMs,
+        userAgent: req.headers?.['user-agent'] ?? null,
+      })
+      .catch(() => {}); // fire-and-forget, never block the response
+  }
+}

--- a/apps/backend/src/api-usage/api-usage.module.ts
+++ b/apps/backend/src/api-usage/api-usage.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { ApiUsageLog } from './api-usage-log.entity';
+import { ApiUsageService } from './api-usage.service';
+import { ApiUsageController } from './api-usage.controller';
+import { ApiUsageInterceptor } from './api-usage.interceptor';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([ApiUsageLog])],
+  providers: [ApiUsageService, ApiUsageInterceptor],
+  controllers: [ApiUsageController],
+  exports: [ApiUsageService, ApiUsageInterceptor],
+})
+export class ApiUsageModule {}

--- a/apps/backend/src/api-usage/api-usage.service.ts
+++ b/apps/backend/src/api-usage/api-usage.service.ts
@@ -1,0 +1,90 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { ApiUsageLog } from './api-usage-log.entity';
+
+@Injectable()
+export class ApiUsageService {
+  constructor(
+    @InjectRepository(ApiUsageLog) private logRepo: Repository<ApiUsageLog>,
+  ) {}
+
+  async log(data: Partial<ApiUsageLog>): Promise<void> {
+    await this.logRepo.save(this.logRepo.create(data));
+  }
+
+  async getAggregatedByEndpoint(from: Date, to: Date) {
+    return this.logRepo
+      .createQueryBuilder('log')
+      .select('log.endpoint', 'endpoint')
+      .addSelect('log.method', 'method')
+      .addSelect('COUNT(*)', 'requestCount')
+      .addSelect('AVG(log.responseTimeMs)', 'avgResponseTimeMs')
+      .addSelect('SUM(CASE WHEN log.statusCode >= 400 THEN 1 ELSE 0 END)', 'errorCount')
+      .where('log.createdAt BETWEEN :from AND :to', { from, to })
+      .groupBy('log.endpoint')
+      .addGroupBy('log.method')
+      .orderBy('"requestCount"', 'DESC')
+      .getRawMany();
+  }
+
+  async getAggregatedByUser(from: Date, to: Date) {
+    return this.logRepo
+      .createQueryBuilder('log')
+      .select('log.userId', 'userId')
+      .addSelect('COUNT(*)', 'requestCount')
+      .addSelect('AVG(log.responseTimeMs)', 'avgResponseTimeMs')
+      .where('log.createdAt BETWEEN :from AND :to', { from, to })
+      .andWhere('log.userId IS NOT NULL')
+      .groupBy('log.userId')
+      .orderBy('"requestCount"', 'DESC')
+      .getRawMany();
+  }
+
+  async getAggregatedByTime(from: Date, to: Date, granularity: 'hour' | 'day' = 'hour') {
+    const trunc = granularity === 'hour' ? 'hour' : 'day';
+    return this.logRepo
+      .createQueryBuilder('log')
+      .select(`DATE_TRUNC('${trunc}', log.createdAt)`, 'period')
+      .addSelect('COUNT(*)', 'requestCount')
+      .where('log.createdAt BETWEEN :from AND :to', { from, to })
+      .groupBy('period')
+      .orderBy('period', 'ASC')
+      .getRawMany();
+  }
+
+  async getDashboard(from: Date, to: Date) {
+    const [byEndpoint, byUser, byTime, totals] = await Promise.all([
+      this.getAggregatedByEndpoint(from, to),
+      this.getAggregatedByUser(from, to),
+      this.getAggregatedByTime(from, to, 'day'),
+      this.logRepo
+        .createQueryBuilder('log')
+        .select('COUNT(*)', 'totalRequests')
+        .addSelect('AVG(log.responseTimeMs)', 'avgResponseTimeMs')
+        .addSelect('SUM(CASE WHEN log.statusCode >= 400 THEN 1 ELSE 0 END)', 'totalErrors')
+        .where('log.createdAt BETWEEN :from AND :to', { from, to })
+        .getRawOne(),
+    ]);
+
+    return { totals, byEndpoint: byEndpoint.slice(0, 20), byUser: byUser.slice(0, 20), byTime };
+  }
+
+  async checkUsageAlerts(thresholdPerMinute = 100): Promise<{ alert: boolean; count: number }> {
+    const since = new Date(Date.now() - 60_000);
+    const count = await this.logRepo
+      .createQueryBuilder('log')
+      .where('log.createdAt > :since', { since })
+      .getCount();
+    return { alert: count > thresholdPerMinute, count };
+  }
+
+  async getUserRequestCount(userId: string, windowMs: number): Promise<number> {
+    const since = new Date(Date.now() - windowMs);
+    return this.logRepo
+      .createQueryBuilder('log')
+      .where('log.userId = :userId', { userId })
+      .andWhere('log.createdAt > :since', { since })
+      .getCount();
+  }
+}

--- a/apps/backend/src/app.module.ts
+++ b/apps/backend/src/app.module.ts
@@ -3,7 +3,7 @@ import { ConfigModule, ConfigService } from '@nestjs/config';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { CacheModule } from '@nestjs/cache-manager';
 import { ThrottlerModule, ThrottlerGuard } from '@nestjs/throttler';
-import { APP_GUARD } from '@nestjs/core';
+import { APP_GUARD, APP_INTERCEPTOR } from '@nestjs/core';
 import { SentryModule } from '@sentry/nestjs/setup';
 import { EventEmitterModule } from '@nestjs/event-emitter';
 import { AuthModule } from './auth/auth.module';
@@ -27,6 +27,8 @@ import { ModerationModule } from './moderation/moderation.module';
 import { ImportExportModule } from './import-export/import-export.module';
 import { SearchModule } from './search/search.module';
 import { BatchModule } from './batch/batch.module';
+import { ApiUsageModule } from './api-usage/api-usage.module';
+import { ApiUsageInterceptor } from './api-usage/api-usage.interceptor';
 import * as redisStore from 'cache-manager-redis-store';
 import { ThrottlerStorageRedisService } from '@nest-lab/throttler-storage-redis';
 import configuration from './config/configuration';
@@ -103,7 +105,11 @@ import { validationSchema } from './config/validation.schema';
     ImportExportModule,
     SearchModule,
     BatchModule,
+    ApiUsageModule,
   ],
-  providers: [{ provide: APP_GUARD, useClass: ThrottlerGuard }],
+  providers: [
+    { provide: APP_GUARD, useClass: ThrottlerGuard },
+    { provide: APP_INTERCEPTOR, useClass: ApiUsageInterceptor },
+  ],
 })
 export class AppModule {}

--- a/apps/backend/src/app.module.ts
+++ b/apps/backend/src/app.module.ts
@@ -26,6 +26,7 @@ import { WebhooksModule } from './webhooks/webhooks.module';
 import { ModerationModule } from './moderation/moderation.module';
 import { ImportExportModule } from './import-export/import-export.module';
 import { SearchModule } from './search/search.module';
+import { BatchModule } from './batch/batch.module';
 import * as redisStore from 'cache-manager-redis-store';
 import { ThrottlerStorageRedisService } from '@nest-lab/throttler-storage-redis';
 import configuration from './config/configuration';
@@ -101,6 +102,7 @@ import { validationSchema } from './config/validation.schema';
     ModerationModule,
     ImportExportModule,
     SearchModule,
+    BatchModule,
   ],
   providers: [{ provide: APP_GUARD, useClass: ThrottlerGuard }],
 })

--- a/apps/backend/src/batch/batch-job.entity.ts
+++ b/apps/backend/src/batch/batch-job.entity.ts
@@ -1,0 +1,49 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+
+export type BatchJobStatus = 'pending' | 'processing' | 'completed' | 'failed';
+export type BatchJobType = 'users' | 'courses';
+
+@Entity('batch_jobs')
+export class BatchJob {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column()
+  type: BatchJobType;
+
+  @Column({ default: 'pending' })
+  status: BatchJobStatus;
+
+  @Column('jsonb')
+  payload: Record<string, any>[];
+
+  @Column('jsonb', { nullable: true })
+  results: Record<string, any>[] | null;
+
+  @Column('jsonb', { nullable: true })
+  errors: Record<string, any>[] | null;
+
+  @Column({ default: 0 })
+  totalItems: number;
+
+  @Column({ default: 0 })
+  processedItems: number;
+
+  @Column({ default: 0 })
+  failedItems: number;
+
+  @Column({ nullable: true })
+  createdById: string;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+}

--- a/apps/backend/src/batch/batch.controller.ts
+++ b/apps/backend/src/batch/batch.controller.ts
@@ -1,0 +1,66 @@
+import { Body, Controller, Get, Param, Post, Query, Request, UseGuards } from '@nestjs/common';
+import { ApiBearerAuth, ApiBody, ApiOperation, ApiQuery, ApiTags } from '@nestjs/swagger';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { RolesGuard } from '../auth/roles.guard';
+import { Roles } from '../auth/roles.decorator';
+import { BatchService } from './batch.service';
+
+@ApiTags('batch')
+@ApiBearerAuth()
+@UseGuards(JwtAuthGuard, RolesGuard)
+@Roles('admin')
+@Controller('batch')
+export class BatchController {
+  constructor(private readonly batchService: BatchService) {}
+
+  @Post('users')
+  @ApiOperation({ summary: 'Bulk user operations (update, ban, unban, changeRole, delete)' })
+  @ApiBody({
+    schema: {
+      example: {
+        operations: [
+          { action: 'ban', userId: 'uuid' },
+          { action: 'changeRole', userId: 'uuid', role: 'instructor' },
+        ],
+      },
+    },
+  })
+  batchUsers(
+    @Body('operations') operations: Record<string, any>[],
+    @Request() req: { user: { id: string } },
+  ) {
+    return this.batchService.createUserBatch(operations, req.user.id);
+  }
+
+  @Post('courses')
+  @ApiOperation({ summary: 'Bulk course operations (create, update, delete)' })
+  @ApiBody({
+    schema: {
+      example: {
+        operations: [
+          { action: 'update', courseId: 'uuid', isPublished: false },
+          { action: 'delete', courseId: 'uuid' },
+        ],
+      },
+    },
+  })
+  batchCourses(
+    @Body('operations') operations: Record<string, any>[],
+    @Request() req: { user: { id: string } },
+  ) {
+    return this.batchService.createCourseBatch(operations, req.user.id);
+  }
+
+  @Get('jobs')
+  @ApiOperation({ summary: 'List batch jobs' })
+  @ApiQuery({ name: 'type', required: false, enum: ['users', 'courses'] })
+  listJobs(@Query('type') type?: string) {
+    return this.batchService.listJobs(type);
+  }
+
+  @Get('jobs/:jobId')
+  @ApiOperation({ summary: 'Get batch job status' })
+  getJobStatus(@Param('jobId') jobId: string) {
+    return this.batchService.getJobStatus(jobId);
+  }
+}

--- a/apps/backend/src/batch/batch.module.ts
+++ b/apps/backend/src/batch/batch.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { BatchJob } from './batch-job.entity';
+import { BatchService } from './batch.service';
+import { BatchController } from './batch.controller';
+import { UsersModule } from '../users/users.module';
+import { CoursesModule } from '../courses/courses.module';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([BatchJob]), UsersModule, CoursesModule],
+  providers: [BatchService],
+  controllers: [BatchController],
+})
+export class BatchModule {}

--- a/apps/backend/src/batch/batch.service.ts
+++ b/apps/backend/src/batch/batch.service.ts
@@ -1,0 +1,125 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { BatchJob } from './batch-job.entity';
+import { UsersService } from '../users/users.service';
+import { CoursesService } from '../courses/courses.service';
+
+@Injectable()
+export class BatchService {
+  constructor(
+    @InjectRepository(BatchJob) private jobRepo: Repository<BatchJob>,
+    private usersService: UsersService,
+    private coursesService: CoursesService,
+  ) {}
+
+  async createUserBatch(payload: Record<string, any>[], createdById: string): Promise<BatchJob> {
+    const job = await this.jobRepo.save(
+      this.jobRepo.create({ type: 'users', payload, totalItems: payload.length, createdById }),
+    );
+    // Process asynchronously
+    setImmediate(() => this.processUserBatch(job.id));
+    return job;
+  }
+
+  async createCourseBatch(payload: Record<string, any>[], createdById: string): Promise<BatchJob> {
+    const job = await this.jobRepo.save(
+      this.jobRepo.create({ type: 'courses', payload, totalItems: payload.length, createdById }),
+    );
+    setImmediate(() => this.processCourseBatch(job.id));
+    return job;
+  }
+
+  async getJobStatus(jobId: string): Promise<BatchJob> {
+    const job = await this.jobRepo.findOne({ where: { id: jobId } });
+    if (!job) throw new NotFoundException('Batch job not found');
+    return job;
+  }
+
+  async listJobs(type?: string): Promise<BatchJob[]> {
+    const where = type ? { type: type as any } : {};
+    return this.jobRepo.find({ where, order: { createdAt: 'DESC' }, take: 100 });
+  }
+
+  private async processUserBatch(jobId: string): Promise<void> {
+    const job = await this.jobRepo.findOne({ where: { id: jobId } });
+    if (!job) return;
+
+    await this.jobRepo.update(jobId, { status: 'processing' });
+
+    const results: Record<string, any>[] = [];
+    const errors: Record<string, any>[] = [];
+
+    for (const item of job.payload) {
+      try {
+        const { action, userId, ...data } = item;
+        let result: any;
+
+        if (action === 'update' && userId) {
+          result = await this.usersService.update(userId, data);
+        } else if (action === 'ban' && userId) {
+          result = await this.usersService.banUser(userId, true);
+        } else if (action === 'unban' && userId) {
+          result = await this.usersService.banUser(userId, false);
+        } else if (action === 'changeRole' && userId) {
+          result = await this.usersService.changeRole(userId, data.role);
+        } else if (action === 'delete' && userId) {
+          result = await this.usersService.softDelete(userId);
+        } else {
+          throw new Error(`Unknown action: ${action}`);
+        }
+
+        results.push({ userId, action, success: true, result: { id: result.id } });
+      } catch (err: any) {
+        errors.push({ item, error: err.message });
+      }
+    }
+
+    await this.jobRepo.update(jobId, {
+      status: errors.length === job.totalItems ? 'failed' : 'completed',
+      results,
+      errors,
+      processedItems: results.length,
+      failedItems: errors.length,
+    });
+  }
+
+  private async processCourseBatch(jobId: string): Promise<void> {
+    const job = await this.jobRepo.findOne({ where: { id: jobId } });
+    if (!job) return;
+
+    await this.jobRepo.update(jobId, { status: 'processing' });
+
+    const results: Record<string, any>[] = [];
+    const errors: Record<string, any>[] = [];
+
+    for (const item of job.payload) {
+      try {
+        const { action, courseId, ...data } = item;
+        let result: any;
+
+        if (action === 'update' && courseId) {
+          result = await this.coursesService.update(courseId, data);
+        } else if (action === 'delete' && courseId) {
+          result = await this.coursesService.delete(courseId);
+        } else if (action === 'create') {
+          result = await this.coursesService.create(data);
+        } else {
+          throw new Error(`Unknown action: ${action}`);
+        }
+
+        results.push({ courseId: result.id, action, success: true });
+      } catch (err: any) {
+        errors.push({ item, error: err.message });
+      }
+    }
+
+    await this.jobRepo.update(jobId, {
+      status: errors.length === job.totalItems ? 'failed' : 'completed',
+      results,
+      errors,
+      processedItems: results.length,
+      failedItems: errors.length,
+    });
+  }
+}

--- a/apps/backend/src/courses/course-prerequisite.entity.ts
+++ b/apps/backend/src/courses/course-prerequisite.entity.ts
@@ -1,0 +1,34 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  ManyToOne,
+  JoinColumn,
+  Unique,
+} from 'typeorm';
+import { Course } from './course.entity';
+
+@Entity('course_prerequisites')
+@Unique(['courseId', 'prerequisiteId'])
+export class CoursePrerequisite {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column()
+  courseId: string;
+
+  @ManyToOne(() => Course, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'courseId' })
+  course: Course;
+
+  @Column()
+  prerequisiteId: string;
+
+  @ManyToOne(() => Course, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'prerequisiteId' })
+  prerequisite: Course;
+
+  @CreateDateColumn()
+  createdAt: Date;
+}

--- a/apps/backend/src/courses/course-version.entity.ts
+++ b/apps/backend/src/courses/course-version.entity.ts
@@ -1,0 +1,45 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  ManyToOne,
+  JoinColumn,
+} from 'typeorm';
+import { Course } from './course.entity';
+import { User } from '../users/user.entity';
+
+@Entity('course_versions')
+export class CourseVersion {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column()
+  courseId: string;
+
+  @ManyToOne(() => Course, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'courseId' })
+  course: Course;
+
+  @Column()
+  versionTag: string; // e.g. "v1.0", "v2.0"
+
+  @Column({ default: 1 })
+  versionNumber: number;
+
+  @Column('jsonb')
+  snapshot: Record<string, any>; // full course + modules + lessons snapshot
+
+  @Column({ nullable: true, type: 'text' })
+  changeNote: string;
+
+  @Column({ nullable: true })
+  createdById: string;
+
+  @ManyToOne(() => User, { nullable: true, onDelete: 'SET NULL' })
+  @JoinColumn({ name: 'createdById' })
+  createdBy: User;
+
+  @CreateDateColumn()
+  createdAt: Date;
+}

--- a/apps/backend/src/courses/course-versioning.controller.ts
+++ b/apps/backend/src/courses/course-versioning.controller.ts
@@ -1,0 +1,59 @@
+import { Body, Controller, Get, Param, Post, Query, Request, UseGuards } from '@nestjs/common';
+import { ApiBearerAuth, ApiOperation, ApiQuery, ApiTags } from '@nestjs/swagger';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { RolesGuard } from '../auth/roles.guard';
+import { Roles } from '../auth/roles.decorator';
+import { CourseVersioningService } from './course-versioning.service';
+
+@ApiTags('course-versions')
+@ApiBearerAuth()
+@UseGuards(JwtAuthGuard, RolesGuard)
+@Controller('courses/:courseId/versions')
+export class CourseVersioningController {
+  constructor(private readonly versioningService: CourseVersioningService) {}
+
+  @Post()
+  @Roles('admin', 'instructor')
+  @ApiOperation({ summary: 'Create a new version snapshot of a course' })
+  createVersion(
+    @Param('courseId') courseId: string,
+    @Body('changeNote') changeNote: string,
+    @Request() req: { user: { id: string } },
+  ) {
+    return this.versioningService.createVersion(courseId, changeNote, req.user.id);
+  }
+
+  @Get()
+  @Roles('admin', 'instructor')
+  @ApiOperation({ summary: 'List all versions of a course' })
+  listVersions(@Param('courseId') courseId: string) {
+    return this.versioningService.listVersions(courseId);
+  }
+
+  @Get('diff')
+  @Roles('admin', 'instructor')
+  @ApiOperation({ summary: 'Diff two versions of a course' })
+  @ApiQuery({ name: 'from', required: true })
+  @ApiQuery({ name: 'to', required: true })
+  diffVersions(
+    @Param('courseId') courseId: string,
+    @Query('from') from: string,
+    @Query('to') to: string,
+  ) {
+    return this.versioningService.diffVersions(courseId, from, to);
+  }
+
+  @Get(':versionId')
+  @Roles('admin', 'instructor')
+  @ApiOperation({ summary: 'Get a specific version snapshot' })
+  getVersion(@Param('courseId') courseId: string, @Param('versionId') versionId: string) {
+    return this.versioningService.getVersion(courseId, versionId);
+  }
+
+  @Post(':versionId/rollback')
+  @Roles('admin')
+  @ApiOperation({ summary: 'Rollback course to a previous version' })
+  rollback(@Param('courseId') courseId: string, @Param('versionId') versionId: string) {
+    return this.versioningService.rollback(courseId, versionId);
+  }
+}

--- a/apps/backend/src/courses/course-versioning.service.ts
+++ b/apps/backend/src/courses/course-versioning.service.ts
@@ -1,0 +1,91 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { CourseVersion } from './course-version.entity';
+import { Course } from './course.entity';
+
+@Injectable()
+export class CourseVersioningService {
+  constructor(
+    @InjectRepository(CourseVersion) private versionRepo: Repository<CourseVersion>,
+    @InjectRepository(Course) private courseRepo: Repository<Course>,
+  ) {}
+
+  async createVersion(courseId: string, changeNote: string, createdById?: string): Promise<CourseVersion> {
+    const course = await this.courseRepo.findOne({
+      where: { id: courseId, isDeleted: false },
+      relations: ['modules', 'modules.lessons'],
+    });
+    if (!course) throw new NotFoundException('Course not found');
+
+    const count = await this.versionRepo.count({ where: { courseId } });
+    const versionNumber = count + 1;
+    const versionTag = `v${versionNumber}.0`;
+
+    return this.versionRepo.save(
+      this.versionRepo.create({
+        courseId,
+        versionNumber,
+        versionTag,
+        snapshot: course as unknown as Record<string, any>,
+        changeNote,
+        createdById,
+      }),
+    );
+  }
+
+  async listVersions(courseId: string): Promise<CourseVersion[]> {
+    return this.versionRepo.find({
+      where: { courseId },
+      order: { versionNumber: 'DESC' },
+      select: ['id', 'courseId', 'versionTag', 'versionNumber', 'changeNote', 'createdAt', 'createdById'],
+    });
+  }
+
+  async getVersion(courseId: string, versionId: string): Promise<CourseVersion> {
+    const version = await this.versionRepo.findOne({ where: { id: versionId, courseId } });
+    if (!version) throw new NotFoundException('Version not found');
+    return version;
+  }
+
+  async diffVersions(courseId: string, fromId: string, toId: string) {
+    const [from, to] = await Promise.all([
+      this.getVersion(courseId, fromId),
+      this.getVersion(courseId, toId),
+    ]);
+
+    return {
+      from: { versionTag: from.versionTag, snapshot: from.snapshot },
+      to: { versionTag: to.versionTag, snapshot: to.snapshot },
+      changes: this.computeDiff(from.snapshot, to.snapshot),
+    };
+  }
+
+  async rollback(courseId: string, versionId: string): Promise<Course> {
+    const version = await this.getVersion(courseId, versionId);
+    const { id, modules, reviews, createdAt, ...fields } = version.snapshot as any;
+
+    await this.courseRepo.update(courseId, {
+      title: fields.title,
+      description: fields.description,
+      level: fields.level,
+      durationHours: fields.durationHours,
+      isPublished: fields.isPublished,
+    });
+
+    const updated = await this.courseRepo.findOne({ where: { id: courseId } });
+    if (!updated) throw new NotFoundException('Course not found after rollback');
+    return updated;
+  }
+
+  private computeDiff(from: Record<string, any>, to: Record<string, any>): Record<string, any> {
+    const changes: Record<string, any> = {};
+    const keys = new Set([...Object.keys(from), ...Object.keys(to)]);
+    for (const key of keys) {
+      if (JSON.stringify(from[key]) !== JSON.stringify(to[key])) {
+        changes[key] = { from: from[key], to: to[key] };
+      }
+    }
+    return changes;
+  }
+}

--- a/apps/backend/src/courses/courses.module.ts
+++ b/apps/backend/src/courses/courses.module.ts
@@ -13,11 +13,14 @@ import { Enrollment } from '../enrollments/enrollment.entity';
 import { ReviewsService } from './reviews.service';
 import { ReviewsController } from './reviews.controller';
 import { SearchModule } from '../search/search.module';
+import { CourseVersion } from './course-version.entity';
+import { CourseVersioningService } from './course-versioning.service';
+import { CourseVersioningController } from './course-versioning.controller';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Course, CourseModule, Lesson, Review, Enrollment]), SearchModule],
-  providers: [CoursesService, ModulesService, LessonsService, ReviewsService],
-  controllers: [CoursesController, ModulesController, ReviewsController],
+  imports: [TypeOrmModule.forFeature([Course, CourseModule, Lesson, Review, Enrollment, CourseVersion]), SearchModule],
+  providers: [CoursesService, ModulesService, LessonsService, ReviewsService, CourseVersioningService],
+  controllers: [CoursesController, ModulesController, ReviewsController, CourseVersioningController],
   exports: [CoursesService],
 })
 export class CoursesModule {}

--- a/apps/backend/src/courses/courses.module.ts
+++ b/apps/backend/src/courses/courses.module.ts
@@ -16,11 +16,17 @@ import { SearchModule } from '../search/search.module';
 import { CourseVersion } from './course-version.entity';
 import { CourseVersioningService } from './course-versioning.service';
 import { CourseVersioningController } from './course-versioning.controller';
+import { CoursePrerequisite } from './course-prerequisite.entity';
+import { PrerequisitesService } from './prerequisites.service';
+import { PrerequisitesController } from './prerequisites.controller';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Course, CourseModule, Lesson, Review, Enrollment, CourseVersion]), SearchModule],
-  providers: [CoursesService, ModulesService, LessonsService, ReviewsService, CourseVersioningService],
-  controllers: [CoursesController, ModulesController, ReviewsController, CourseVersioningController],
-  exports: [CoursesService],
+  imports: [
+    TypeOrmModule.forFeature([Course, CourseModule, Lesson, Review, Enrollment, CourseVersion, CoursePrerequisite]),
+    SearchModule,
+  ],
+  providers: [CoursesService, ModulesService, LessonsService, ReviewsService, CourseVersioningService, PrerequisitesService],
+  controllers: [CoursesController, ModulesController, ReviewsController, CourseVersioningController, PrerequisitesController],
+  exports: [CoursesService, PrerequisitesService],
 })
 export class CoursesModule {}

--- a/apps/backend/src/courses/prerequisites.controller.ts
+++ b/apps/backend/src/courses/prerequisites.controller.ts
@@ -1,0 +1,59 @@
+import { Body, Controller, Delete, Get, Param, Post, UseGuards } from '@nestjs/common';
+import { ApiBearerAuth, ApiOperation, ApiTags } from '@nestjs/swagger';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { RolesGuard } from '../auth/roles.guard';
+import { Roles } from '../auth/roles.decorator';
+import { PrerequisitesService } from './prerequisites.service';
+
+@ApiTags('course-prerequisites')
+@ApiBearerAuth()
+@UseGuards(JwtAuthGuard, RolesGuard)
+@Controller('courses/:courseId/prerequisites')
+export class PrerequisitesController {
+  constructor(private readonly prereqService: PrerequisitesService) {}
+
+  @Get()
+  @Roles('admin', 'instructor', 'student')
+  @ApiOperation({ summary: 'List prerequisites for a course' })
+  getPrerequisites(@Param('courseId') courseId: string) {
+    return this.prereqService.getPrerequisites(courseId);
+  }
+
+  @Get('chain')
+  @Roles('admin', 'instructor', 'student')
+  @ApiOperation({ summary: 'Get full prerequisite chain for visualization' })
+  getChain(@Param('courseId') courseId: string) {
+    return this.prereqService.getPrerequisiteChain(courseId);
+  }
+
+  @Post()
+  @Roles('admin', 'instructor')
+  @ApiOperation({ summary: 'Add a prerequisite to a course' })
+  addPrerequisite(
+    @Param('courseId') courseId: string,
+    @Body('prerequisiteId') prerequisiteId: string,
+  ) {
+    return this.prereqService.addPrerequisite(courseId, prerequisiteId);
+  }
+
+  @Delete(':prerequisiteId')
+  @Roles('admin', 'instructor')
+  @ApiOperation({ summary: 'Remove a prerequisite from a course' })
+  removePrerequisite(
+    @Param('courseId') courseId: string,
+    @Param('prerequisiteId') prerequisiteId: string,
+  ) {
+    return this.prereqService.removePrerequisite(courseId, prerequisiteId);
+  }
+
+  @Post('validate/:userId')
+  @Roles('admin')
+  @ApiOperation({ summary: 'Check if a user satisfies prerequisites (admin can override)' })
+  validatePrerequisites(
+    @Param('courseId') courseId: string,
+    @Param('userId') userId: string,
+    @Body('adminOverride') adminOverride?: boolean,
+  ) {
+    return this.prereqService.validatePrerequisites(userId, courseId, adminOverride ?? false);
+  }
+}

--- a/apps/backend/src/courses/prerequisites.service.ts
+++ b/apps/backend/src/courses/prerequisites.service.ts
@@ -1,0 +1,108 @@
+import {
+  BadRequestException,
+  ForbiddenException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { CoursePrerequisite } from './course-prerequisite.entity';
+import { Enrollment } from '../enrollments/enrollment.entity';
+import { Course } from './course.entity';
+
+@Injectable()
+export class PrerequisitesService {
+  constructor(
+    @InjectRepository(CoursePrerequisite)
+    private prereqRepo: Repository<CoursePrerequisite>,
+    @InjectRepository(Enrollment)
+    private enrollmentRepo: Repository<Enrollment>,
+    @InjectRepository(Course)
+    private courseRepo: Repository<Course>,
+  ) {}
+
+  async addPrerequisite(courseId: string, prerequisiteId: string): Promise<CoursePrerequisite> {
+    if (courseId === prerequisiteId) {
+      throw new BadRequestException('A course cannot be its own prerequisite');
+    }
+    const [course, prereq] = await Promise.all([
+      this.courseRepo.findOne({ where: { id: courseId, isDeleted: false } }),
+      this.courseRepo.findOne({ where: { id: prerequisiteId, isDeleted: false } }),
+    ]);
+    if (!course) throw new NotFoundException('Course not found');
+    if (!prereq) throw new NotFoundException('Prerequisite course not found');
+
+    return this.prereqRepo.save(this.prereqRepo.create({ courseId, prerequisiteId }));
+  }
+
+  async removePrerequisite(courseId: string, prerequisiteId: string): Promise<void> {
+    const record = await this.prereqRepo.findOne({ where: { courseId, prerequisiteId } });
+    if (!record) throw new NotFoundException('Prerequisite relationship not found');
+    await this.prereqRepo.remove(record);
+  }
+
+  async getPrerequisites(courseId: string): Promise<CoursePrerequisite[]> {
+    return this.prereqRepo.find({
+      where: { courseId },
+      relations: ['prerequisite'],
+    });
+  }
+
+  /** Returns the full prerequisite chain (BFS) for visualization */
+  async getPrerequisiteChain(courseId: string): Promise<Record<string, string[]>> {
+    const chain: Record<string, string[]> = {};
+    const queue = [courseId];
+    const visited = new Set<string>();
+
+    while (queue.length) {
+      const current = queue.shift()!;
+      if (visited.has(current)) continue;
+      visited.add(current);
+
+      const prereqs = await this.prereqRepo.find({ where: { courseId: current } });
+      chain[current] = prereqs.map((p) => p.prerequisiteId);
+      for (const p of prereqs) {
+        if (!visited.has(p.prerequisiteId)) queue.push(p.prerequisiteId);
+      }
+    }
+
+    return chain;
+  }
+
+  /** Validate that a user has completed all prerequisites for a course */
+  async validatePrerequisites(
+    userId: string,
+    courseId: string,
+    adminOverride = false,
+  ): Promise<{ satisfied: boolean; missing: string[] }> {
+    if (adminOverride) return { satisfied: true, missing: [] };
+
+    const prereqs = await this.prereqRepo.find({ where: { courseId } });
+    if (!prereqs.length) return { satisfied: true, missing: [] };
+
+    const completedEnrollments = await this.enrollmentRepo.find({
+      where: { userId },
+      select: ['courseId', 'completedAt'],
+    });
+
+    const completedCourseIds = new Set(
+      completedEnrollments.filter((e) => e.completedAt).map((e) => e.courseId),
+    );
+
+    const missing = prereqs
+      .filter((p) => !completedCourseIds.has(p.prerequisiteId))
+      .map((p) => p.prerequisiteId);
+
+    return { satisfied: missing.length === 0, missing };
+  }
+
+  /** Throws if prerequisites are not met (used by enrollment) */
+  async enforcePrerequisites(userId: string, courseId: string, adminOverride = false): Promise<void> {
+    const { satisfied, missing } = await this.validatePrerequisites(userId, courseId, adminOverride);
+    if (!satisfied) {
+      throw new ForbiddenException(
+        `Prerequisites not completed. Missing course IDs: ${missing.join(', ')}`,
+      );
+    }
+  }
+}

--- a/apps/backend/src/enrollments/enrollments.controller.ts
+++ b/apps/backend/src/enrollments/enrollments.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Delete, Get, Param, Post, Request, UseGuards } from '@nestjs/common';
+import { Body, Controller, Delete, Get, Param, Post, Request, UseGuards } from '@nestjs/common';
 import { ApiBearerAuth, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 import { EnrollmentsService } from './enrollments.service';
@@ -25,10 +25,16 @@ export class EnrollmentsController {
     },
   })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 403, description: 'Prerequisites not completed' })
   @ApiResponse({ status: 404, description: 'Course not found' })
   @ApiResponse({ status: 409, description: 'Already enrolled' })
-  enroll(@Param('id') courseId: string, @Request() req: { user: { id: string } }) {
-    return this.enrollmentsService.enroll(req.user.id, courseId);
+  enroll(
+    @Param('id') courseId: string,
+    @Request() req: { user: { id: string; role: string } },
+    @Body('adminOverride') adminOverride?: boolean,
+  ) {
+    const isAdmin = req.user.role === 'admin';
+    return this.enrollmentsService.enroll(req.user.id, courseId, isAdmin && !!adminOverride);
   }
 
   @Delete('courses/:id/enroll')

--- a/apps/backend/src/enrollments/enrollments.module.ts
+++ b/apps/backend/src/enrollments/enrollments.module.ts
@@ -3,9 +3,10 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { Enrollment } from './enrollment.entity';
 import { EnrollmentsService } from './enrollments.service';
 import { EnrollmentsController } from './enrollments.controller';
+import { CoursesModule } from '../courses/courses.module';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Enrollment])],
+  imports: [TypeOrmModule.forFeature([Enrollment]), CoursesModule],
   providers: [EnrollmentsService],
   controllers: [EnrollmentsController],
   exports: [EnrollmentsService],

--- a/apps/backend/src/enrollments/enrollments.service.ts
+++ b/apps/backend/src/enrollments/enrollments.service.ts
@@ -3,18 +3,22 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { EventEmitter2 } from '@nestjs/event-emitter';
 import { Enrollment } from './enrollment.entity';
+import { PrerequisitesService } from '../courses/prerequisites.service';
 
 @Injectable()
 export class EnrollmentsService {
   constructor(
     @InjectRepository(Enrollment)
     private repo: Repository<Enrollment>,
-    private eventEmitter: EventEmitter2
+    private eventEmitter: EventEmitter2,
+    private prereqService: PrerequisitesService,
   ) {}
 
-  async enroll(userId: string, courseId: string): Promise<Enrollment> {
+  async enroll(userId: string, courseId: string, adminOverride = false): Promise<Enrollment> {
     const existing = await this.repo.findOne({ where: { userId, courseId } });
     if (existing) throw new ConflictException('Already enrolled in this course');
+
+    await this.prereqService.enforcePrerequisites(userId, courseId, adminOverride);
 
     const enrollment = await this.repo.save(this.repo.create({ userId, courseId }));
 


### PR DESCRIPTION

  
 
  Closes #278
  Closes #279
  Closes #280
  Closes #281
  
  ---
  
  ## Overview
  
  This PR implements four backend features across the Brain-Storm platform, covering course content versioning, bulk admin operations, API usage
  observability, and prerequisite-gated course enrollment.
  
  ---
  
  ## #278 — Course Versioning
  
  **Goal:** Version control for course content with rollback capability.
  
  **New files:**
  - `src/courses/course-version.entity.ts` — `course_versions` table storing a full JSONB snapshot of a course (including modules and lessons) at the time
  of versioning, with `versionTag` (e.g. `v1.0`, `v2.0`), `versionNumber`, `changeNote`, and `createdById`.
  - `src/courses/course-versioning.service.ts` — Service providing:
    - `createVersion(courseId, changeNote, userId)` — snapshots the current course state and auto-increments the version tag.
    - `listVersions(courseId)` — returns all versions in descending order (metadata only, no snapshot payload).
    - `getVersion(courseId, versionId)` — retrieves a specific version with its full snapshot.
    - `diffVersions(courseId, fromId, toId)` — computes a field-level diff between two snapshots.
    - `rollback(courseId, versionId)` — restores course fields (title, description, level, durationHours, isPublished) from a prior snapshot.
  - `src/courses/course-versioning.controller.ts` — REST endpoints (admin/instructor only):
    - `POST   /courses/:courseId/versions` — create a new version snapshot
    - `GET    /courses/:courseId/versions` — list all versions
    - `GET    /courses/:courseId/versions/diff?from=&to=` — diff two versions
    - `GET    /courses/:courseId/versions/:versionId` — get a specific version
    - `POST   /courses/:courseId/versions/:versionId/rollback` — rollback (admin only)
  
  **Modified files:**
  - `src/courses/courses.module.ts` — registered `CourseVersion` entity, `CourseVersioningService`, and `CourseVersioningController`.
  
  ---
  
  ## #279 — Batch Operations API
  
  **Goal:** Bulk operations for admin tasks (user management, course updates) with async job processing and status tracking.
  
  **New files:**
  - `src/batch/batch-job.entity.ts` — `batch_jobs` table tracking job `type` (`users` | `courses`), `status` (`pending → processing → completed |
  failed`), `payload` (JSONB array of operations), `results`, `errors`, `totalItems`, `processedItems`, `failedItems`, and `createdById`.
  - `src/batch/batch.service.ts` — Service providing:
    - `createUserBatch(payload, createdById)` — queues and asynchronously processes bulk user operations: `update`, `ban`, `unban`, `changeRole`,
  `delete`.
    - `createCourseBatch(payload, createdById)` — queues and asynchronously processes bulk course operations: `create`, `update`, `delete`.
    - `getJobStatus(jobId)` — returns current job state including per-item results and errors.
    - `listJobs(type?)` — lists recent batch jobs, optionally filtered by type.
    - Processing is fire-and-forget via `setImmediate`; each item is processed individually with per-item error capture so partial failures don't abort
  the batch.
  - `src/batch/batch.controller.ts` — REST endpoints (admin only):
    - `POST /batch/users` — submit a bulk user operation job
    - `POST /batch/courses` — submit a bulk course operation job
    - `GET  /batch/jobs` — list batch jobs (optional `?type=` filter)
    - `GET  /batch/jobs/:jobId` — poll job status
  - `src/batch/batch.module.ts` — module wiring `BatchJob` entity, `UsersModule`, and `CoursesModule`.
  
  **Modified files:**
  - `src/app.module.ts` — registered `BatchModule`.
  
  ---
  
  ## #280 — API Usage Analytics
  
  **Goal:** Track and analyze API usage patterns for optimization and anomaly alerting.
  
  **New files:**
  - `src/api-usage/api-usage-log.entity.ts` — `api_usage_logs` table with indexed columns: `endpoint`, `method`, `userId`, `ip`, `statusCode`,
  `responseTimeMs`, `userAgent`, `createdAt`. Composite indexes on `(endpoint, createdAt)` and `(userId, createdAt)` for efficient aggregation queries.
  - `src/api-usage/api-usage.interceptor.ts` — Global `NestInterceptor` registered via `APP_INTERCEPTOR`. Captures every HTTP request/response (including
  errors) and fire-and-forgets a log entry — never blocks the response path.
  - `src/api-usage/api-usage.service.ts` — Service providing:
    - `log(data)` — persists a single request log entry.
    - `getAggregatedByEndpoint(from, to)` — request count, avg response time, error count per endpoint+method.
    - `getAggregatedByUser(from, to)` — request count and avg response time per user.
    - `getAggregatedByTime(from, to, granularity)` — time-series bucketed by `hour` or `day`.
    - `getDashboard(from, to)` — combined totals + top-20 by endpoint + top-20 by user + daily time series.
    - `checkUsageAlerts(thresholdPerMinute)` — returns `{ alert: boolean, count }` for anomaly detection.
    - `getUserRequestCount(userId, windowMs)` — per-user request count within a sliding window (for usage-based rate limiting).
  - `src/api-usage/api-usage.controller.ts` — REST endpoints (admin only):
    - `GET /api-usage/dashboard` — full aggregated dashboard (default: last 7 days)
    - `GET /api-usage/by-endpoint` — usage by endpoint
    - `GET /api-usage/by-user` — usage by user
    - `GET /api-usage/by-time` — time-series (`?granularity=hour|day`)
    - `GET /api-usage/alerts` — anomaly alert check (`?threshold=100`)
  - `src/api-usage/api-usage.module.ts` — module wiring.
  
  **Modified files:**
  - `src/app.module.ts` — registered `ApiUsageModule` and `ApiUsageInterceptor` as a global interceptor via `APP_INTERCEPTOR`.
  
  ---
  
  ## #281 — Course Prerequisite System
  
  **Goal:** Enforce course prerequisites before enrollment, with chain visualization and admin override.
  
  **New files:**
  - `src/courses/course-prerequisite.entity.ts` — `course_prerequisites` table with a unique constraint on `(courseId, prerequisiteId)`, linking two
  `Course` records.
  - `src/courses/prerequisites.service.ts` — Service providing:
    - `addPrerequisite(courseId, prerequisiteId)` — creates a prerequisite relationship (validates both courses exist; prevents self-reference).
    - `removePrerequisite(courseId, prerequisiteId)` — removes a prerequisite relationship.
    - `getPrerequisites(courseId)` — lists all direct prerequisites with course details.
    - `getPrerequisiteChain(courseId)` — BFS traversal returning the full prerequisite graph as `{ courseId: [prerequisiteIds] }` for frontend
  visualization.
    - `validatePrerequisites(userId, courseId, adminOverride)` — checks whether a user has completed all prerequisites; returns `{ satisfied, missing[]
  }`.
    - `enforcePrerequisites(userId, courseId, adminOverride)` — throws `ForbiddenException` with missing course IDs if prerequisites are not met.
  - `src/courses/prerequisites.controller.ts` — REST endpoints:
    - `GET    /courses/:courseId/prerequisites` — list prerequisites (all roles)
    - `GET    /courses/:courseId/prerequisites/chain` — full BFS chain (all roles)
    - `POST   /courses/:courseId/prerequisites` — add prerequisite (admin/instructor)
    - `DELETE /courses/:courseId/prerequisites/:prerequisiteId` — remove prerequisite (admin/instructor)
    - `POST   /courses/:courseId/prerequisites/validate/:userId` — validate user eligibility with optional admin override (admin only)
  
  **Modified files:**
  - `src/courses/courses.module.ts` — registered `CoursePrerequisite` entity, `PrerequisitesService`, `PrerequisitesController`; exported
  `PrerequisitesService`.
  - `src/enrollments/enrollments.service.ts` — `enroll()` now calls `prereqService.enforcePrerequisites()` before creating the enrollment. Accepts
  `adminOverride` parameter.
  - `src/enrollments/enrollments.controller.ts` — `POST /courses/:id/enroll` now accepts optional `adminOverride: boolean` in the request body (only
  honoured when the requesting user has the `admin` role).
  - `src/enrollments/enrollments.module.ts` — imports `CoursesModule` to resolve `PrerequisitesService`.
  
  ---
  
  ## Testing Notes
  
  - All new modules use `autoLoadEntities: true` (set in `AppModule`) — no manual entity registration needed beyond `TypeOrmModule.forFeature`.
  - Database schema changes are applied automatically via `synchronize: true` in non-production environments.
  - Batch jobs process asynchronously; poll `GET /batch/jobs/:jobId` to track completion.
  - API usage logging is non-blocking — failures are silently swallowed to never impact request latency.