### PR TITLE
feat(frontend): a11y testing, error/loading states, email verificatio…

### DIFF
--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -47,6 +47,9 @@
   },
   "devDependencies": {
     "@axe-core/react": "^4.11.1",
+    "axe-playwright": "^2.0.3",
+    "jest-axe": "^9.0.0",
+    "@types/jest-axe": "^3.5.9",
     "@chromatic-com/storybook": "^3.0.0",
     "@pact-foundation/pact": "^16.3.0",
     "@playwright/test": "^1.44.0",

--- a/apps/frontend/src/__tests__/components/Breadcrumb.test.tsx
+++ b/apps/frontend/src/__tests__/components/Breadcrumb.test.tsx
@@ -1,0 +1,95 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, within } from '@testing-library/react';
+import { Breadcrumb, CompactBreadcrumb } from '@/components/ui/Breadcrumb';
+
+vi.mock('next/navigation', () => ({
+  usePathname: () => '/courses/intro-to-stellar',
+}));
+
+vi.mock('next/link', () => ({
+  default: ({ href, children, ...rest }: any) => (
+    <a href={href} {...rest}>
+      {children}
+    </a>
+  ),
+}));
+
+describe('Breadcrumb', () => {
+  it('renders nothing when items list is empty', () => {
+    const { container } = render(<Breadcrumb items={[]} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders custom items with proper aria-label', () => {
+    render(
+      <Breadcrumb
+        items={[
+          { label: 'Home', href: '/' },
+          { label: 'Courses', href: '/courses' },
+          { label: 'Intro', href: '/courses/intro', current: true },
+        ]}
+      />,
+    );
+    const nav = screen.getByRole('navigation', { name: /breadcrumb/i });
+    expect(nav).toBeInTheDocument();
+    expect(within(nav).getByText('Home')).toBeInTheDocument();
+    expect(within(nav).getByText('Courses')).toBeInTheDocument();
+    expect(within(nav).getByText('Intro')).toBeInTheDocument();
+  });
+
+  it('marks current page with aria-current', () => {
+    render(
+      <Breadcrumb
+        items={[
+          { label: 'Home', href: '/' },
+          { label: 'Courses', href: '/courses', current: true },
+        ]}
+      />,
+    );
+    expect(screen.getByText('Courses').closest('[aria-current="page"]')).toBeTruthy();
+  });
+
+  it('auto-generates breadcrumbs from pathname when no items provided', () => {
+    render(<Breadcrumb />);
+    expect(screen.getByText('Home')).toBeInTheDocument();
+    expect(screen.getByText('Courses')).toBeInTheDocument();
+    expect(screen.getByText(/Intro To Stellar/i)).toBeInTheDocument();
+  });
+
+  it('renders schema.org BreadcrumbList microdata', () => {
+    const { container } = render(
+      <Breadcrumb
+        items={[
+          { label: 'Home', href: '/' },
+          { label: 'Courses', href: '/courses' },
+        ]}
+      />,
+    );
+    expect(
+      container.querySelector('[itemtype="https://schema.org/BreadcrumbList"]'),
+    ).toBeInTheDocument();
+  });
+});
+
+describe('CompactBreadcrumb', () => {
+  it('renders parent and current item', () => {
+    render(
+      <CompactBreadcrumb
+        items={[
+          { label: 'Home', href: '/' },
+          { label: 'Courses', href: '/courses' },
+          { label: 'Intro', href: '/courses/intro', current: true },
+        ]}
+      />,
+    );
+    expect(screen.getByText('Courses')).toBeInTheDocument();
+    expect(screen.getByText('Intro')).toBeInTheDocument();
+  });
+
+  it('renders nothing for a single-item list', () => {
+    const { container } = render(
+      <CompactBreadcrumb items={[{ label: 'Home', href: '/' }]} />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/apps/frontend/src/__tests__/components/ErrorBoundary.test.tsx
+++ b/apps/frontend/src/__tests__/components/ErrorBoundary.test.tsx
@@ -1,0 +1,101 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ErrorBoundary, ErrorFallback } from '@/components/ui/ErrorBoundary';
+
+vi.mock('@sentry/nextjs', () => ({
+  captureException: vi.fn(),
+}));
+
+function Boom({ shouldThrow }: { shouldThrow: boolean }) {
+  if (shouldThrow) throw new Error('boom');
+  return <div>ok</div>;
+}
+
+describe('ErrorBoundary', () => {
+  const originalError = console.error;
+  beforeEach(() => {
+    console.error = vi.fn();
+  });
+  afterEach(() => {
+    console.error = originalError;
+  });
+
+  it('renders children when there is no error', () => {
+    render(
+      <ErrorBoundary>
+        <Boom shouldThrow={false} />
+      </ErrorBoundary>,
+    );
+    expect(screen.getByText('ok')).toBeInTheDocument();
+  });
+
+  it('renders default fallback on error', () => {
+    render(
+      <ErrorBoundary>
+        <Boom shouldThrow={true} />
+      </ErrorBoundary>,
+    );
+    expect(screen.getByRole('alert')).toBeInTheDocument();
+    expect(screen.getByText(/something went wrong/i)).toBeInTheDocument();
+  });
+
+  it('calls onError prop', () => {
+    const onError = vi.fn();
+    render(
+      <ErrorBoundary onError={onError}>
+        <Boom shouldThrow={true} />
+      </ErrorBoundary>,
+    );
+    expect(onError).toHaveBeenCalledOnce();
+  });
+
+  it('resets when retry is clicked', async () => {
+    const user = userEvent.setup();
+    function Wrapper() {
+      return (
+        <ErrorBoundary>
+          <Boom shouldThrow={false} />
+        </ErrorBoundary>
+      );
+    }
+    const { rerender } = render(<Wrapper />);
+    rerender(
+      <ErrorBoundary>
+        <Boom shouldThrow={true} />
+      </ErrorBoundary>,
+    );
+    expect(screen.getByText(/something went wrong/i)).toBeInTheDocument();
+
+    rerender(
+      <ErrorBoundary>
+        <Boom shouldThrow={false} />
+      </ErrorBoundary>,
+    );
+    // Manual reset via try-again button
+    const btn = screen.queryByRole('button', { name: /try again/i });
+    if (btn) {
+      await user.click(btn);
+      expect(screen.getByText('ok')).toBeInTheDocument();
+    }
+  });
+
+  it('uses custom function fallback', () => {
+    render(
+      <ErrorBoundary fallback={(err, reset) => <div>custom: {err.message}</div>}>
+        <Boom shouldThrow={true} />
+      </ErrorBoundary>,
+    );
+    expect(screen.getByText('custom: boom')).toBeInTheDocument();
+  });
+});
+
+describe('ErrorFallback', () => {
+  it('renders title, description, and retry button', async () => {
+    const user = userEvent.setup();
+    const reset = vi.fn();
+    render(<ErrorFallback error={new Error('x')} reset={reset} />);
+    await user.click(screen.getByRole('button', { name: /try again/i }));
+    expect(reset).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/frontend/src/__tests__/components/VerificationCodeInput.test.tsx
+++ b/apps/frontend/src/__tests__/components/VerificationCodeInput.test.tsx
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { VerificationCodeInput } from '@/components/ui/VerificationCodeInput';
+
+describe('VerificationCodeInput', () => {
+  it('renders the configured number of inputs', () => {
+    render(<VerificationCodeInput length={6} />);
+    expect(screen.getAllByRole('textbox')).toHaveLength(6);
+  });
+
+  it('advances focus on digit entry and calls onComplete', async () => {
+    const user = userEvent.setup();
+    const onComplete = vi.fn();
+    const onChange = vi.fn();
+    render(
+      <VerificationCodeInput length={4} onChange={onChange} onComplete={onComplete} />,
+    );
+    const inputs = screen.getAllByRole('textbox');
+    await user.type(inputs[0], '1');
+    await user.type(inputs[1], '2');
+    await user.type(inputs[2], '3');
+    await user.type(inputs[3], '4');
+    expect(onComplete).toHaveBeenCalledWith('1234');
+    expect(onChange).toHaveBeenLastCalledWith('1234');
+  });
+
+  it('rejects non-numeric input', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(<VerificationCodeInput length={4} onChange={onChange} />);
+    const inputs = screen.getAllByRole('textbox');
+    await user.type(inputs[0], 'a');
+    expect(inputs[0]).toHaveValue('');
+  });
+
+  it('handles paste of multi-digit code', async () => {
+    const user = userEvent.setup();
+    const onComplete = vi.fn();
+    render(<VerificationCodeInput length={6} onComplete={onComplete} />);
+    const inputs = screen.getAllByRole('textbox');
+    inputs[0].focus();
+    await user.paste('123456');
+    expect(onComplete).toHaveBeenCalledWith('123456');
+  });
+
+  it('shows error message and marks inputs invalid', () => {
+    render(<VerificationCodeInput length={4} error="Invalid code" />);
+    expect(screen.getByRole('alert')).toHaveTextContent('Invalid code');
+    expect(screen.getAllByRole('textbox')[0]).toHaveAttribute('aria-invalid', 'true');
+  });
+
+  it('handles backspace to clear and move focus back', async () => {
+    const user = userEvent.setup();
+    render(<VerificationCodeInput length={4} />);
+    const inputs = screen.getAllByRole('textbox');
+    await user.type(inputs[0], '1');
+    await user.type(inputs[1], '2');
+    expect(inputs[1]).toHaveValue('2');
+    await user.keyboard('{Backspace}');
+    expect(inputs[1]).toHaveValue('');
+    await user.keyboard('{Backspace}');
+    expect(inputs[0]).toHaveValue('');
+  });
+});

--- a/apps/frontend/src/__tests__/components/a11y.test.tsx
+++ b/apps/frontend/src/__tests__/components/a11y.test.tsx
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/react';
+import { axe, toHaveNoViolations } from 'jest-axe';
+import { Button } from '@/components/ui/Button';
+import { Input } from '@/components/ui/Input';
+import { Spinner } from '@/components/ui/Spinner';
+import { Skeleton } from '@/components/ui/Skeleton';
+
+expect.extend(toHaveNoViolations);
+
+describe('Component accessibility (axe)', () => {
+  it('Button has no a11y violations', async () => {
+    const { container } = render(<Button>Submit</Button>);
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  it('Input has no a11y violations with label', async () => {
+    const { container } = render(<Input label="Email" type="email" />);
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  it('Input has no a11y violations with error state', async () => {
+    const { container } = render(
+      <Input label="Email" type="email" error="Invalid email" />,
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  it('Spinner has no a11y violations', async () => {
+    const { container } = render(<Spinner label="Loading content" />);
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  it('Skeleton has no a11y violations', async () => {
+    const { container } = render(<Skeleton width={200} height={20} />);
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+});

--- a/apps/frontend/src/__tests__/hooks/useCountdown.test.ts
+++ b/apps/frontend/src/__tests__/hooks/useCountdown.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useCountdown } from '@/hooks/useCountdown';
+
+describe('useCountdown', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('starts inactive at zero', () => {
+    const { result } = renderHook(() => useCountdown());
+    expect(result.current.secondsLeft).toBe(0);
+    expect(result.current.isActive).toBe(false);
+  });
+
+  it('counts down each second', () => {
+    const { result } = renderHook(() => useCountdown());
+    act(() => result.current.start(3));
+    expect(result.current.secondsLeft).toBe(3);
+    expect(result.current.isActive).toBe(true);
+
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+    expect(result.current.secondsLeft).toBe(2);
+
+    act(() => {
+      vi.advanceTimersByTime(2000);
+    });
+    expect(result.current.secondsLeft).toBe(0);
+    expect(result.current.isActive).toBe(false);
+  });
+
+  it('stop halts the countdown', () => {
+    const { result } = renderHook(() => useCountdown());
+    act(() => result.current.start(5));
+    act(() => result.current.stop());
+    const snapshot = result.current.secondsLeft;
+    act(() => {
+      vi.advanceTimersByTime(2000);
+    });
+    expect(result.current.secondsLeft).toBe(snapshot);
+  });
+});

--- a/apps/frontend/src/app/auth/register/page.tsx
+++ b/apps/frontend/src/app/auth/register/page.tsx
@@ -40,7 +40,7 @@ export default function RegisterPage() {
     });
     localStorage.setItem('access_token', res.data.access_token);
     login(res.data.access_token, res.data.user);
-    router.push('/dashboard');
+    router.push(`/auth/verify-email?email=${encodeURIComponent(data.email)}`);
   };
 
   return (

--- a/apps/frontend/src/app/auth/verify-email/page.tsx
+++ b/apps/frontend/src/app/auth/verify-email/page.tsx
@@ -1,0 +1,174 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import Link from 'next/link';
+import { useRouter, useSearchParams } from 'next/navigation';
+import api from '@/lib/api';
+import { Button } from '@/components/ui/Button';
+import { Input } from '@/components/ui/Input';
+import { Spinner } from '@/components/ui/Spinner';
+import { VerificationCodeInput } from '@/components/ui/VerificationCodeInput';
+import { useCountdown } from '@/hooks/useCountdown';
+import { logError } from '@/lib/errorLogger';
+
+type Status = 'idle' | 'verifying' | 'success' | 'error';
+
+const RESEND_COOLDOWN_SECONDS = 60;
+
+export default function VerifyEmailPage() {
+  const router = useRouter();
+  const params = useSearchParams();
+  const tokenFromUrl = params.get('token');
+  const emailFromUrl = params.get('email') ?? '';
+
+  const [status, setStatus] = useState<Status>('idle');
+  const [error, setError] = useState<string | null>(null);
+  const [email, setEmail] = useState(emailFromUrl);
+  const [code, setCode] = useState('');
+  const [resending, setResending] = useState(false);
+  const { secondsLeft, start: startCountdown, isActive: cooldownActive } = useCountdown(0);
+
+  const verifyToken = useCallback(async (token: string) => {
+    setStatus('verifying');
+    setError(null);
+    try {
+      await api.get('/auth/verify', { params: { token } });
+      setStatus('success');
+    } catch (err) {
+      const message =
+        (err as { response?: { data?: { message?: string } } })?.response?.data?.message ??
+        'The verification link is invalid or has expired.';
+      setError(message);
+      setStatus('error');
+      logError(err, { source: 'verify-email' });
+    }
+  }, []);
+
+  useEffect(() => {
+    if (tokenFromUrl) {
+      verifyToken(tokenFromUrl);
+    }
+  }, [tokenFromUrl, verifyToken]);
+
+  const handleResend = async () => {
+    if (!email || cooldownActive) return;
+    setResending(true);
+    setError(null);
+    try {
+      await api.post('/auth/resend-verification', { email });
+      startCountdown(RESEND_COOLDOWN_SECONDS);
+    } catch (err) {
+      const message =
+        (err as { response?: { data?: { message?: string } } })?.response?.data?.message ??
+        'Could not resend the verification email.';
+      setError(message);
+      logError(err, { source: 'verify-email-resend' });
+    } finally {
+      setResending(false);
+    }
+  };
+
+  const handleCodeComplete = (entered: string) => {
+    // Treats the code as a verification token. If the backend later supports
+    // OTP-style codes, this path is ready to call a dedicated endpoint.
+    setCode(entered);
+    verifyToken(entered);
+  };
+
+  return (
+    <main className="min-h-screen flex items-center justify-center bg-gray-50 dark:bg-gray-950 px-4">
+      <div className="w-full max-w-md bg-white dark:bg-gray-900 rounded-2xl shadow p-8 flex flex-col gap-6">
+        {status === 'verifying' && (
+          <div role="status" aria-live="polite" className="text-center flex flex-col items-center gap-4">
+            <Spinner size="lg" label="Verifying your email" />
+            <h1 className="text-xl font-semibold text-gray-900 dark:text-white">
+              Verifying your email…
+            </h1>
+            <p className="text-sm text-gray-500 dark:text-gray-400">
+              This will only take a moment.
+            </p>
+          </div>
+        )}
+
+        {status === 'success' && (
+          <div role="status" aria-live="polite" className="text-center flex flex-col items-center gap-4">
+            <div className="w-16 h-16 rounded-full bg-green-100 dark:bg-green-900/30 flex items-center justify-center text-green-600 dark:text-green-400 text-4xl" aria-hidden="true">
+              ✓
+            </div>
+            <h1 className="text-2xl font-bold text-gray-900 dark:text-white">
+              Email verified
+            </h1>
+            <p className="text-sm text-gray-600 dark:text-gray-400">
+              Your email address has been confirmed. You can now access your account.
+            </p>
+            <Button onClick={() => router.push('/dashboard')} className="w-full">
+              Continue to dashboard
+            </Button>
+          </div>
+        )}
+
+        {(status === 'idle' || status === 'error') && (
+          <>
+            <div className="text-center">
+              <h1 className="text-2xl font-bold text-gray-900 dark:text-white">
+                Verify your email
+              </h1>
+              <p className="mt-2 text-sm text-gray-600 dark:text-gray-400">
+                {emailFromUrl
+                  ? `We sent a verification link to ${emailFromUrl}.`
+                  : 'Enter the 6-digit code from your email or click the link we sent you.'}
+              </p>
+            </div>
+
+            <VerificationCodeInput
+              value={code}
+              onChange={setCode}
+              onComplete={handleCodeComplete}
+              error={status === 'error' ? error ?? undefined : undefined}
+            />
+
+            {status === 'error' && !error?.includes('code') && (
+              <div role="alert" className="text-sm text-red-600 text-center">
+                {error}
+              </div>
+            )}
+
+            <div className="flex flex-col gap-3">
+              {!emailFromUrl && (
+                <Input
+                  label="Email"
+                  type="email"
+                  autoComplete="email"
+                  value={email}
+                  onChange={(e) => setEmail(e.target.value)}
+                  placeholder="you@example.com"
+                />
+              )}
+
+              <Button
+                onClick={handleResend}
+                disabled={!email || resending || cooldownActive}
+                variant="outline"
+                className="w-full"
+                aria-live="polite"
+              >
+                {resending
+                  ? 'Sending…'
+                  : cooldownActive
+                  ? `Resend available in ${secondsLeft}s`
+                  : 'Resend verification email'}
+              </Button>
+            </div>
+
+            <p className="text-xs text-center text-gray-500 dark:text-gray-400">
+              Wrong account?{' '}
+              <Link href="/auth/login" className="text-blue-600 hover:underline dark:text-blue-400">
+                Sign in with a different email
+              </Link>
+            </p>
+          </>
+        )}
+      </div>
+    </main>
+  );
+}

--- a/apps/frontend/src/components/ui/ErrorBoundary.tsx
+++ b/apps/frontend/src/components/ui/ErrorBoundary.tsx
@@ -1,0 +1,93 @@
+'use client';
+
+import React, { Component, ErrorInfo, ReactNode } from 'react';
+import * as Sentry from '@sentry/nextjs';
+import { Button } from './Button';
+
+interface ErrorBoundaryProps {
+  children: ReactNode;
+  fallback?: ReactNode | ((error: Error, reset: () => void) => ReactNode);
+  onError?: (error: Error, info: ErrorInfo) => void;
+  resetKeys?: unknown[];
+}
+
+interface ErrorBoundaryState {
+  error: Error | null;
+}
+
+export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  state: ErrorBoundaryState = { error: null };
+
+  static getDerivedStateFromError(error: Error): ErrorBoundaryState {
+    return { error };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo): void {
+    Sentry.captureException(error, {
+      contexts: { react: { componentStack: info.componentStack } },
+    });
+    this.props.onError?.(error, info);
+  }
+
+  componentDidUpdate(prevProps: ErrorBoundaryProps): void {
+    if (this.state.error && this.props.resetKeys && prevProps.resetKeys) {
+      const changed = this.props.resetKeys.some(
+        (key, i) => !Object.is(key, prevProps.resetKeys?.[i]),
+      );
+      if (changed) this.reset();
+    }
+  }
+
+  reset = (): void => {
+    this.setState({ error: null });
+  };
+
+  render(): ReactNode {
+    const { error } = this.state;
+    if (!error) return this.props.children;
+
+    if (typeof this.props.fallback === 'function') {
+      return this.props.fallback(error, this.reset);
+    }
+
+    if (this.props.fallback !== undefined) {
+      return this.props.fallback;
+    }
+
+    return <ErrorFallback error={error} reset={this.reset} />;
+  }
+}
+
+interface ErrorFallbackProps {
+  error: Error;
+  reset: () => void;
+  title?: string;
+  description?: string;
+}
+
+export function ErrorFallback({
+  error,
+  reset,
+  title = 'Something went wrong',
+  description = 'An unexpected error occurred. Please try again.',
+}: ErrorFallbackProps) {
+  return (
+    <div
+      role="alert"
+      aria-live="assertive"
+      className="flex flex-col items-center justify-center p-8 text-center min-h-[300px]"
+    >
+      <div className="text-5xl mb-4" aria-hidden="true">
+        ⚠️
+      </div>
+      <h2 className="text-xl font-bold mb-2 text-gray-900 dark:text-white">{title}</h2>
+      <p className="text-gray-500 dark:text-gray-400 mb-4 max-w-md">{description}</p>
+      {process.env.NODE_ENV !== 'production' && error?.message && (
+        <p className="text-xs text-gray-400 bg-gray-100 dark:bg-gray-800 rounded px-3 py-2 mb-4 max-w-md break-all">
+          {error.message}
+        </p>
+      )}
+      <Button onClick={reset}>Try again</Button>
+    </div>
+  );
+}

--- a/apps/frontend/src/components/ui/ErrorState.tsx
+++ b/apps/frontend/src/components/ui/ErrorState.tsx
@@ -1,0 +1,52 @@
+'use client';
+
+import React from 'react';
+import { Button } from './Button';
+
+interface ErrorStateProps {
+  title?: string;
+  message?: string;
+  error?: Error | string | null;
+  onRetry?: () => void | Promise<void>;
+  retryLabel?: string;
+  isRetrying?: boolean;
+  className?: string;
+}
+
+export function ErrorState({
+  title = 'Failed to load',
+  message = 'Something went wrong while loading this content.',
+  error,
+  onRetry,
+  retryLabel = 'Retry',
+  isRetrying = false,
+  className = '',
+}: ErrorStateProps) {
+  const errorMessage = error instanceof Error ? error.message : error;
+
+  return (
+    <div
+      role="alert"
+      aria-live="polite"
+      className={`flex flex-col items-center justify-center p-6 text-center border border-red-200 dark:border-red-900 rounded-lg bg-red-50 dark:bg-red-950/30 ${className}`}
+    >
+      <div className="text-3xl mb-2" aria-hidden="true">
+        ⚠️
+      </div>
+      <h3 className="text-base font-semibold text-red-900 dark:text-red-200 mb-1">
+        {title}
+      </h3>
+      <p className="text-sm text-red-700 dark:text-red-300 mb-3 max-w-md">{message}</p>
+      {process.env.NODE_ENV !== 'production' && errorMessage && (
+        <p className="text-xs text-red-600 dark:text-red-400 mb-3 max-w-md break-all font-mono">
+          {errorMessage}
+        </p>
+      )}
+      {onRetry && (
+        <Button onClick={onRetry} disabled={isRetrying}>
+          {isRetrying ? 'Retrying…' : retryLabel}
+        </Button>
+      )}
+    </div>
+  );
+}

--- a/apps/frontend/src/components/ui/VerificationCodeInput.tsx
+++ b/apps/frontend/src/components/ui/VerificationCodeInput.tsx
@@ -1,0 +1,140 @@
+'use client';
+
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+
+interface VerificationCodeInputProps {
+  length?: number;
+  value?: string;
+  onChange?: (code: string) => void;
+  onComplete?: (code: string) => void;
+  disabled?: boolean;
+  autoFocus?: boolean;
+  error?: string;
+  label?: string;
+  className?: string;
+}
+
+export function VerificationCodeInput({
+  length = 6,
+  value,
+  onChange,
+  onComplete,
+  disabled = false,
+  autoFocus = true,
+  error,
+  label = 'Verification code',
+  className = '',
+}: VerificationCodeInputProps) {
+  const [digits, setDigits] = useState<string[]>(() =>
+    (value ?? '').padEnd(length, ' ').slice(0, length).split('').map((c) => (c === ' ' ? '' : c)),
+  );
+  const inputRefs = useRef<Array<HTMLInputElement | null>>([]);
+
+  useEffect(() => {
+    if (value !== undefined) {
+      const next = value.padEnd(length, ' ').slice(0, length).split('').map((c) => (c === ' ' ? '' : c));
+      setDigits(next);
+    }
+  }, [value, length]);
+
+  useEffect(() => {
+    if (autoFocus && !disabled) inputRefs.current[0]?.focus();
+  }, [autoFocus, disabled]);
+
+  const emit = useCallback(
+    (next: string[]) => {
+      const code = next.join('');
+      onChange?.(code);
+      if (code.length === length && next.every((d) => d !== '')) {
+        onComplete?.(code);
+      }
+    },
+    [length, onChange, onComplete],
+  );
+
+  const handleChange = (i: number, raw: string) => {
+    const char = raw.replace(/\D/g, '').slice(-1);
+    if (!char && raw !== '') return;
+    const next = [...digits];
+    next[i] = char;
+    setDigits(next);
+    emit(next);
+    if (char && i < length - 1) inputRefs.current[i + 1]?.focus();
+  };
+
+  const handleKeyDown = (i: number, e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Backspace') {
+      if (digits[i]) {
+        const next = [...digits];
+        next[i] = '';
+        setDigits(next);
+        emit(next);
+      } else if (i > 0) {
+        inputRefs.current[i - 1]?.focus();
+        const next = [...digits];
+        next[i - 1] = '';
+        setDigits(next);
+        emit(next);
+      }
+      e.preventDefault();
+    } else if (e.key === 'ArrowLeft' && i > 0) {
+      inputRefs.current[i - 1]?.focus();
+      e.preventDefault();
+    } else if (e.key === 'ArrowRight' && i < length - 1) {
+      inputRefs.current[i + 1]?.focus();
+      e.preventDefault();
+    }
+  };
+
+  const handlePaste = (e: React.ClipboardEvent<HTMLInputElement>) => {
+    e.preventDefault();
+    const pasted = e.clipboardData.getData('text').replace(/\D/g, '').slice(0, length);
+    if (!pasted) return;
+    const next = Array(length).fill('');
+    for (let i = 0; i < pasted.length; i++) next[i] = pasted[i];
+    setDigits(next);
+    emit(next);
+    const focusIndex = Math.min(pasted.length, length - 1);
+    inputRefs.current[focusIndex]?.focus();
+  };
+
+  return (
+    <fieldset
+      className={`flex flex-col gap-2 ${className}`}
+      aria-describedby={error ? 'verification-code-error' : undefined}
+    >
+      <legend className="text-sm font-medium text-gray-700 dark:text-gray-300">{label}</legend>
+      <div className="flex gap-2 justify-center" role="group" aria-label={label}>
+        {digits.map((digit, i) => (
+          <input
+            key={i}
+            ref={(el) => {
+              inputRefs.current[i] = el;
+            }}
+            type="text"
+            inputMode="numeric"
+            autoComplete={i === 0 ? 'one-time-code' : 'off'}
+            maxLength={1}
+            value={digit}
+            disabled={disabled}
+            aria-label={`Digit ${i + 1} of ${length}`}
+            aria-invalid={!!error}
+            onChange={(e) => handleChange(i, e.target.value)}
+            onKeyDown={(e) => handleKeyDown(i, e)}
+            onPaste={handlePaste}
+            onFocus={(e) => e.target.select()}
+            className={`w-12 h-14 text-center text-2xl font-semibold rounded-lg border-2 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100
+              focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500
+              disabled:opacity-50 disabled:cursor-not-allowed
+              ${error ? 'border-red-500' : 'border-gray-300 dark:border-gray-600'}`}
+          />
+        ))}
+      </div>
+      {error && (
+        <p id="verification-code-error" role="alert" className="text-xs text-red-600 text-center">
+          {error}
+        </p>
+      )}
+    </fieldset>
+  );
+}

--- a/apps/frontend/src/hooks/useCountdown.ts
+++ b/apps/frontend/src/hooks/useCountdown.ts
@@ -1,0 +1,43 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+interface UseCountdownResult {
+  secondsLeft: number;
+  isActive: boolean;
+  start: (seconds: number) => void;
+  stop: () => void;
+}
+
+export function useCountdown(initialSeconds = 0): UseCountdownResult {
+  const [secondsLeft, setSecondsLeft] = useState(initialSeconds);
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  const stop = useCallback(() => {
+    if (intervalRef.current) {
+      clearInterval(intervalRef.current);
+      intervalRef.current = null;
+    }
+  }, []);
+
+  const start = useCallback(
+    (seconds: number) => {
+      stop();
+      setSecondsLeft(seconds);
+      intervalRef.current = setInterval(() => {
+        setSecondsLeft((prev) => {
+          if (prev <= 1) {
+            stop();
+            return 0;
+          }
+          return prev - 1;
+        });
+      }, 1000);
+    },
+    [stop],
+  );
+
+  useEffect(() => stop, [stop]);
+
+  return { secondsLeft, isActive: secondsLeft > 0, start, stop };
+}

--- a/apps/frontend/src/hooks/useRetry.ts
+++ b/apps/frontend/src/hooks/useRetry.ts
@@ -1,0 +1,67 @@
+'use client';
+
+import { useCallback, useState } from 'react';
+import * as Sentry from '@sentry/nextjs';
+
+interface UseRetryOptions {
+  maxAttempts?: number;
+  backoffMs?: number;
+  onError?: (error: Error, attempt: number) => void;
+}
+
+interface UseRetryResult<T> {
+  execute: () => Promise<T | undefined>;
+  isRetrying: boolean;
+  attempt: number;
+  error: Error | null;
+  reset: () => void;
+}
+
+export function useRetry<T>(
+  fn: () => Promise<T>,
+  options: UseRetryOptions = {},
+): UseRetryResult<T> {
+  const { maxAttempts = 3, backoffMs = 500, onError } = options;
+  const [isRetrying, setIsRetrying] = useState(false);
+  const [attempt, setAttempt] = useState(0);
+  const [error, setError] = useState<Error | null>(null);
+
+  const execute = useCallback(async (): Promise<T | undefined> => {
+    setIsRetrying(true);
+    setError(null);
+    let lastError: Error | null = null;
+
+    for (let i = 0; i < maxAttempts; i++) {
+      setAttempt(i + 1);
+      try {
+        const result = await fn();
+        setIsRetrying(false);
+        setError(null);
+        return result;
+      } catch (err) {
+        lastError = err instanceof Error ? err : new Error(String(err));
+        onError?.(lastError, i + 1);
+        if (i < maxAttempts - 1) {
+          await new Promise((r) => setTimeout(r, backoffMs * Math.pow(2, i)));
+        }
+      }
+    }
+
+    if (lastError) {
+      Sentry.captureException(lastError, {
+        tags: { source: 'useRetry', attempts: String(maxAttempts) },
+      });
+      setError(lastError);
+    }
+    setIsRetrying(false);
+    return undefined;
+  }, [fn, maxAttempts, backoffMs, onError]);
+
+  const reset = useCallback(() => {
+    setError(null);
+    setAttempt(0);
+    setIsRetrying(false);
+  }, []);
+
+  return { execute, isRetrying, attempt, error, reset };
+}

--- a/apps/frontend/src/lib/errorLogger.ts
+++ b/apps/frontend/src/lib/errorLogger.ts
@@ -1,0 +1,35 @@
+import * as Sentry from '@sentry/nextjs';
+
+interface LogContext {
+  source?: string;
+  userId?: string;
+  extra?: Record<string, unknown>;
+  tags?: Record<string, string>;
+}
+
+export function logError(error: unknown, context: LogContext = {}): void {
+  const err = error instanceof Error ? error : new Error(String(error));
+
+  if (process.env.NODE_ENV !== 'production') {
+    // eslint-disable-next-line no-console
+    console.error('[errorLogger]', context.source ?? 'app', err, context.extra);
+  }
+
+  Sentry.captureException(err, {
+    tags: { source: context.source ?? 'app', ...context.tags },
+    user: context.userId ? { id: context.userId } : undefined,
+    extra: context.extra,
+  });
+}
+
+export function logMessage(
+  message: string,
+  level: 'info' | 'warning' | 'error' = 'info',
+  context: LogContext = {},
+): void {
+  Sentry.captureMessage(message, {
+    level,
+    tags: { source: context.source ?? 'app', ...context.tags },
+    extra: context.extra,
+  });
+}


### PR DESCRIPTION
…n (#441-#444)

- #441: add axe-playwright/jest-axe deps, unit-level axe tests for UI primitives
- #442: ErrorBoundary, ErrorState, useRetry hook, central errorLogger (Sentry)
- #443: tests for existing Breadcrumb / CompactBreadcrumb components
- #444: VerificationCodeInput (6-digit OTP), useCountdown, verify-email page with link/token + resend cooldown + idle/verifying/success/error states; register flow redirects to /auth/verify-email

Closes #441 
Closes #442 
Closes #443 
Closes #444 