### PR TITLE
feat(frontend): leaderboard, cohorts, form framework, i18n extensions…

### DIFF
--- a/apps/frontend/messages/ar.json
+++ b/apps/frontend/messages/ar.json
@@ -88,5 +88,106 @@
     "playPause": "تشغيل / إيقاف",
     "seekBack": "رجوع 10 ثوانٍ",
     "seekForward": "تقديم 10 ثوانٍ"
+  },
+  "leaderboard": {
+    "title": "لوحة المتصدرين",
+    "subtitle": "أفضل المتعلمين حسب النقاط والإنجازات.",
+    "rank": "المرتبة",
+    "learner": "المتعلم",
+    "points": "النقاط",
+    "courses": "الدورات",
+    "badges": "الأوسمة",
+    "you": "أنت",
+    "loading": "جارٍ تحميل التصنيف…",
+    "empty": "لا توجد تصنيفات بعد.",
+    "previous": "السابق",
+    "next": "التالي",
+    "page": "الصفحة {page} من {total}",
+    "periods": {
+      "week": "هذا الأسبوع",
+      "month": "هذا الشهر",
+      "all": "كل الوقت"
+    },
+    "pointsValue": "{value, number} نقطة",
+    "coursesValue": "{value, number} مكتملة",
+    "updated": "آخر تحديث {date}"
+  },
+  "cohorts": {
+    "title": "المجموعات",
+    "subtitle": "إدارة مجموعات الطلاب والأعضاء والتعيينات.",
+    "newCohort": "مجموعة جديدة",
+    "empty": "لا توجد مجموعات بعد. أنشئ أول مجموعة للبدء.",
+    "loading": "جارٍ تحميل المجموعات…",
+    "membersCount": "{count, plural, =0 {لا يوجد أعضاء} one {عضو واحد} two {عضوان} few {# أعضاء} many {# عضواً} other {# عضو}}",
+    "coursesCount": "{count, plural, =0 {لا توجد دورات} one {دورة واحدة} two {دورتان} few {# دورات} many {# دورة} other {# دورة}}",
+    "progressLabel": "{value, number, ::percent} مكتمل",
+    "created": "أُنشئت في {date}",
+    "form": {
+      "title": "إنشاء مجموعة",
+      "editTitle": "تعديل المجموعة",
+      "name": "اسم المجموعة",
+      "namePlaceholder": "مثال: ربيع 2026 — مسار Stellar",
+      "description": "الوصف",
+      "descriptionPlaceholder": "ما الذي تركز عليه هذه المجموعة؟",
+      "startDate": "تاريخ البداية",
+      "endDate": "تاريخ النهاية",
+      "capacity": "السعة",
+      "capacityHint": "الحد الأقصى لعدد الطلاب",
+      "submit": "إنشاء المجموعة",
+      "submitting": "جارٍ الإنشاء…",
+      "cancel": "إلغاء"
+    },
+    "tabs": {
+      "overview": "نظرة عامة",
+      "members": "الأعضاء",
+      "discussion": "النقاش",
+      "courses": "الدورات",
+      "analytics": "التحليلات"
+    },
+    "members": {
+      "addMember": "إضافة عضو",
+      "emailPlaceholder": "student@example.com",
+      "role": "الدور",
+      "joined": "انضم في {date}",
+      "remove": "إزالة",
+      "roles": {
+        "student": "طالب",
+        "ta": "مساعد",
+        "instructor": "مدرّس"
+      },
+      "empty": "لا يوجد أعضاء بعد. ادعُ شخصاً للانضمام."
+    },
+    "discussion": {
+      "title": "نقاش المجموعة",
+      "placeholder": "شارك تحديثاً مع مجموعتك…",
+      "post": "نشر",
+      "empty": "لا توجد رسائل بعد. ابدأ المحادثة."
+    },
+    "courses": {
+      "assignedTitle": "الدورات المعيّنة",
+      "assign": "تعيين دورة",
+      "empty": "لا توجد دورات معيّنة.",
+      "due": "الموعد النهائي {date}"
+    },
+    "analytics": {
+      "activeMembers": "الأعضاء النشطون",
+      "avgProgress": "متوسط التقدم",
+      "completionRate": "معدل الإكمال",
+      "totalPoints": "إجمالي النقاط المكتسبة"
+    }
+  },
+  "forms": {
+    "required": "هذا الحقل مطلوب",
+    "invalidEmail": "أدخل بريداً إلكترونياً صالحاً",
+    "minLength": "يجب أن يحتوي على {min} حرفاً على الأقل",
+    "maxLength": "يجب ألا يتجاوز {max} حرفاً",
+    "minValue": "يجب أن يكون {min} على الأقل",
+    "maxValue": "يجب ألا يتجاوز {max}",
+    "passwordMismatch": "كلمتا المرور غير متطابقتين",
+    "checking": "جارٍ التحقق…",
+    "checkingError": "تعذّر التحقق. حاول مرة أخرى.",
+    "submitting": "جارٍ الإرسال…",
+    "submit": "إرسال",
+    "reset": "إعادة تعيين"
   }
 }

--- a/apps/frontend/messages/en.json
+++ b/apps/frontend/messages/en.json
@@ -80,5 +80,106 @@
     "playPause": "Play / Pause",
     "seekBack": "Seek back 10s",
     "seekForward": "Seek forward 10s"
+  },
+  "leaderboard": {
+    "title": "Leaderboard",
+    "subtitle": "Top learners by points and achievements.",
+    "rank": "Rank",
+    "learner": "Learner",
+    "points": "Points",
+    "courses": "Courses",
+    "badges": "Badges",
+    "you": "You",
+    "loading": "Loading rankings…",
+    "empty": "No rankings to display yet.",
+    "previous": "Previous",
+    "next": "Next",
+    "page": "Page {page} of {total}",
+    "periods": {
+      "week": "This week",
+      "month": "This month",
+      "all": "All time"
+    },
+    "pointsValue": "{value, number} pts",
+    "coursesValue": "{value, number} completed",
+    "updated": "Updated {date}"
+  },
+  "cohorts": {
+    "title": "Cohorts",
+    "subtitle": "Manage student cohorts, members, and assignments.",
+    "newCohort": "New cohort",
+    "empty": "No cohorts yet. Create your first one to get started.",
+    "loading": "Loading cohorts…",
+    "membersCount": "{count, plural, =0 {No members} one {# member} other {# members}}",
+    "coursesCount": "{count, plural, =0 {No courses} one {# course} other {# courses}}",
+    "progressLabel": "{value, number, ::percent} complete",
+    "created": "Created {date}",
+    "form": {
+      "title": "Create cohort",
+      "editTitle": "Edit cohort",
+      "name": "Cohort name",
+      "namePlaceholder": "e.g. Spring 2026 — Stellar Track",
+      "description": "Description",
+      "descriptionPlaceholder": "What is this cohort focused on?",
+      "startDate": "Start date",
+      "endDate": "End date",
+      "capacity": "Capacity",
+      "capacityHint": "Maximum number of students",
+      "submit": "Create cohort",
+      "submitting": "Creating…",
+      "cancel": "Cancel"
+    },
+    "tabs": {
+      "overview": "Overview",
+      "members": "Members",
+      "discussion": "Discussion",
+      "courses": "Courses",
+      "analytics": "Analytics"
+    },
+    "members": {
+      "addMember": "Add member",
+      "emailPlaceholder": "student@example.com",
+      "role": "Role",
+      "joined": "Joined {date}",
+      "remove": "Remove",
+      "roles": {
+        "student": "Student",
+        "ta": "TA",
+        "instructor": "Instructor"
+      },
+      "empty": "No members yet. Invite someone to join."
+    },
+    "discussion": {
+      "title": "Cohort discussion",
+      "placeholder": "Share an update with your cohort…",
+      "post": "Post",
+      "empty": "No messages yet. Start the conversation."
+    },
+    "courses": {
+      "assignedTitle": "Assigned courses",
+      "assign": "Assign course",
+      "empty": "No courses assigned.",
+      "due": "Due {date}"
+    },
+    "analytics": {
+      "activeMembers": "Active members",
+      "avgProgress": "Average progress",
+      "completionRate": "Completion rate",
+      "totalPoints": "Total points earned"
+    }
+  },
+  "forms": {
+    "required": "This field is required",
+    "invalidEmail": "Enter a valid email address",
+    "minLength": "Must be at least {min} characters",
+    "maxLength": "Must be at most {max} characters",
+    "minValue": "Must be at least {min}",
+    "maxValue": "Must be at most {max}",
+    "passwordMismatch": "Passwords do not match",
+    "checking": "Checking…",
+    "checkingError": "Could not validate. Try again.",
+    "submitting": "Submitting…",
+    "submit": "Submit",
+    "reset": "Reset"
   }
 }

--- a/apps/frontend/messages/es.json
+++ b/apps/frontend/messages/es.json
@@ -80,5 +80,106 @@
     "playPause": "Reproducir / Pausar",
     "seekBack": "Retroceder 10s",
     "seekForward": "Avanzar 10s"
+  },
+  "leaderboard": {
+    "title": "Tabla de clasificación",
+    "subtitle": "Mejores estudiantes por puntos y logros.",
+    "rank": "Puesto",
+    "learner": "Estudiante",
+    "points": "Puntos",
+    "courses": "Cursos",
+    "badges": "Insignias",
+    "you": "Tú",
+    "loading": "Cargando clasificación…",
+    "empty": "Aún no hay clasificaciones.",
+    "previous": "Anterior",
+    "next": "Siguiente",
+    "page": "Página {page} de {total}",
+    "periods": {
+      "week": "Esta semana",
+      "month": "Este mes",
+      "all": "Todo el tiempo"
+    },
+    "pointsValue": "{value, number} pts",
+    "coursesValue": "{value, number} completados",
+    "updated": "Actualizado {date}"
+  },
+  "cohorts": {
+    "title": "Cohortes",
+    "subtitle": "Gestiona cohortes de estudiantes, miembros y asignaciones.",
+    "newCohort": "Nueva cohorte",
+    "empty": "Aún no hay cohortes. Crea la primera para empezar.",
+    "loading": "Cargando cohortes…",
+    "membersCount": "{count, plural, =0 {Sin miembros} one {# miembro} other {# miembros}}",
+    "coursesCount": "{count, plural, =0 {Sin cursos} one {# curso} other {# cursos}}",
+    "progressLabel": "{value, number, ::percent} completado",
+    "created": "Creada el {date}",
+    "form": {
+      "title": "Crear cohorte",
+      "editTitle": "Editar cohorte",
+      "name": "Nombre de la cohorte",
+      "namePlaceholder": "ej. Primavera 2026 — Pista Stellar",
+      "description": "Descripción",
+      "descriptionPlaceholder": "¿En qué se centra esta cohorte?",
+      "startDate": "Fecha de inicio",
+      "endDate": "Fecha de fin",
+      "capacity": "Capacidad",
+      "capacityHint": "Número máximo de estudiantes",
+      "submit": "Crear cohorte",
+      "submitting": "Creando…",
+      "cancel": "Cancelar"
+    },
+    "tabs": {
+      "overview": "Resumen",
+      "members": "Miembros",
+      "discussion": "Discusión",
+      "courses": "Cursos",
+      "analytics": "Analíticas"
+    },
+    "members": {
+      "addMember": "Añadir miembro",
+      "emailPlaceholder": "estudiante@ejemplo.com",
+      "role": "Rol",
+      "joined": "Unido el {date}",
+      "remove": "Eliminar",
+      "roles": {
+        "student": "Estudiante",
+        "ta": "Auxiliar",
+        "instructor": "Instructor"
+      },
+      "empty": "Aún no hay miembros. Invita a alguien a unirse."
+    },
+    "discussion": {
+      "title": "Discusión de la cohorte",
+      "placeholder": "Comparte una actualización con tu cohorte…",
+      "post": "Publicar",
+      "empty": "Aún no hay mensajes. Empieza la conversación."
+    },
+    "courses": {
+      "assignedTitle": "Cursos asignados",
+      "assign": "Asignar curso",
+      "empty": "Sin cursos asignados.",
+      "due": "Hasta {date}"
+    },
+    "analytics": {
+      "activeMembers": "Miembros activos",
+      "avgProgress": "Progreso promedio",
+      "completionRate": "Tasa de finalización",
+      "totalPoints": "Puntos totales ganados"
+    }
+  },
+  "forms": {
+    "required": "Este campo es obligatorio",
+    "invalidEmail": "Introduce un correo electrónico válido",
+    "minLength": "Debe tener al menos {min} caracteres",
+    "maxLength": "Debe tener como máximo {max} caracteres",
+    "minValue": "Debe ser al menos {min}",
+    "maxValue": "Debe ser como máximo {max}",
+    "passwordMismatch": "Las contraseñas no coinciden",
+    "checking": "Comprobando…",
+    "checkingError": "No se pudo validar. Inténtalo de nuevo.",
+    "submitting": "Enviando…",
+    "submit": "Enviar",
+    "reset": "Restablecer"
   }
 }

--- a/apps/frontend/messages/fr.json
+++ b/apps/frontend/messages/fr.json
@@ -88,5 +88,106 @@
     "playPause": "Lecture / Pause",
     "seekBack": "Reculer de 10s",
     "seekForward": "Avancer de 10s"
+  },
+  "leaderboard": {
+    "title": "Classement",
+    "subtitle": "Meilleurs apprenants par points et succès.",
+    "rank": "Rang",
+    "learner": "Apprenant",
+    "points": "Points",
+    "courses": "Cours",
+    "badges": "Badges",
+    "you": "Vous",
+    "loading": "Chargement du classement…",
+    "empty": "Aucun classement à afficher.",
+    "previous": "Précédent",
+    "next": "Suivant",
+    "page": "Page {page} sur {total}",
+    "periods": {
+      "week": "Cette semaine",
+      "month": "Ce mois",
+      "all": "Tout le temps"
+    },
+    "pointsValue": "{value, number} pts",
+    "coursesValue": "{value, number} terminés",
+    "updated": "Mis à jour {date}"
+  },
+  "cohorts": {
+    "title": "Cohortes",
+    "subtitle": "Gérez les cohortes d'étudiants, les membres et les affectations.",
+    "newCohort": "Nouvelle cohorte",
+    "empty": "Aucune cohorte. Créez la première pour commencer.",
+    "loading": "Chargement des cohortes…",
+    "membersCount": "{count, plural, =0 {Aucun membre} one {# membre} other {# membres}}",
+    "coursesCount": "{count, plural, =0 {Aucun cours} one {# cours} other {# cours}}",
+    "progressLabel": "{value, number, ::percent} terminé",
+    "created": "Créée le {date}",
+    "form": {
+      "title": "Créer une cohorte",
+      "editTitle": "Modifier la cohorte",
+      "name": "Nom de la cohorte",
+      "namePlaceholder": "ex. Printemps 2026 — Parcours Stellar",
+      "description": "Description",
+      "descriptionPlaceholder": "Sur quoi cette cohorte est-elle axée ?",
+      "startDate": "Date de début",
+      "endDate": "Date de fin",
+      "capacity": "Capacité",
+      "capacityHint": "Nombre maximum d'étudiants",
+      "submit": "Créer la cohorte",
+      "submitting": "Création…",
+      "cancel": "Annuler"
+    },
+    "tabs": {
+      "overview": "Aperçu",
+      "members": "Membres",
+      "discussion": "Discussion",
+      "courses": "Cours",
+      "analytics": "Analytique"
+    },
+    "members": {
+      "addMember": "Ajouter un membre",
+      "emailPlaceholder": "etudiant@exemple.com",
+      "role": "Rôle",
+      "joined": "Inscrit le {date}",
+      "remove": "Retirer",
+      "roles": {
+        "student": "Étudiant",
+        "ta": "Assistant",
+        "instructor": "Instructeur"
+      },
+      "empty": "Aucun membre pour l'instant. Invitez quelqu'un à rejoindre."
+    },
+    "discussion": {
+      "title": "Discussion de la cohorte",
+      "placeholder": "Partagez une mise à jour avec votre cohorte…",
+      "post": "Publier",
+      "empty": "Aucun message. Lancez la conversation."
+    },
+    "courses": {
+      "assignedTitle": "Cours assignés",
+      "assign": "Assigner un cours",
+      "empty": "Aucun cours assigné.",
+      "due": "Échéance {date}"
+    },
+    "analytics": {
+      "activeMembers": "Membres actifs",
+      "avgProgress": "Progression moyenne",
+      "completionRate": "Taux d'achèvement",
+      "totalPoints": "Points totaux gagnés"
+    }
+  },
+  "forms": {
+    "required": "Ce champ est obligatoire",
+    "invalidEmail": "Saisissez une adresse e-mail valide",
+    "minLength": "Doit contenir au moins {min} caractères",
+    "maxLength": "Doit contenir au plus {max} caractères",
+    "minValue": "Doit être au moins {min}",
+    "maxValue": "Doit être au plus {max}",
+    "passwordMismatch": "Les mots de passe ne correspondent pas",
+    "checking": "Vérification…",
+    "checkingError": "Validation impossible. Réessayez.",
+    "submitting": "Envoi…",
+    "submit": "Envoyer",
+    "reset": "Réinitialiser"
   }
 }

--- a/apps/frontend/src/app/[locale]/cohorts/[id]/page.tsx
+++ b/apps/frontend/src/app/[locale]/cohorts/[id]/page.tsx
@@ -1,0 +1,311 @@
+'use client';
+
+import { useState, use } from 'react';
+import { useTranslations } from 'next-intl';
+import { notFound } from 'next/navigation';
+import Link from 'next/link';
+import { useCohort, useCohorts, type CohortRole } from '@/hooks/useCohorts';
+import { useAuth } from '@/hooks/useAuth';
+import { useDateFormatter, useNumberFormatter } from '@/lib/format';
+import { Button } from '@/components/ui/Button';
+
+type Tab = 'overview' | 'members' | 'discussion' | 'courses' | 'analytics';
+const TABS: Tab[] = ['overview', 'members', 'discussion', 'courses', 'analytics'];
+
+export default function CohortDetailPage({
+  params,
+}: {
+  params: Promise<{ id: string; locale: string }>;
+}) {
+  const { id } = use(params);
+  const t = useTranslations('cohorts');
+  const cohort = useCohort(id);
+  const [tab, setTab] = useState<Tab>('overview');
+
+  if (!cohort) return notFound();
+
+  return (
+    <main className="max-w-5xl mx-auto p-8 space-y-6">
+      <header className="space-y-1">
+        <Link href="/cohorts" className="text-sm text-blue-600 dark:text-blue-400 hover:underline">
+          ← {t('title')}
+        </Link>
+        <h1 className="text-3xl font-bold text-gray-900 dark:text-white">{cohort.name}</h1>
+        {cohort.description && (
+          <p className="text-gray-600 dark:text-gray-400">{cohort.description}</p>
+        )}
+      </header>
+
+      <div
+        role="tablist"
+        aria-label={cohort.name}
+        className="border-b border-gray-200 dark:border-gray-700 flex gap-4"
+      >
+        {TABS.map((key) => (
+          <button
+            key={key}
+            role="tab"
+            type="button"
+            aria-selected={tab === key}
+            onClick={() => setTab(key)}
+            className={`px-3 py-2 text-sm font-medium -mb-px border-b-2 transition-colors ${
+              tab === key
+                ? 'border-blue-600 text-blue-600 dark:text-blue-400'
+                : 'border-transparent text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white'
+            }`}
+          >
+            {t(`tabs.${key}`)}
+          </button>
+        ))}
+      </div>
+
+      {tab === 'overview' && <Overview cohortId={cohort.id} />}
+      {tab === 'members' && <Members cohortId={cohort.id} />}
+      {tab === 'discussion' && <Discussion cohortId={cohort.id} />}
+      {tab === 'courses' && <Courses cohortId={cohort.id} />}
+      {tab === 'analytics' && <Analytics cohortId={cohort.id} />}
+    </main>
+  );
+}
+
+function Overview({ cohortId }: { cohortId: string }) {
+  const t = useTranslations('cohorts');
+  const cohort = useCohort(cohortId)!;
+  const dateFmt = useDateFormatter();
+  const numFmt = useNumberFormatter();
+
+  return (
+    <section className="grid gap-4 md:grid-cols-2">
+      <Stat
+        label={t('analytics.activeMembers')}
+        value={numFmt.decimal(cohort.analytics.activeMembers)}
+      />
+      <Stat
+        label={t('analytics.avgProgress')}
+        value={numFmt.percent(cohort.analytics.avgProgress)}
+      />
+      <Stat
+        label={t('analytics.completionRate')}
+        value={numFmt.percent(cohort.analytics.completionRate)}
+      />
+      <Stat
+        label={t('analytics.totalPoints')}
+        value={numFmt.compact(cohort.analytics.totalPoints)}
+      />
+      <div className="md:col-span-2 text-sm text-gray-500 dark:text-gray-400">
+        {t('created', { date: dateFmt.long(cohort.createdAt) })}
+      </div>
+    </section>
+  );
+}
+
+function Stat({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="border border-gray-200 dark:border-gray-700 rounded-lg p-4 bg-white dark:bg-gray-900">
+      <div className="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400">
+        {label}
+      </div>
+      <div className="text-2xl font-semibold text-gray-900 dark:text-white tabular-nums mt-1">
+        {value}
+      </div>
+    </div>
+  );
+}
+
+function Members({ cohortId }: { cohortId: string }) {
+  const t = useTranslations('cohorts.members');
+  const cohort = useCohort(cohortId)!;
+  const { addMember, removeMember } = useCohorts();
+  const dateFmt = useDateFormatter();
+  const [email, setEmail] = useState('');
+  const [role, setRole] = useState<CohortRole>('student');
+
+  const handleAdd = () => {
+    if (!email.trim()) return;
+    addMember(cohortId, { email: email.trim(), name: email.split('@')[0], role });
+    setEmail('');
+  };
+
+  return (
+    <section className="space-y-4">
+      <div className="flex flex-wrap items-end gap-2">
+        <input
+          type="email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          placeholder={t('emailPlaceholder')}
+          className="flex-1 min-w-[240px] border border-gray-300 dark:border-gray-600 rounded-lg px-3 py-2 bg-white dark:bg-gray-800"
+        />
+        <select
+          value={role}
+          onChange={(e) => setRole(e.target.value as CohortRole)}
+          aria-label={t('role')}
+          className="border border-gray-300 dark:border-gray-600 rounded-lg px-3 py-2 bg-white dark:bg-gray-800"
+        >
+          <option value="student">{t('roles.student')}</option>
+          <option value="ta">{t('roles.ta')}</option>
+          <option value="instructor">{t('roles.instructor')}</option>
+        </select>
+        <Button onClick={handleAdd}>{t('addMember')}</Button>
+      </div>
+
+      {cohort.members.length === 0 ? (
+        <p className="text-center py-10 text-gray-500 dark:text-gray-400">{t('empty')}</p>
+      ) : (
+        <ul className="divide-y divide-gray-200 dark:divide-gray-700 border border-gray-200 dark:border-gray-700 rounded-lg overflow-hidden">
+          {cohort.members.map((m) => (
+            <li
+              key={m.id}
+              className="flex items-center justify-between gap-3 px-4 py-3 bg-white dark:bg-gray-900"
+            >
+              <div>
+                <div className="text-sm font-medium text-gray-900 dark:text-white">{m.name}</div>
+                <div className="text-xs text-gray-500 dark:text-gray-400">
+                  {m.email} · {t(`roles.${m.role}`)} ·{' '}
+                  {t('joined', { date: dateFmt.short(m.joinedAt) })}
+                </div>
+              </div>
+              <button
+                type="button"
+                onClick={() => removeMember(cohortId, m.id)}
+                className="text-sm text-red-600 hover:underline"
+              >
+                {t('remove')}
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}
+
+function Discussion({ cohortId }: { cohortId: string }) {
+  const t = useTranslations('cohorts.discussion');
+  const cohort = useCohort(cohortId)!;
+  const { postMessage } = useCohorts();
+  const { user } = useAuth();
+  const dateFmt = useDateFormatter();
+  const [body, setBody] = useState('');
+
+  const handlePost = () => {
+    const trimmed = body.trim();
+    if (!trimmed) return;
+    postMessage(cohortId, user?.username ?? 'Anonymous', trimmed);
+    setBody('');
+  };
+
+  return (
+    <section className="space-y-4">
+      <div className="space-y-2">
+        <textarea
+          value={body}
+          onChange={(e) => setBody(e.target.value)}
+          placeholder={t('placeholder')}
+          rows={3}
+          className="w-full border border-gray-300 dark:border-gray-600 rounded-lg px-3 py-2 bg-white dark:bg-gray-800"
+        />
+        <div className="flex justify-end">
+          <Button onClick={handlePost} disabled={!body.trim()}>
+            {t('post')}
+          </Button>
+        </div>
+      </div>
+
+      {cohort.messages.length === 0 ? (
+        <p className="text-center py-10 text-gray-500 dark:text-gray-400">{t('empty')}</p>
+      ) : (
+        <ul className="space-y-2">
+          {cohort.messages.map((m) => (
+            <li
+              key={m.id}
+              className="border border-gray-200 dark:border-gray-700 rounded-lg p-3 bg-white dark:bg-gray-900"
+            >
+              <div className="flex items-center justify-between gap-2 mb-1">
+                <span className="text-sm font-medium text-gray-900 dark:text-white">
+                  {m.author}
+                </span>
+                <span className="text-xs text-gray-500 dark:text-gray-400">
+                  {dateFmt.relative(m.postedAt)}
+                </span>
+              </div>
+              <p className="text-sm text-gray-700 dark:text-gray-300 whitespace-pre-wrap">
+                {m.body}
+              </p>
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}
+
+function Courses({ cohortId }: { cohortId: string }) {
+  const t = useTranslations('cohorts.courses');
+  const cohort = useCohort(cohortId)!;
+  const { assignCourse } = useCohorts();
+  const dateFmt = useDateFormatter();
+  const [title, setTitle] = useState('');
+  const [dueAt, setDueAt] = useState('');
+
+  const handleAssign = () => {
+    if (!title.trim() || !dueAt) return;
+    assignCourse(cohortId, { title: title.trim(), dueAt });
+    setTitle('');
+    setDueAt('');
+  };
+
+  return (
+    <section className="space-y-4">
+      <h2 className="text-lg font-semibold text-gray-900 dark:text-white">{t('assignedTitle')}</h2>
+
+      <div className="flex flex-wrap items-end gap-2">
+        <input
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+          placeholder="Course title"
+          className="flex-1 min-w-[200px] border border-gray-300 dark:border-gray-600 rounded-lg px-3 py-2 bg-white dark:bg-gray-800"
+        />
+        <input
+          type="date"
+          value={dueAt}
+          onChange={(e) => setDueAt(e.target.value)}
+          className="border border-gray-300 dark:border-gray-600 rounded-lg px-3 py-2 bg-white dark:bg-gray-800"
+        />
+        <Button onClick={handleAssign}>{t('assign')}</Button>
+      </div>
+
+      {cohort.courses.length === 0 ? (
+        <p className="text-center py-10 text-gray-500 dark:text-gray-400">{t('empty')}</p>
+      ) : (
+        <ul className="divide-y divide-gray-200 dark:divide-gray-700 border border-gray-200 dark:border-gray-700 rounded-lg overflow-hidden">
+          {cohort.courses.map((c) => (
+            <li
+              key={c.id}
+              className="px-4 py-3 bg-white dark:bg-gray-900 flex items-center justify-between gap-2"
+            >
+              <span className="text-sm font-medium text-gray-900 dark:text-white">{c.title}</span>
+              <span className="text-xs text-gray-500 dark:text-gray-400">
+                {t('due', { date: dateFmt.short(c.dueAt) })}
+              </span>
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}
+
+function Analytics({ cohortId }: { cohortId: string }) {
+  const t = useTranslations('cohorts.analytics');
+  const cohort = useCohort(cohortId)!;
+  const numFmt = useNumberFormatter();
+  return (
+    <section className="grid gap-4 md:grid-cols-2">
+      <Stat label={t('activeMembers')} value={numFmt.decimal(cohort.analytics.activeMembers)} />
+      <Stat label={t('avgProgress')} value={numFmt.percent(cohort.analytics.avgProgress)} />
+      <Stat label={t('completionRate')} value={numFmt.percent(cohort.analytics.completionRate)} />
+      <Stat label={t('totalPoints')} value={numFmt.compact(cohort.analytics.totalPoints)} />
+    </section>
+  );
+}

--- a/apps/frontend/src/app/[locale]/cohorts/page.tsx
+++ b/apps/frontend/src/app/[locale]/cohorts/page.tsx
@@ -1,0 +1,74 @@
+'use client';
+
+import { useState } from 'react';
+import Link from 'next/link';
+import { useTranslations } from 'next-intl';
+import { useCohorts } from '@/hooks/useCohorts';
+import { useDateFormatter } from '@/lib/format';
+import { Button } from '@/components/ui/Button';
+import { CohortForm, type CohortFormValues } from '@/components/cohorts/CohortForm';
+
+export default function CohortsPage() {
+  const t = useTranslations('cohorts');
+  const { cohorts, create } = useCohorts();
+  const dateFmt = useDateFormatter();
+  const [creating, setCreating] = useState(false);
+
+  const onCreate = (values: CohortFormValues) => {
+    create(values);
+    setCreating(false);
+  };
+
+  return (
+    <main className="max-w-5xl mx-auto p-8 space-y-6">
+      <header className="flex items-start justify-between gap-4 flex-wrap">
+        <div>
+          <h1 className="text-3xl font-bold text-gray-900 dark:text-white">{t('title')}</h1>
+          <p className="text-gray-600 dark:text-gray-400">{t('subtitle')}</p>
+        </div>
+        {!creating && <Button onClick={() => setCreating(true)}>{t('newCohort')}</Button>}
+      </header>
+
+      {creating && (
+        <section className="border border-gray-200 dark:border-gray-700 rounded-lg p-6 bg-white dark:bg-gray-900">
+          <h2 className="text-lg font-semibold mb-4 text-gray-900 dark:text-white">
+            {t('form.title')}
+          </h2>
+          <CohortForm onSubmit={onCreate} onCancel={() => setCreating(false)} />
+        </section>
+      )}
+
+      {cohorts.length === 0 ? (
+        <p className="text-center py-16 text-gray-500 dark:text-gray-400">{t('empty')}</p>
+      ) : (
+        <ul className="grid gap-4 md:grid-cols-2">
+          {cohorts.map((c) => (
+            <li
+              key={c.id}
+              className="border border-gray-200 dark:border-gray-700 rounded-lg p-5 bg-white dark:bg-gray-900 hover:shadow-sm transition-shadow"
+            >
+              <Link href={`/cohorts/${c.id}`} className="block space-y-2">
+                <h3 className="text-base font-semibold text-gray-900 dark:text-white">{c.name}</h3>
+                {c.description && (
+                  <p className="text-sm text-gray-600 dark:text-gray-400 line-clamp-2">
+                    {c.description}
+                  </p>
+                )}
+                <div className="flex flex-wrap gap-3 text-xs text-gray-500 dark:text-gray-400">
+                  <span>{t('membersCount', { count: c.members.length })}</span>
+                  <span>·</span>
+                  <span>{t('coursesCount', { count: c.courses.length })}</span>
+                  <span>·</span>
+                  <span>{t('progressLabel', { value: c.analytics.avgProgress })}</span>
+                </div>
+                <p className="text-xs text-gray-500 dark:text-gray-500">
+                  {t('created', { date: dateFmt.short(c.createdAt) })}
+                </p>
+              </Link>
+            </li>
+          ))}
+        </ul>
+      )}
+    </main>
+  );
+}

--- a/apps/frontend/src/app/[locale]/leaderboard/page.tsx
+++ b/apps/frontend/src/app/[locale]/leaderboard/page.tsx
@@ -1,0 +1,228 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import { useTranslations } from 'next-intl';
+import { useAuth } from '@/hooks/useAuth';
+import { useLeaderboard, type LeaderboardPeriod } from '@/hooks/useLeaderboard';
+import { useDateFormatter, useNumberFormatter } from '@/lib/format';
+
+const PERIODS: LeaderboardPeriod[] = ['week', 'month', 'all'];
+const PAGE_SIZE = 10;
+
+export default function LeaderboardPage() {
+  const t = useTranslations('leaderboard');
+  const { user } = useAuth();
+  const dateFmt = useDateFormatter();
+  const numberFmt = useNumberFormatter();
+
+  const [period, setPeriod] = useState<LeaderboardPeriod>('week');
+  const [page, setPage] = useState(1);
+
+  const data = useLeaderboard({ period, page, pageSize: PAGE_SIZE });
+  const totalPages = Math.max(1, Math.ceil(data.total / PAGE_SIZE));
+  const startRank = (page - 1) * PAGE_SIZE;
+
+  const updated = useMemo(() => dateFmt.long(data.updatedAt), [dateFmt, data.updatedAt]);
+
+  return (
+    <main className="max-w-5xl mx-auto p-8 space-y-6">
+      <header className="space-y-1">
+        <h1 className="text-3xl font-bold text-gray-900 dark:text-white">{t('title')}</h1>
+        <p className="text-gray-600 dark:text-gray-400">{t('subtitle')}</p>
+        <p className="text-xs text-gray-500 dark:text-gray-500">
+          {t('updated', { date: updated })}
+        </p>
+      </header>
+
+      <div
+        role="tablist"
+        aria-label={t('title')}
+        className="inline-flex rounded-lg border border-gray-200 dark:border-gray-700 overflow-hidden"
+      >
+        {PERIODS.map((p) => (
+          <button
+            key={p}
+            role="tab"
+            type="button"
+            aria-selected={period === p}
+            onClick={() => {
+              setPeriod(p);
+              setPage(1);
+            }}
+            className={`px-4 py-2 text-sm transition-colors ${
+              period === p
+                ? 'bg-blue-600 text-white'
+                : 'bg-white dark:bg-gray-900 text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-800'
+            }`}
+          >
+            {t(`periods.${p}`)}
+          </button>
+        ))}
+      </div>
+
+      {data.entries.length === 0 ? (
+        <p className="text-center py-16 text-gray-500 dark:text-gray-400">{t('empty')}</p>
+      ) : (
+        <div className="overflow-x-auto rounded-lg border border-gray-200 dark:border-gray-700">
+          <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
+            <thead className="bg-gray-50 dark:bg-gray-800/50">
+              <tr>
+                <th
+                  scope="col"
+                  className="px-4 py-3 text-start text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400"
+                >
+                  {t('rank')}
+                </th>
+                <th
+                  scope="col"
+                  className="px-4 py-3 text-start text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400"
+                >
+                  {t('learner')}
+                </th>
+                <th
+                  scope="col"
+                  className="px-4 py-3 text-end text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400"
+                >
+                  {t('points')}
+                </th>
+                <th
+                  scope="col"
+                  className="px-4 py-3 text-end text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400"
+                >
+                  {t('courses')}
+                </th>
+                <th
+                  scope="col"
+                  className="px-4 py-3 text-start text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400"
+                >
+                  {t('badges')}
+                </th>
+              </tr>
+            </thead>
+            <tbody className="bg-white dark:bg-gray-900 divide-y divide-gray-200 dark:divide-gray-700">
+              {data.entries.map((e, i) => {
+                const rank = startRank + i + 1;
+                const isCurrent = !!user && user.id === e.userId;
+                return (
+                  <tr
+                    key={e.userId}
+                    className={
+                      isCurrent
+                        ? 'bg-blue-50 dark:bg-blue-950/40'
+                        : 'hover:bg-gray-50 dark:hover:bg-gray-800/50'
+                    }
+                  >
+                    <td className="px-4 py-3 text-sm font-semibold text-gray-900 dark:text-white">
+                      <RankBadge rank={rank} />
+                    </td>
+                    <td className="px-4 py-3 text-sm">
+                      <div className="flex items-center gap-3">
+                        <Avatar name={e.username} url={e.avatarUrl} />
+                        <div>
+                          <div className="font-medium text-gray-900 dark:text-white">
+                            {e.username}
+                            {isCurrent && (
+                              <span className="ms-2 inline-block rounded bg-blue-600 px-1.5 py-0.5 text-[10px] font-semibold uppercase text-white">
+                                {t('you')}
+                              </span>
+                            )}
+                          </div>
+                        </div>
+                      </div>
+                    </td>
+                    <td className="px-4 py-3 text-sm text-end tabular-nums text-gray-900 dark:text-gray-100">
+                      {t('pointsValue', { value: e.points })}
+                    </td>
+                    <td className="px-4 py-3 text-sm text-end tabular-nums text-gray-700 dark:text-gray-300">
+                      {numberFmt.decimal(e.coursesCompleted)}
+                    </td>
+                    <td className="px-4 py-3 text-sm">
+                      <div className="flex flex-wrap gap-1">
+                        {e.badges.map((b) => (
+                          <span
+                            key={b}
+                            title={b}
+                            className="inline-block rounded bg-gray-100 dark:bg-gray-800 px-2 py-0.5 text-xs text-gray-700 dark:text-gray-300"
+                          >
+                            {b}
+                          </span>
+                        ))}
+                      </div>
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      <nav
+        aria-label="Pagination"
+        className="flex items-center justify-between text-sm text-gray-700 dark:text-gray-300"
+      >
+        <button
+          type="button"
+          onClick={() => setPage((p) => Math.max(1, p - 1))}
+          disabled={page <= 1}
+          className="px-3 py-1.5 rounded border border-gray-300 dark:border-gray-600 disabled:opacity-50 disabled:cursor-not-allowed hover:bg-gray-100 dark:hover:bg-gray-800"
+        >
+          {t('previous')}
+        </button>
+        <span>{t('page', { page, total: totalPages })}</span>
+        <button
+          type="button"
+          onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
+          disabled={page >= totalPages}
+          className="px-3 py-1.5 rounded border border-gray-300 dark:border-gray-600 disabled:opacity-50 disabled:cursor-not-allowed hover:bg-gray-100 dark:hover:bg-gray-800"
+        >
+          {t('next')}
+        </button>
+      </nav>
+    </main>
+  );
+}
+
+function RankBadge({ rank }: { rank: number }) {
+  if (rank === 1)
+    return (
+      <span aria-label="Rank 1" className="text-yellow-500 text-lg">
+        🥇
+      </span>
+    );
+  if (rank === 2)
+    return (
+      <span aria-label="Rank 2" className="text-gray-400 text-lg">
+        🥈
+      </span>
+    );
+  if (rank === 3)
+    return (
+      <span aria-label="Rank 3" className="text-amber-700 text-lg">
+        🥉
+      </span>
+    );
+  return <span className="tabular-nums">{rank}</span>;
+}
+
+function Avatar({ name, url }: { name: string; url?: string }) {
+  if (url) {
+    // eslint-disable-next-line @next/next/no-img-element
+    return (
+      <img
+        src={url}
+        alt={name}
+        className="w-8 h-8 rounded-full object-cover bg-gray-200 dark:bg-gray-700"
+      />
+    );
+  }
+  const initial = name.slice(0, 1).toUpperCase();
+  return (
+    <span
+      aria-hidden="true"
+      className="w-8 h-8 rounded-full bg-blue-100 dark:bg-blue-900/50 text-blue-700 dark:text-blue-300 flex items-center justify-center text-sm font-semibold"
+    >
+      {initial}
+    </span>
+  );
+}

--- a/apps/frontend/src/components/cohorts/CohortForm.tsx
+++ b/apps/frontend/src/components/cohorts/CohortForm.tsx
@@ -1,0 +1,95 @@
+'use client';
+
+import { useTranslations } from 'next-intl';
+import { z } from 'zod';
+import { Form, TextField, TextareaField, SubmitButton, useZodForm } from '@/components/forms';
+import { Button } from '@/components/ui/Button';
+
+export interface CohortFormValues {
+  name: string;
+  description: string;
+  startDate: string;
+  endDate: string;
+  capacity: number;
+}
+
+interface CohortFormProps {
+  onSubmit: (values: CohortFormValues) => void | Promise<void>;
+  onCancel?: () => void;
+  defaultValues?: Partial<CohortFormValues>;
+}
+
+export function CohortForm({ onSubmit, onCancel, defaultValues }: CohortFormProps) {
+  const t = useTranslations('cohorts.form');
+  const tForms = useTranslations('forms');
+
+  const schema = z
+    .object({
+      name: z
+        .string()
+        .min(3, tForms('minLength', { min: 3 }))
+        .max(80, tForms('maxLength', { max: 80 })),
+      description: z
+        .string()
+        .max(500, tForms('maxLength', { max: 500 }))
+        .default(''),
+      startDate: z.string().min(1, tForms('required')),
+      endDate: z.string().min(1, tForms('required')),
+      capacity: z.coerce
+        .number()
+        .int()
+        .min(1, tForms('minValue', { min: 1 }))
+        .max(500, tForms('maxValue', { max: 500 })),
+    })
+    .refine((v) => !v.endDate || v.endDate >= v.startDate, {
+      path: ['endDate'],
+      message: tForms('minValue', { min: 'start date' }),
+    });
+
+  const form = useZodForm<CohortFormValues>({
+    schema,
+    defaultValues: {
+      name: '',
+      description: '',
+      startDate: '',
+      endDate: '',
+      capacity: 25,
+      ...defaultValues,
+    },
+  });
+
+  return (
+    <Form form={form} onSubmit={onSubmit}>
+      <TextField<CohortFormValues>
+        name="name"
+        label={t('name')}
+        placeholder={t('namePlaceholder')}
+        autoComplete="off"
+      />
+      <TextareaField<CohortFormValues>
+        name="description"
+        label={t('description')}
+        placeholder={t('descriptionPlaceholder')}
+      />
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+        <TextField<CohortFormValues> name="startDate" label={t('startDate')} type="date" />
+        <TextField<CohortFormValues> name="endDate" label={t('endDate')} type="date" />
+      </div>
+      <TextField<CohortFormValues>
+        name="capacity"
+        label={t('capacity')}
+        helperText={t('capacityHint')}
+        type="number"
+        min={1}
+      />
+      <div className="flex items-center gap-2 justify-end">
+        {onCancel && (
+          <Button type="button" variant="outline" onClick={onCancel}>
+            {t('cancel')}
+          </Button>
+        )}
+        <SubmitButton label={t('submit')} submittingLabel={t('submitting')} />
+      </div>
+    </Form>
+  );
+}

--- a/apps/frontend/src/components/forms/Form.tsx
+++ b/apps/frontend/src/components/forms/Form.tsx
@@ -1,0 +1,34 @@
+'use client';
+
+import { FormProvider, type UseFormReturn, type FieldValues } from 'react-hook-form';
+import React from 'react';
+
+export interface FormProps<T extends FieldValues> extends Omit<
+  React.FormHTMLAttributes<HTMLFormElement>,
+  'onSubmit'
+> {
+  form: UseFormReturn<T>;
+  onSubmit: (values: T) => unknown | Promise<unknown>;
+  children: React.ReactNode;
+}
+
+export function Form<T extends FieldValues>({
+  form,
+  onSubmit,
+  children,
+  className = '',
+  ...rest
+}: FormProps<T>) {
+  return (
+    <FormProvider {...form}>
+      <form
+        noValidate
+        onSubmit={form.handleSubmit(onSubmit)}
+        className={`space-y-4 ${className}`}
+        {...rest}
+      >
+        {children}
+      </form>
+    </FormProvider>
+  );
+}

--- a/apps/frontend/src/components/forms/FormField.tsx
+++ b/apps/frontend/src/components/forms/FormField.tsx
@@ -1,0 +1,199 @@
+'use client';
+
+import React from 'react';
+import {
+  useFormContext,
+  type FieldValues,
+  type FieldPath,
+  type RegisterOptions,
+} from 'react-hook-form';
+
+type BaseProps<T extends FieldValues> = {
+  name: FieldPath<T>;
+  label?: string;
+  helperText?: string;
+  rules?: RegisterOptions<T, FieldPath<T>>;
+};
+
+type TextFieldProps<T extends FieldValues> = BaseProps<T> &
+  Omit<React.InputHTMLAttributes<HTMLInputElement>, 'name' | 'defaultValue'>;
+
+export function TextField<T extends FieldValues>({
+  name,
+  label,
+  helperText,
+  rules,
+  className = '',
+  type = 'text',
+  ...rest
+}: TextFieldProps<T>) {
+  const {
+    register,
+    formState: { errors },
+  } = useFormContext<T>();
+  const error = getError(errors, name);
+  const id = `field-${String(name)}`;
+
+  return (
+    <div className="flex flex-col gap-1">
+      {label && (
+        <label htmlFor={id} className="text-sm font-medium text-gray-700 dark:text-gray-300">
+          {label}
+        </label>
+      )}
+      <input
+        id={id}
+        type={type}
+        aria-invalid={!!error}
+        aria-describedby={error ? `${id}-error` : helperText ? `${id}-helper` : undefined}
+        {...register(name, rules)}
+        className={`w-full border rounded-lg px-3 py-2 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100
+          focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500
+          disabled:opacity-50 disabled:cursor-not-allowed
+          ${error ? 'border-red-500' : 'border-gray-300 dark:border-gray-600'}
+          ${className}`}
+        {...rest}
+      />
+      <FieldFeedback id={id} error={error} helperText={helperText} />
+    </div>
+  );
+}
+
+type TextareaFieldProps<T extends FieldValues> = BaseProps<T> &
+  Omit<React.TextareaHTMLAttributes<HTMLTextAreaElement>, 'name' | 'defaultValue'>;
+
+export function TextareaField<T extends FieldValues>({
+  name,
+  label,
+  helperText,
+  rules,
+  className = '',
+  rows = 4,
+  ...rest
+}: TextareaFieldProps<T>) {
+  const {
+    register,
+    formState: { errors },
+  } = useFormContext<T>();
+  const error = getError(errors, name);
+  const id = `field-${String(name)}`;
+
+  return (
+    <div className="flex flex-col gap-1">
+      {label && (
+        <label htmlFor={id} className="text-sm font-medium text-gray-700 dark:text-gray-300">
+          {label}
+        </label>
+      )}
+      <textarea
+        id={id}
+        rows={rows}
+        aria-invalid={!!error}
+        aria-describedby={error ? `${id}-error` : helperText ? `${id}-helper` : undefined}
+        {...register(name, rules)}
+        className={`w-full border rounded-lg px-3 py-2 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100
+          focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500
+          disabled:opacity-50 disabled:cursor-not-allowed
+          ${error ? 'border-red-500' : 'border-gray-300 dark:border-gray-600'}
+          ${className}`}
+        {...rest}
+      />
+      <FieldFeedback id={id} error={error} helperText={helperText} />
+    </div>
+  );
+}
+
+type SelectFieldProps<T extends FieldValues> = BaseProps<T> &
+  Omit<React.SelectHTMLAttributes<HTMLSelectElement>, 'name' | 'defaultValue'> & {
+    options: { value: string; label: string }[];
+  };
+
+export function SelectField<T extends FieldValues>({
+  name,
+  label,
+  helperText,
+  rules,
+  options,
+  className = '',
+  ...rest
+}: SelectFieldProps<T>) {
+  const {
+    register,
+    formState: { errors },
+  } = useFormContext<T>();
+  const error = getError(errors, name);
+  const id = `field-${String(name)}`;
+
+  return (
+    <div className="flex flex-col gap-1">
+      {label && (
+        <label htmlFor={id} className="text-sm font-medium text-gray-700 dark:text-gray-300">
+          {label}
+        </label>
+      )}
+      <select
+        id={id}
+        aria-invalid={!!error}
+        aria-describedby={error ? `${id}-error` : helperText ? `${id}-helper` : undefined}
+        {...register(name, rules)}
+        className={`w-full border rounded-lg px-3 py-2 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100
+          focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500
+          disabled:opacity-50 disabled:cursor-not-allowed
+          ${error ? 'border-red-500' : 'border-gray-300 dark:border-gray-600'}
+          ${className}`}
+        {...rest}
+      >
+        {options.map((o) => (
+          <option key={o.value} value={o.value}>
+            {o.label}
+          </option>
+        ))}
+      </select>
+      <FieldFeedback id={id} error={error} helperText={helperText} />
+    </div>
+  );
+}
+
+function FieldFeedback({
+  id,
+  error,
+  helperText,
+}: {
+  id: string;
+  error?: string;
+  helperText?: string;
+}) {
+  if (error) {
+    return (
+      <p id={`${id}-error`} role="alert" className="text-xs text-red-600">
+        {error}
+      </p>
+    );
+  }
+  if (helperText) {
+    return (
+      <p id={`${id}-helper`} className="text-xs text-gray-500 dark:text-gray-400">
+        {helperText}
+      </p>
+    );
+  }
+  return null;
+}
+
+function getError(errors: Record<string, unknown>, name: string): string | undefined {
+  const parts = name.split('.');
+  let node: unknown = errors;
+  for (const part of parts) {
+    if (!node || typeof node !== 'object') return undefined;
+    node = (node as Record<string, unknown>)[part];
+  }
+  if (
+    node &&
+    typeof node === 'object' &&
+    'message' in node &&
+    typeof (node as { message: unknown }).message === 'string'
+  ) {
+    return (node as { message: string }).message;
+  }
+  return undefined;
+}

--- a/apps/frontend/src/components/forms/SubmitButton.tsx
+++ b/apps/frontend/src/components/forms/SubmitButton.tsx
@@ -1,0 +1,29 @@
+'use client';
+
+import { useFormContext } from 'react-hook-form';
+import { useTranslations } from 'next-intl';
+import { Button } from '@/components/ui/Button';
+
+interface SubmitButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: 'primary' | 'outline';
+  label?: string;
+  submittingLabel?: string;
+}
+
+export function SubmitButton({
+  label,
+  submittingLabel,
+  variant = 'primary',
+  ...rest
+}: SubmitButtonProps) {
+  const t = useTranslations('forms');
+  const {
+    formState: { isSubmitting },
+  } = useFormContext();
+
+  return (
+    <Button type="submit" variant={variant} disabled={isSubmitting} {...rest}>
+      {isSubmitting ? (submittingLabel ?? t('submitting')) : (label ?? t('submit'))}
+    </Button>
+  );
+}

--- a/apps/frontend/src/components/forms/index.ts
+++ b/apps/frontend/src/components/forms/index.ts
@@ -1,0 +1,5 @@
+export { Form } from './Form';
+export { TextField, TextareaField, SelectField } from './FormField';
+export { SubmitButton } from './SubmitButton';
+export { useZodForm } from './useZodForm';
+export { useAsyncValidator } from './validation';

--- a/apps/frontend/src/components/forms/useZodForm.ts
+++ b/apps/frontend/src/components/forms/useZodForm.ts
@@ -1,0 +1,21 @@
+'use client';
+
+import { useForm, type UseFormProps, type UseFormReturn, type FieldValues } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import type { ZodType } from 'zod';
+
+export type ZodFormOptions<T extends FieldValues> = Omit<UseFormProps<T>, 'resolver'> & {
+  schema: ZodType<T>;
+};
+
+export function useZodForm<T extends FieldValues>({
+  schema,
+  mode = 'onBlur',
+  ...rest
+}: ZodFormOptions<T>): UseFormReturn<T> {
+  return useForm<T>({
+    mode,
+    resolver: zodResolver(schema),
+    ...rest,
+  });
+}

--- a/apps/frontend/src/components/forms/validation.ts
+++ b/apps/frontend/src/components/forms/validation.ts
@@ -1,0 +1,41 @@
+'use client';
+
+import { useCallback, useRef } from 'react';
+import type { Validate } from 'react-hook-form';
+
+/**
+ * Debounced async validator factory. Use as a `validate` rule on a field:
+ *
+ *   const checkEmail = useAsyncValidator(async (email) => {
+ *     const r = await fetch(`/api/users/exists?email=${email}`);
+ *     const { exists } = await r.json();
+ *     return !exists || 'Email is already taken';
+ *   }, 400);
+ *
+ *   <TextField name="email" rules={{ validate: checkEmail }} />
+ *
+ * Returns true | string | Promise<true | string>. Returning a string marks
+ * the field invalid with that message — same contract as react-hook-form.
+ */
+export function useAsyncValidator<TValue>(
+  fn: (value: TValue) => Promise<true | string>,
+  debounceMs = 300
+): Validate<TValue, Record<string, unknown>> {
+  const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  return useCallback(
+    (value: TValue) => {
+      if (timer.current) clearTimeout(timer.current);
+      return new Promise<true | string>((resolve) => {
+        timer.current = setTimeout(async () => {
+          try {
+            resolve(await fn(value));
+          } catch {
+            resolve('Validation failed');
+          }
+        }, debounceMs);
+      });
+    },
+    [fn, debounceMs]
+  );
+}

--- a/apps/frontend/src/components/layout/Navbar.tsx
+++ b/apps/frontend/src/components/layout/Navbar.tsx
@@ -40,6 +40,24 @@ export function Navbar() {
           Dashboard
         </Link>
       )}
+      <Link
+        href="/leaderboard"
+        aria-current={pathname.endsWith('/leaderboard') ? 'page' : undefined}
+        className={`text-sm transition-colors ${isActive('/leaderboard')}`}
+        onClick={() => setMenuOpen(false)}
+      >
+        Leaderboard
+      </Link>
+      {isAuthenticated && (
+        <Link
+          href="/cohorts"
+          aria-current={pathname.endsWith('/cohorts') ? 'page' : undefined}
+          className={`text-sm transition-colors ${isActive('/cohorts')}`}
+          onClick={() => setMenuOpen(false)}
+        >
+          Cohorts
+        </Link>
+      )}
     </>
   );
 

--- a/apps/frontend/src/hooks/useCohorts.ts
+++ b/apps/frontend/src/hooks/useCohorts.ts
@@ -1,0 +1,188 @@
+'use client';
+
+import { useCallback, useSyncExternalStore } from 'react';
+
+export type CohortRole = 'student' | 'ta' | 'instructor';
+
+export interface CohortMember {
+  id: string;
+  email: string;
+  name: string;
+  role: CohortRole;
+  joinedAt: string;
+}
+
+export interface CohortMessage {
+  id: string;
+  author: string;
+  body: string;
+  postedAt: string;
+}
+
+export interface AssignedCourse {
+  id: string;
+  title: string;
+  dueAt: string;
+}
+
+export interface CohortAnalytics {
+  activeMembers: number;
+  avgProgress: number;
+  completionRate: number;
+  totalPoints: number;
+}
+
+export interface Cohort {
+  id: string;
+  name: string;
+  description: string;
+  startDate: string;
+  endDate: string;
+  capacity: number;
+  createdAt: string;
+  members: CohortMember[];
+  messages: CohortMessage[];
+  courses: AssignedCourse[];
+  analytics: CohortAnalytics;
+}
+
+let id = 0;
+const nextId = () => `c${++id}`;
+
+let cohorts: Cohort[] = [
+  {
+    id: nextId(),
+    name: 'Spring 2026 — Stellar Track',
+    description: 'Intro to Soroban and on-chain credentials.',
+    startDate: '2026-02-01',
+    endDate: '2026-05-31',
+    capacity: 30,
+    createdAt: '2026-01-15T10:00:00Z',
+    members: [
+      {
+        id: 'm1',
+        email: 'aria@example.com',
+        name: 'Aria Dev',
+        role: 'student',
+        joinedAt: '2026-02-02T10:00:00Z',
+      },
+      {
+        id: 'm2',
+        email: 'noor@example.com',
+        name: 'Noor Builds',
+        role: 'ta',
+        joinedAt: '2026-02-02T10:00:00Z',
+      },
+    ],
+    messages: [
+      {
+        id: 'msg1',
+        author: 'Noor Builds',
+        body: 'Welcome everyone! Module 1 is due Friday.',
+        postedAt: '2026-02-03T14:00:00Z',
+      },
+    ],
+    courses: [
+      { id: 'cr1', title: 'Soroban Fundamentals', dueAt: '2026-03-15' },
+      { id: 'cr2', title: 'Stellar Asset Issuance', dueAt: '2026-04-15' },
+    ],
+    analytics: {
+      activeMembers: 24,
+      avgProgress: 0.62,
+      completionRate: 0.48,
+      totalPoints: 18420,
+    },
+  },
+];
+
+const listeners = new Set<() => void>();
+const emit = () => listeners.forEach((l) => l());
+
+function subscribe(cb: () => void) {
+  listeners.add(cb);
+  return () => listeners.delete(cb);
+}
+
+export function useCohorts() {
+  const list = useSyncExternalStore(
+    subscribe,
+    () => cohorts,
+    () => cohorts
+  );
+
+  const create = useCallback(
+    (
+      input: Omit<Cohort, 'id' | 'createdAt' | 'members' | 'messages' | 'courses' | 'analytics'>
+    ) => {
+      const cohort: Cohort = {
+        ...input,
+        id: nextId(),
+        createdAt: new Date().toISOString(),
+        members: [],
+        messages: [],
+        courses: [],
+        analytics: { activeMembers: 0, avgProgress: 0, completionRate: 0, totalPoints: 0 },
+      };
+      cohorts = [cohort, ...cohorts];
+      emit();
+      return cohort;
+    },
+    []
+  );
+
+  const addMember = useCallback(
+    (cohortId: string, member: Omit<CohortMember, 'id' | 'joinedAt'>) => {
+      cohorts = cohorts.map((c) =>
+        c.id === cohortId
+          ? {
+              ...c,
+              members: [
+                ...c.members,
+                { ...member, id: `m${Date.now()}`, joinedAt: new Date().toISOString() },
+              ],
+            }
+          : c
+      );
+      emit();
+    },
+    []
+  );
+
+  const removeMember = useCallback((cohortId: string, memberId: string) => {
+    cohorts = cohorts.map((c) =>
+      c.id === cohortId ? { ...c, members: c.members.filter((m) => m.id !== memberId) } : c
+    );
+    emit();
+  }, []);
+
+  const postMessage = useCallback((cohortId: string, author: string, body: string) => {
+    cohorts = cohorts.map((c) =>
+      c.id === cohortId
+        ? {
+            ...c,
+            messages: [
+              ...c.messages,
+              { id: `msg${Date.now()}`, author, body, postedAt: new Date().toISOString() },
+            ],
+          }
+        : c
+    );
+    emit();
+  }, []);
+
+  const assignCourse = useCallback((cohortId: string, course: Omit<AssignedCourse, 'id'>) => {
+    cohorts = cohorts.map((c) =>
+      c.id === cohortId
+        ? { ...c, courses: [...c.courses, { ...course, id: `cr${Date.now()}` }] }
+        : c
+    );
+    emit();
+  }, []);
+
+  return { cohorts: list, create, addMember, removeMember, postMessage, assignCourse };
+}
+
+export function useCohort(cohortId: string): Cohort | undefined {
+  const { cohorts: list } = useCohorts();
+  return list.find((c) => c.id === cohortId);
+}

--- a/apps/frontend/src/hooks/useLeaderboard.ts
+++ b/apps/frontend/src/hooks/useLeaderboard.ts
@@ -1,0 +1,104 @@
+'use client';
+
+import { useMemo } from 'react';
+
+export type LeaderboardPeriod = 'week' | 'month' | 'all';
+
+export interface LeaderboardEntry {
+  userId: string;
+  username: string;
+  avatarUrl?: string;
+  points: number;
+  coursesCompleted: number;
+  badges: string[];
+}
+
+export interface LeaderboardPage {
+  entries: LeaderboardEntry[];
+  total: number;
+  page: number;
+  pageSize: number;
+  updatedAt: string;
+}
+
+const MOCK_USERS: Omit<LeaderboardEntry, 'points' | 'coursesCompleted' | 'badges'>[] = [
+  { userId: 'u1', username: 'aria.dev' },
+  { userId: 'u2', username: 'noor.builds' },
+  { userId: 'u3', username: 'sofia.codes' },
+  { userId: 'u4', username: 'kenji.io' },
+  { userId: 'u5', username: 'lina.web' },
+  { userId: 'u6', username: 'jamal.eth' },
+  { userId: 'u7', username: 'emma.dev' },
+  { userId: 'u8', username: 'amir.ai' },
+  { userId: 'u9', username: 'priya.k' },
+  { userId: 'u10', username: 'theo.dev' },
+  { userId: 'u11', username: 'maya.codes' },
+  { userId: 'u12', username: 'omar.dev' },
+  { userId: 'u13', username: 'sara.tech' },
+  { userId: 'u14', username: 'lucas.dev' },
+  { userId: 'u15', username: 'zoe.builds' },
+  { userId: 'u16', username: 'rafa.codes' },
+  { userId: 'u17', username: 'kara.dev' },
+  { userId: 'u18', username: 'ivan.eth' },
+  { userId: 'u19', username: 'mei.tech' },
+  { userId: 'u20', username: 'leo.dev' },
+  { userId: 'u21', username: 'eva.codes' },
+  { userId: 'u22', username: 'sam.web' },
+  { userId: 'u23', username: 'nia.dev' },
+  { userId: 'u24', username: 'kai.io' },
+  { userId: 'u25', username: 'tara.dev' },
+];
+
+const BADGES = ['first-cert', 'streak-7', 'streak-30', 'top-10', 'mentor', 'early-bird'];
+
+const PERIOD_SCALE: Record<LeaderboardPeriod, number> = {
+  week: 0.15,
+  month: 0.45,
+  all: 1,
+};
+
+function deterministicRandom(seed: number): number {
+  const x = Math.sin(seed) * 10000;
+  return x - Math.floor(x);
+}
+
+function buildEntries(period: LeaderboardPeriod): LeaderboardEntry[] {
+  const scale = PERIOD_SCALE[period];
+  return MOCK_USERS.map((u, i) => {
+    const base = 4200 - i * 110;
+    const jitter = Math.floor(deterministicRandom(i + 1) * 200);
+    const points = Math.max(0, Math.round((base + jitter) * scale));
+    const coursesCompleted = Math.max(0, Math.round((18 - i * 0.6) * scale));
+    const badgeCount = Math.max(0, Math.min(BADGES.length, Math.round(5 - i * 0.2)));
+    return {
+      ...u,
+      points,
+      coursesCompleted,
+      badges: BADGES.slice(0, badgeCount),
+    };
+  }).sort((a, b) => b.points - a.points);
+}
+
+export interface UseLeaderboardOptions {
+  period: LeaderboardPeriod;
+  page: number;
+  pageSize?: number;
+}
+
+export function useLeaderboard({
+  period,
+  page,
+  pageSize = 10,
+}: UseLeaderboardOptions): LeaderboardPage {
+  return useMemo(() => {
+    const all = buildEntries(period);
+    const start = (page - 1) * pageSize;
+    return {
+      entries: all.slice(start, start + pageSize),
+      total: all.length,
+      page,
+      pageSize,
+      updatedAt: '2026-05-26T12:00:00Z',
+    };
+  }, [period, page, pageSize]);
+}

--- a/apps/frontend/src/lib/format.ts
+++ b/apps/frontend/src/lib/format.ts
@@ -1,0 +1,34 @@
+import { useFormatter, useLocale } from 'next-intl';
+
+/**
+ * Locale-aware formatting helpers built on next-intl's `useFormatter`.
+ * All helpers are client-side hooks; they read the active locale from
+ * `NextIntlClientProvider`, so calls re-render when the user switches language.
+ */
+
+export function useDateFormatter() {
+  const format = useFormatter();
+  return {
+    short: (d: Date | number | string) => format.dateTime(toDate(d), { dateStyle: 'medium' }),
+    long: (d: Date | number | string) =>
+      format.dateTime(toDate(d), { dateStyle: 'long', timeStyle: 'short' }),
+    relative: (d: Date | number | string, now: Date = new Date()) =>
+      format.relativeTime(toDate(d), now),
+  };
+}
+
+export function useNumberFormatter() {
+  const format = useFormatter();
+  const locale = useLocale();
+  return {
+    decimal: (n: number) => format.number(n),
+    percent: (n: number) => format.number(n, { style: 'percent', maximumFractionDigits: 0 }),
+    compact: (n: number) =>
+      new Intl.NumberFormat(locale, { notation: 'compact', maximumFractionDigits: 1 }).format(n),
+    currency: (n: number, currency = 'USD') => format.number(n, { style: 'currency', currency }),
+  };
+}
+
+function toDate(d: Date | number | string): Date {
+  return d instanceof Date ? d : new Date(d);
+}


### PR DESCRIPTION
… (#437, #438, #439, #440)

- #437 i18n: add translations (en/es/fr/ar) for new pages with ICU plurals; add useDateFormatter/useNumberFormatter helpers for locale-aware formatting.
- #440 forms: Form/TextField/TextareaField/SelectField/SubmitButton built on react-hook-form + zod, plus useAsyncValidator for debounced async checks.
- #438 leaderboard: /[locale]/leaderboard with week/month/all-time tabs, pagination, current-user highlight, medal ranks, achievement badges.
- #439 cohorts: /[locale]/cohorts list + create + detail (overview/members/ discussion/courses/analytics tabs), wired through useCohorts store and the new form framework with zod validation.
- Navbar: add Leaderboard and Cohorts links.


Closes #437 
Closes #438 
Closes #439 
Closes #440 