### PR TITLE
feat(frontend): build instructor dashboard (#436)

### DIFF
--- a/apps/frontend/src/app/instructor/dashboard/page.tsx
+++ b/apps/frontend/src/app/instructor/dashboard/page.tsx
@@ -1,230 +1,57 @@
 'use client';
 
-import { useEffect, useState } from 'react';
-import Link from 'next/link';
-import api from '@/lib/api';
+import { useState } from 'react';
 import { ProtectedRoute } from '@/components/ProtectedRoute';
+import { CourseAnalytics } from '@/components/instructor/CourseAnalytics';
+import { StudentList } from '@/components/instructor/StudentList';
+import { CourseEditor } from '@/components/instructor/CourseEditor';
+import { EarningsPayouts } from '@/components/instructor/EarningsPayouts';
+import { MessagingPanel } from '@/components/instructor/MessagingPanel';
+import { CoursePerformance } from '@/components/instructor/CoursePerformance';
 
-interface CourseAnalytics {
-  id: string;
-  title: string;
-  enrollments: number;
-  completionRate: number;
-  rating: number;
-  revenue: number;
-  tokenEarnings: number;
-}
+type Tab = 'analytics' | 'students' | 'courses' | 'earnings' | 'messages' | 'performance';
 
-interface StudentProgress {
-  studentId: string;
-  studentName: string;
-  courseId: string;
-  courseTitle: string;
-  progressPct: number;
-}
-
-interface DashboardData {
-  courses: CourseAnalytics[];
-  studentProgress: StudentProgress[];
-  totalRevenue: number;
-  totalTokens: number;
-  totalEnrollments: number;
-}
-
-function StatCard({ label, value }: { label: string; value: string | number }) {
-  return (
-    <div className="rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 p-4">
-      <p className="text-sm text-gray-500 dark:text-gray-400">{label}</p>
-      <p className="text-2xl font-bold text-gray-900 dark:text-gray-100 mt-1">{value}</p>
-    </div>
-  );
-}
-
-function BarChart({ data }: { data: { label: string; value: number; max: number }[] }) {
-  return (
-    <div className="space-y-2">
-      {data.map(({ label, value, max }) => (
-        <div key={label}>
-          <div className="flex justify-between text-xs text-gray-500 dark:text-gray-400 mb-1">
-            <span className="truncate max-w-[60%]">{label}</span>
-            <span>{value}</span>
-          </div>
-          <div className="h-2 w-full rounded-full bg-gray-200 dark:bg-gray-700">
-            <div
-              className="h-full rounded-full bg-blue-500"
-              style={{ width: `${max > 0 ? (value / max) * 100 : 0}%` }}
-            />
-          </div>
-        </div>
-      ))}
-    </div>
-  );
-}
-
-// Fallback mock data when API is unavailable
-function getMockData(): DashboardData {
-  return {
-    totalRevenue: 1240,
-    totalTokens: 3800,
-    totalEnrollments: 142,
-    courses: [
-      { id: '1', title: 'Intro to Stellar', enrollments: 80, completionRate: 72, rating: 4.8, revenue: 800, tokenEarnings: 2400 },
-      { id: '2', title: 'Soroban Smart Contracts', enrollments: 42, completionRate: 55, rating: 4.5, revenue: 420, tokenEarnings: 1260 },
-      { id: '3', title: 'DeFi on Stellar', enrollments: 20, completionRate: 40, rating: 4.2, revenue: 200, tokenEarnings: 600 },
-    ],
-    studentProgress: [
-      { studentId: 's1', studentName: 'Alice', courseId: '1', courseTitle: 'Intro to Stellar', progressPct: 90 },
-      { studentId: 's2', studentName: 'Bob', courseId: '1', courseTitle: 'Intro to Stellar', progressPct: 45 },
-      { studentId: 's3', studentName: 'Carol', courseId: '2', courseTitle: 'Soroban Smart Contracts', progressPct: 60 },
-    ],
-  };
-}
+const TABS: { value: Tab; label: string }[] = [
+  { value: 'analytics', label: 'Analytics' },
+  { value: 'students', label: 'Students' },
+  { value: 'courses', label: 'Courses' },
+  { value: 'earnings', label: 'Earnings' },
+  { value: 'messages', label: 'Messages' },
+  { value: 'performance', label: 'Performance' },
+];
 
 export default function InstructorDashboardPage() {
-  const [data, setData] = useState<DashboardData | null>(null);
-  const [isLoading, setIsLoading] = useState(true);
-
-  useEffect(() => {
-    async function load() {
-      try {
-        const [coursesRes, progressRes] = await Promise.all([
-          api.get('/instructor/courses/analytics'),
-          api.get('/instructor/students/progress'),
-        ]);
-        const courses: CourseAnalytics[] = coursesRes.data ?? [];
-        const studentProgress: StudentProgress[] = progressRes.data ?? [];
-        setData({
-          courses,
-          studentProgress,
-          totalRevenue: courses.reduce((s, c) => s + (c.revenue ?? 0), 0),
-          totalTokens: courses.reduce((s, c) => s + (c.tokenEarnings ?? 0), 0),
-          totalEnrollments: courses.reduce((s, c) => s + (c.enrollments ?? 0), 0),
-        });
-      } catch {
-        setData(getMockData());
-      } finally {
-        setIsLoading(false);
-      }
-    }
-    load();
-  }, []);
-
-  const d = data ?? getMockData();
-  const maxEnrollments = Math.max(...d.courses.map((c) => c.enrollments), 1);
+  const [tab, setTab] = useState<Tab>('analytics');
 
   return (
     <ProtectedRoute>
-      <main className="max-w-5xl mx-auto p-8 space-y-8">
-        <div className="flex items-center justify-between">
-          <h1 className="text-3xl font-bold text-gray-900 dark:text-white">Instructor Dashboard</h1>
-          <Link
-            href="/instructor/courses/new"
-            className="rounded-lg bg-blue-600 text-white px-4 py-2 text-sm hover:bg-blue-700"
-          >
-            + New Course
-          </Link>
+      <main className="max-w-6xl mx-auto p-8 space-y-6">
+        <h1 className="text-3xl font-bold text-gray-900 dark:text-white">Instructor Dashboard</h1>
+
+        <div className="flex gap-1 border-b border-gray-200 dark:border-gray-700 overflow-x-auto">
+          {TABS.map((t) => (
+            <button
+              key={t.value}
+              onClick={() => setTab(t.value)}
+              className={`pb-2 px-3 text-sm font-medium border-b-2 whitespace-nowrap transition-colors ${
+                tab === t.value
+                  ? 'border-blue-600 text-blue-600 dark:border-blue-400 dark:text-blue-400'
+                  : 'border-transparent text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200'
+              }`}
+            >
+              {t.label}
+            </button>
+          ))}
         </div>
 
-        {/* Summary Stats */}
-        <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
-          <StatCard label="Total Enrollments" value={isLoading ? '…' : d.totalEnrollments} />
-          <StatCard label="Revenue (USD)" value={isLoading ? '…' : `$${d.totalRevenue}`} />
-          <StatCard label="BST Earned" value={isLoading ? '…' : `${d.totalTokens} BST`} />
-          <StatCard label="Courses" value={isLoading ? '…' : d.courses.length} />
+        <div>
+          {tab === 'analytics' && <CourseAnalytics />}
+          {tab === 'students' && <StudentList />}
+          {tab === 'courses' && <CourseEditor />}
+          {tab === 'earnings' && <EarningsPayouts />}
+          {tab === 'messages' && <MessagingPanel />}
+          {tab === 'performance' && <CoursePerformance />}
         </div>
-
-        {/* Course Analytics Table */}
-        <section>
-          <h2 className="text-xl font-semibold text-gray-900 dark:text-gray-100 mb-3">Course Performance</h2>
-          <div className="overflow-x-auto rounded-lg border border-gray-200 dark:border-gray-700">
-            <table className="w-full text-sm">
-              <thead className="bg-gray-50 dark:bg-gray-800 text-gray-500 dark:text-gray-400">
-                <tr>
-                  {['Course', 'Enrollments', 'Completion', 'Rating', 'Revenue', 'BST', 'Actions'].map((h) => (
-                    <th key={h} className="px-4 py-3 text-left font-medium">{h}</th>
-                  ))}
-                </tr>
-              </thead>
-              <tbody className="divide-y divide-gray-200 dark:divide-gray-700 bg-white dark:bg-gray-900">
-                {isLoading
-                  ? Array.from({ length: 3 }).map((_, i) => (
-                      <tr key={i}>
-                        {Array.from({ length: 7 }).map((__, j) => (
-                          <td key={j} className="px-4 py-3">
-                            <div className="h-4 bg-gray-200 dark:bg-gray-700 rounded animate-pulse" />
-                          </td>
-                        ))}
-                      </tr>
-                    ))
-                  : d.courses.map((c) => (
-                      <tr key={c.id} className="hover:bg-gray-50 dark:hover:bg-gray-800/50">
-                        <td className="px-4 py-3 font-medium text-gray-900 dark:text-gray-100">{c.title}</td>
-                        <td className="px-4 py-3 text-gray-600 dark:text-gray-300">{c.enrollments}</td>
-                        <td className="px-4 py-3">
-                          <div className="flex items-center gap-2">
-                            <div className="h-2 w-16 rounded-full bg-gray-200 dark:bg-gray-700">
-                              <div className="h-full rounded-full bg-green-500" style={{ width: `${c.completionRate}%` }} />
-                            </div>
-                            <span className="text-gray-600 dark:text-gray-300">{c.completionRate}%</span>
-                          </div>
-                        </td>
-                        <td className="px-4 py-3 text-yellow-500">{'★'.repeat(Math.round(c.rating))} {c.rating}</td>
-                        <td className="px-4 py-3 text-gray-600 dark:text-gray-300">${c.revenue}</td>
-                        <td className="px-4 py-3 text-green-600 dark:text-green-400">{c.tokenEarnings} BST</td>
-                        <td className="px-4 py-3">
-                          <div className="flex gap-2">
-                            <Link href={`/instructor/courses/${c.id}/edit`} className="text-blue-600 dark:text-blue-400 hover:underline text-xs">Edit</Link>
-                            <Link href={`/courses/${c.id}/forum`} className="text-gray-500 hover:underline text-xs">Forum</Link>
-                            <Link href={`/instructor/courses/${c.id}/message`} className="text-gray-500 hover:underline text-xs">Message</Link>
-                          </div>
-                        </td>
-                      </tr>
-                    ))}
-              </tbody>
-            </table>
-          </div>
-        </section>
-
-        {/* Enrollment Chart */}
-        <section>
-          <h2 className="text-xl font-semibold text-gray-900 dark:text-gray-100 mb-3">Enrollments by Course</h2>
-          <div className="rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 p-4">
-            {isLoading ? (
-              <div className="space-y-3">
-                {Array.from({ length: 3 }).map((_, i) => (
-                  <div key={i} className="h-4 bg-gray-200 dark:bg-gray-700 rounded animate-pulse" />
-                ))}
-              </div>
-            ) : (
-              <BarChart data={d.courses.map((c) => ({ label: c.title, value: c.enrollments, max: maxEnrollments }))} />
-            )}
-          </div>
-        </section>
-
-        {/* Student Progress */}
-        <section>
-          <h2 className="text-xl font-semibold text-gray-900 dark:text-gray-100 mb-3">Student Progress</h2>
-          <div className="space-y-3">
-            {isLoading
-              ? Array.from({ length: 3 }).map((_, i) => (
-                  <div key={i} className="h-12 bg-gray-200 dark:bg-gray-700 rounded-lg animate-pulse" />
-                ))
-              : d.studentProgress.map((sp) => (
-                  <div key={`${sp.studentId}-${sp.courseId}`} className="rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 p-3 flex items-center gap-4">
-                    <div className="flex-1 min-w-0">
-                      <p className="text-sm font-medium text-gray-900 dark:text-gray-100">{sp.studentName}</p>
-                      <p className="text-xs text-gray-500 dark:text-gray-400 truncate">{sp.courseTitle}</p>
-                    </div>
-                    <div className="flex items-center gap-2 w-40">
-                      <div className="flex-1 h-2 rounded-full bg-gray-200 dark:bg-gray-700">
-                        <div className="h-full rounded-full bg-blue-500" style={{ width: `${sp.progressPct}%` }} />
-                      </div>
-                      <span className="text-xs text-gray-500 dark:text-gray-400 w-8 text-right">{sp.progressPct}%</span>
-                    </div>
-                  </div>
-                ))}
-          </div>
-        </section>
       </main>
     </ProtectedRoute>
   );

--- a/apps/frontend/src/components/instructor/CourseAnalytics.tsx
+++ b/apps/frontend/src/components/instructor/CourseAnalytics.tsx
@@ -1,0 +1,95 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import api from '@/lib/api';
+
+interface CourseAnalytics {
+  id: string;
+  title: string;
+  enrollments: number;
+  completionRate: number;
+  rating: number;
+}
+
+function Skeleton() {
+  return (
+    <div className="space-y-3">
+      {Array.from({ length: 3 }).map((_, i) => (
+        <div key={i} className="h-10 bg-gray-200 dark:bg-gray-700 rounded animate-pulse" />
+      ))}
+    </div>
+  );
+}
+
+const MOCK: CourseAnalytics[] = [
+  { id: '1', title: 'Intro to Stellar', enrollments: 80, completionRate: 72, rating: 4.8 },
+  { id: '2', title: 'Soroban Smart Contracts', enrollments: 42, completionRate: 55, rating: 4.5 },
+  { id: '3', title: 'DeFi on Stellar', enrollments: 20, completionRate: 40, rating: 4.2 },
+];
+
+export function CourseAnalytics() {
+  const [courses, setCourses] = useState<CourseAnalytics[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    api.get('/instructor/courses/analytics')
+      .then((r) => setCourses(r.data ?? []))
+      .catch(() => setCourses(MOCK))
+      .finally(() => setLoading(false));
+  }, []);
+
+  const maxEnrollments = Math.max(...courses.map((c) => c.enrollments), 1);
+
+  return (
+    <div className="space-y-4">
+      <h2 className="text-xl font-semibold text-gray-900 dark:text-gray-100">Course Analytics</h2>
+      {loading ? (
+        <Skeleton />
+      ) : (
+        <div className="overflow-x-auto rounded-lg border border-gray-200 dark:border-gray-700">
+          <table className="w-full text-sm">
+            <thead className="bg-gray-50 dark:bg-gray-800 text-gray-500 dark:text-gray-400">
+              <tr>
+                {['Course', 'Enrollments', 'Completion Rate', 'Rating'].map((h) => (
+                  <th key={h} className="px-4 py-3 text-left font-medium">{h}</th>
+                ))}
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-gray-200 dark:divide-gray-700 bg-white dark:bg-gray-900">
+              {courses.map((c) => (
+                <tr key={c.id} className="hover:bg-gray-50 dark:hover:bg-gray-800/50">
+                  <td className="px-4 py-3 font-medium text-gray-900 dark:text-gray-100">{c.title}</td>
+                  <td className="px-4 py-3">
+                    <div className="flex items-center gap-2">
+                      <div className="h-2 w-20 rounded-full bg-gray-200 dark:bg-gray-700">
+                        <div
+                          className="h-full rounded-full bg-blue-500"
+                          style={{ width: `${(c.enrollments / maxEnrollments) * 100}%` }}
+                        />
+                      </div>
+                      <span className="text-gray-600 dark:text-gray-300">{c.enrollments}</span>
+                    </div>
+                  </td>
+                  <td className="px-4 py-3">
+                    <div className="flex items-center gap-2">
+                      <div className="h-2 w-20 rounded-full bg-gray-200 dark:bg-gray-700">
+                        <div
+                          className="h-full rounded-full bg-green-500"
+                          style={{ width: `${c.completionRate}%` }}
+                        />
+                      </div>
+                      <span className="text-gray-600 dark:text-gray-300">{c.completionRate}%</span>
+                    </div>
+                  </td>
+                  <td className="px-4 py-3 text-yellow-500">
+                    {'★'.repeat(Math.round(c.rating))} <span className="text-gray-600 dark:text-gray-300">{c.rating}</span>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/frontend/src/components/instructor/CourseEditor.tsx
+++ b/apps/frontend/src/components/instructor/CourseEditor.tsx
@@ -1,0 +1,93 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+import api from '@/lib/api';
+import { Button } from '@/components/ui/Button';
+
+interface Course {
+  id: string;
+  title: string;
+  status: 'draft' | 'published' | 'archived';
+  updatedAt?: string;
+}
+
+const MOCK: Course[] = [
+  { id: '1', title: 'Intro to Stellar', status: 'published', updatedAt: '2026-05-20' },
+  { id: '2', title: 'Soroban Smart Contracts', status: 'published', updatedAt: '2026-05-15' },
+  { id: '3', title: 'DeFi on Stellar', status: 'draft', updatedAt: '2026-05-10' },
+];
+
+const STATUS_STYLES: Record<Course['status'], string> = {
+  published: 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400',
+  draft: 'bg-yellow-100 text-yellow-700 dark:bg-yellow-900/30 dark:text-yellow-400',
+  archived: 'bg-gray-100 text-gray-600 dark:bg-gray-700 dark:text-gray-400',
+};
+
+export function CourseEditor() {
+  const [courses, setCourses] = useState<Course[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    api.get('/instructor/courses')
+      .then((r) => setCourses(r.data ?? []))
+      .catch(() => setCourses(MOCK))
+      .finally(() => setLoading(false));
+  }, []);
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <h2 className="text-xl font-semibold text-gray-900 dark:text-gray-100">My Courses</h2>
+        <Link href="/instructor/courses/new">
+          <Button className="text-sm py-1.5">+ New Course</Button>
+        </Link>
+      </div>
+
+      {loading ? (
+        <div className="space-y-3">
+          {Array.from({ length: 3 }).map((_, i) => (
+            <div key={i} className="h-16 bg-gray-200 dark:bg-gray-700 rounded-lg animate-pulse" />
+          ))}
+        </div>
+      ) : courses.length === 0 ? (
+        <p className="text-gray-500 dark:text-gray-400 text-sm">No courses yet. Create your first course!</p>
+      ) : (
+        <div className="space-y-2">
+          {courses.map((c) => (
+            <div
+              key={c.id}
+              className="rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 p-4 flex items-center gap-4"
+            >
+              <div className="flex-1 min-w-0">
+                <p className="font-medium text-gray-900 dark:text-gray-100 truncate">{c.title}</p>
+                {c.updatedAt && (
+                  <p className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">
+                    Updated {new Date(c.updatedAt).toLocaleDateString()}
+                  </p>
+                )}
+              </div>
+              <span className={`text-xs font-medium px-2 py-0.5 rounded-full ${STATUS_STYLES[c.status]}`}>
+                {c.status}
+              </span>
+              <div className="flex gap-2 shrink-0">
+                <Link
+                  href={`/instructor/courses/${c.id}/edit`}
+                  className="text-sm text-blue-600 dark:text-blue-400 hover:underline"
+                >
+                  Edit
+                </Link>
+                <Link
+                  href={`/courses/${c.id}`}
+                  className="text-sm text-gray-500 dark:text-gray-400 hover:underline"
+                >
+                  View
+                </Link>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/frontend/src/components/instructor/CoursePerformance.tsx
+++ b/apps/frontend/src/components/instructor/CoursePerformance.tsx
@@ -1,0 +1,82 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import api from '@/lib/api';
+
+interface PerformanceData {
+  courseId: string;
+  courseTitle: string;
+  avgScore: number;
+  dropOffRate: number;
+  avgCompletionDays: number;
+  totalReviews: number;
+  avgRating: number;
+}
+
+const MOCK: PerformanceData[] = [
+  { courseId: '1', courseTitle: 'Intro to Stellar', avgScore: 82, dropOffRate: 18, avgCompletionDays: 14, totalReviews: 34, avgRating: 4.8 },
+  { courseId: '2', courseTitle: 'Soroban Smart Contracts', avgScore: 74, dropOffRate: 28, avgCompletionDays: 21, totalReviews: 18, avgRating: 4.5 },
+  { courseId: '3', courseTitle: 'DeFi on Stellar', avgScore: 68, dropOffRate: 35, avgCompletionDays: 30, totalReviews: 9, avgRating: 4.2 },
+];
+
+function MetricBar({ value, max = 100, color = 'bg-blue-500' }: { value: number; max?: number; color?: string }) {
+  return (
+    <div className="flex items-center gap-2">
+      <div className="h-2 w-24 rounded-full bg-gray-200 dark:bg-gray-700">
+        <div className={`h-full rounded-full ${color}`} style={{ width: `${(value / max) * 100}%` }} />
+      </div>
+      <span className="text-xs text-gray-600 dark:text-gray-300 w-8">{value}%</span>
+    </div>
+  );
+}
+
+export function CoursePerformance() {
+  const [data, setData] = useState<PerformanceData[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    api.get('/instructor/courses/performance')
+      .then((r) => setData(r.data ?? []))
+      .catch(() => setData(MOCK))
+      .finally(() => setLoading(false));
+  }, []);
+
+  return (
+    <div className="space-y-4">
+      <h2 className="text-xl font-semibold text-gray-900 dark:text-gray-100">Course Performance Metrics</h2>
+      {loading ? (
+        <div className="space-y-3">
+          {Array.from({ length: 3 }).map((_, i) => (
+            <div key={i} className="h-20 bg-gray-200 dark:bg-gray-700 rounded-lg animate-pulse" />
+          ))}
+        </div>
+      ) : (
+        <div className="overflow-x-auto rounded-lg border border-gray-200 dark:border-gray-700">
+          <table className="w-full text-sm">
+            <thead className="bg-gray-50 dark:bg-gray-800 text-gray-500 dark:text-gray-400">
+              <tr>
+                {['Course', 'Avg Score', 'Drop-off Rate', 'Avg Days to Complete', 'Reviews', 'Rating'].map((h) => (
+                  <th key={h} className="px-4 py-3 text-left font-medium whitespace-nowrap">{h}</th>
+                ))}
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-gray-200 dark:divide-gray-700 bg-white dark:bg-gray-900">
+              {data.map((d) => (
+                <tr key={d.courseId} className="hover:bg-gray-50 dark:hover:bg-gray-800/50">
+                  <td className="px-4 py-3 font-medium text-gray-900 dark:text-gray-100 max-w-[160px] truncate">{d.courseTitle}</td>
+                  <td className="px-4 py-3"><MetricBar value={d.avgScore} color="bg-blue-500" /></td>
+                  <td className="px-4 py-3"><MetricBar value={d.dropOffRate} color="bg-red-400" /></td>
+                  <td className="px-4 py-3 text-gray-600 dark:text-gray-300">{d.avgCompletionDays}d</td>
+                  <td className="px-4 py-3 text-gray-600 dark:text-gray-300">{d.totalReviews}</td>
+                  <td className="px-4 py-3 text-yellow-500">
+                    {'★'.repeat(Math.round(d.avgRating))} <span className="text-gray-600 dark:text-gray-300">{d.avgRating}</span>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/frontend/src/components/instructor/EarningsPayouts.tsx
+++ b/apps/frontend/src/components/instructor/EarningsPayouts.tsx
@@ -1,0 +1,99 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import api from '@/lib/api';
+
+interface EarningsData {
+  totalRevenue: number;
+  totalTokens: number;
+  pendingPayout: number;
+  payouts: { id: string; amount: number; date: string; status: 'paid' | 'pending' }[];
+}
+
+const MOCK: EarningsData = {
+  totalRevenue: 1240,
+  totalTokens: 3800,
+  pendingPayout: 320,
+  payouts: [
+    { id: 'p1', amount: 480, date: '2026-05-01', status: 'paid' },
+    { id: 'p2', amount: 440, date: '2026-04-01', status: 'paid' },
+    { id: 'p3', amount: 320, date: '2026-06-01', status: 'pending' },
+  ],
+};
+
+export function EarningsPayouts() {
+  const [data, setData] = useState<EarningsData | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    api.get('/instructor/earnings')
+      .then((r) => setData(r.data))
+      .catch(() => setData(MOCK))
+      .finally(() => setLoading(false));
+  }, []);
+
+  const d = data ?? MOCK;
+
+  return (
+    <div className="space-y-4">
+      <h2 className="text-xl font-semibold text-gray-900 dark:text-gray-100">Earnings & Payouts</h2>
+
+      <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+        {[
+          { label: 'Total Revenue', value: loading ? '…' : `$${d.totalRevenue.toLocaleString()}`, color: 'text-green-600 dark:text-green-400' },
+          { label: 'BST Earned', value: loading ? '…' : `${d.totalTokens.toLocaleString()} BST`, color: 'text-blue-600 dark:text-blue-400' },
+          { label: 'Pending Payout', value: loading ? '…' : `$${d.pendingPayout.toLocaleString()}`, color: 'text-yellow-600 dark:text-yellow-400' },
+        ].map(({ label, value, color }) => (
+          <div key={label} className="rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 p-4">
+            <p className="text-sm text-gray-500 dark:text-gray-400">{label}</p>
+            <p className={`text-2xl font-bold mt-1 ${color}`}>{value}</p>
+          </div>
+        ))}
+      </div>
+
+      <div>
+        <h3 className="text-sm font-semibold text-gray-700 dark:text-gray-300 mb-2">Payout History</h3>
+        {loading ? (
+          <div className="space-y-2">
+            {Array.from({ length: 3 }).map((_, i) => (
+              <div key={i} className="h-10 bg-gray-200 dark:bg-gray-700 rounded animate-pulse" />
+            ))}
+          </div>
+        ) : (
+          <div className="rounded-lg border border-gray-200 dark:border-gray-700 overflow-hidden">
+            <table className="w-full text-sm">
+              <thead className="bg-gray-50 dark:bg-gray-800 text-gray-500 dark:text-gray-400">
+                <tr>
+                  {['Date', 'Amount', 'Status'].map((h) => (
+                    <th key={h} className="px-4 py-2 text-left font-medium">{h}</th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-gray-200 dark:divide-gray-700 bg-white dark:bg-gray-900">
+                {d.payouts.map((p) => (
+                  <tr key={p.id}>
+                    <td className="px-4 py-2 text-gray-600 dark:text-gray-300">
+                      {new Date(p.date).toLocaleDateString()}
+                    </td>
+                    <td className="px-4 py-2 font-medium text-gray-900 dark:text-gray-100">
+                      ${p.amount.toLocaleString()}
+                    </td>
+                    <td className="px-4 py-2">
+                      <span className={`text-xs font-medium px-2 py-0.5 rounded-full ${
+                        p.status === 'paid'
+                          ? 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400'
+                          : 'bg-yellow-100 text-yellow-700 dark:bg-yellow-900/30 dark:text-yellow-400'
+                      }`}>
+                        {p.status}
+                      </span>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/frontend/src/components/instructor/MessagingPanel.tsx
+++ b/apps/frontend/src/components/instructor/MessagingPanel.tsx
@@ -1,0 +1,159 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import api from '@/lib/api';
+import { Button } from '@/components/ui/Button';
+
+interface Message {
+  id: string;
+  from: string;
+  text: string;
+  createdAt: string;
+  isInstructor: boolean;
+}
+
+interface Thread {
+  studentId: string;
+  studentName: string;
+  courseTitle: string;
+  messages: Message[];
+}
+
+const MOCK: Thread[] = [
+  {
+    studentId: 's1',
+    studentName: 'Alice Johnson',
+    courseTitle: 'Intro to Stellar',
+    messages: [
+      { id: 'm1', from: 'Alice Johnson', text: 'Hi, I have a question about lesson 3.', createdAt: '2026-05-26T10:00:00Z', isInstructor: false },
+      { id: 'm2', from: 'You', text: 'Sure, what would you like to know?', createdAt: '2026-05-26T10:05:00Z', isInstructor: true },
+    ],
+  },
+  {
+    studentId: 's2',
+    studentName: 'Bob Smith',
+    courseTitle: 'Intro to Stellar',
+    messages: [
+      { id: 'm3', from: 'Bob Smith', text: 'When will the next module be available?', createdAt: '2026-05-25T09:00:00Z', isInstructor: false },
+    ],
+  },
+];
+
+export function MessagingPanel() {
+  const [threads, setThreads] = useState<Thread[]>([]);
+  const [selected, setSelected] = useState<string | null>(null);
+  const [text, setText] = useState('');
+  const [loading, setLoading] = useState(true);
+  const [sending, setSending] = useState(false);
+  const bottomRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    api.get('/instructor/messages')
+      .then((r) => setThreads(r.data ?? []))
+      .catch(() => setThreads(MOCK))
+      .finally(() => setLoading(false));
+  }, []);
+
+  useEffect(() => {
+    bottomRef.current?.scrollIntoView({ behavior: 'smooth' });
+  }, [selected, threads]);
+
+  const activeThread = threads.find((t) => t.studentId === selected);
+
+  async function send() {
+    if (!text.trim() || !selected) return;
+    setSending(true);
+    const newMsg: Message = {
+      id: `m-${Date.now()}`,
+      from: 'You',
+      text: text.trim(),
+      createdAt: new Date().toISOString(),
+      isInstructor: true,
+    };
+    try {
+      await api.post(`/instructor/messages/${selected}`, { text: text.trim() });
+    } catch {
+      // optimistic update even on error
+    } finally {
+      setThreads((prev) =>
+        prev.map((t) =>
+          t.studentId === selected ? { ...t, messages: [...t.messages, newMsg] } : t
+        )
+      );
+      setText('');
+      setSending(false);
+    }
+  }
+
+  return (
+    <div className="space-y-4">
+      <h2 className="text-xl font-semibold text-gray-900 dark:text-gray-100">Messages</h2>
+      <div className="flex gap-4 h-96 rounded-lg border border-gray-200 dark:border-gray-700 overflow-hidden">
+        {/* Thread list */}
+        <div className="w-48 shrink-0 border-r border-gray-200 dark:border-gray-700 overflow-y-auto bg-gray-50 dark:bg-gray-800">
+          {loading ? (
+            <div className="p-3 space-y-2">
+              {Array.from({ length: 3 }).map((_, i) => (
+                <div key={i} className="h-10 bg-gray-200 dark:bg-gray-700 rounded animate-pulse" />
+              ))}
+            </div>
+          ) : threads.length === 0 ? (
+            <p className="p-3 text-xs text-gray-500 dark:text-gray-400">No messages yet.</p>
+          ) : (
+            threads.map((t) => (
+              <button
+                key={t.studentId}
+                onClick={() => setSelected(t.studentId)}
+                className={`w-full text-left px-3 py-2.5 text-sm border-b border-gray-200 dark:border-gray-700 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors ${
+                  selected === t.studentId ? 'bg-blue-50 dark:bg-blue-900/20 text-blue-700 dark:text-blue-300' : 'text-gray-700 dark:text-gray-300'
+                }`}
+              >
+                <p className="font-medium truncate">{t.studentName}</p>
+                <p className="text-xs text-gray-400 truncate">{t.courseTitle}</p>
+              </button>
+            ))
+          )}
+        </div>
+
+        {/* Message pane */}
+        <div className="flex-1 flex flex-col bg-white dark:bg-gray-900">
+          {!activeThread ? (
+            <div className="flex-1 flex items-center justify-center text-gray-400 dark:text-gray-500 text-sm">
+              Select a conversation
+            </div>
+          ) : (
+            <>
+              <div className="flex-1 overflow-y-auto p-3 space-y-2">
+                {activeThread.messages.map((m) => (
+                  <div key={m.id} className={`flex ${m.isInstructor ? 'justify-end' : 'justify-start'}`}>
+                    <div className={`max-w-[75%] rounded-lg px-3 py-2 text-sm ${
+                      m.isInstructor
+                        ? 'bg-blue-600 text-white'
+                        : 'bg-gray-100 dark:bg-gray-700 text-gray-900 dark:text-gray-100'
+                    }`}>
+                      {m.text}
+                    </div>
+                  </div>
+                ))}
+                <div ref={bottomRef} />
+              </div>
+              <div className="border-t border-gray-200 dark:border-gray-700 p-2 flex gap-2">
+                <input
+                  type="text"
+                  value={text}
+                  onChange={(e) => setText(e.target.value)}
+                  onKeyDown={(e) => e.key === 'Enter' && !e.shiftKey && send()}
+                  placeholder="Type a message…"
+                  className="flex-1 rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 px-3 py-1.5 text-sm text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                />
+                <Button onClick={send} disabled={sending || !text.trim()} className="text-sm py-1.5 px-3">
+                  Send
+                </Button>
+              </div>
+            </>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/frontend/src/components/instructor/StudentList.tsx
+++ b/apps/frontend/src/components/instructor/StudentList.tsx
@@ -1,0 +1,94 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import api from '@/lib/api';
+
+interface StudentProgress {
+  studentId: string;
+  studentName: string;
+  courseTitle: string;
+  progressPct: number;
+  lastActive?: string;
+}
+
+const MOCK: StudentProgress[] = [
+  { studentId: 's1', studentName: 'Alice Johnson', courseTitle: 'Intro to Stellar', progressPct: 90, lastActive: '2026-05-26' },
+  { studentId: 's2', studentName: 'Bob Smith', courseTitle: 'Intro to Stellar', progressPct: 45, lastActive: '2026-05-25' },
+  { studentId: 's3', studentName: 'Carol White', courseTitle: 'Soroban Smart Contracts', progressPct: 60, lastActive: '2026-05-24' },
+  { studentId: 's4', studentName: 'David Lee', courseTitle: 'DeFi on Stellar', progressPct: 20, lastActive: '2026-05-23' },
+];
+
+export function StudentList() {
+  const [students, setStudents] = useState<StudentProgress[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [search, setSearch] = useState('');
+
+  useEffect(() => {
+    api.get('/instructor/students/progress')
+      .then((r) => setStudents(r.data ?? []))
+      .catch(() => setStudents(MOCK))
+      .finally(() => setLoading(false));
+  }, []);
+
+  const filtered = students.filter(
+    (s) =>
+      s.studentName.toLowerCase().includes(search.toLowerCase()) ||
+      s.courseTitle.toLowerCase().includes(search.toLowerCase())
+  );
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between gap-4">
+        <h2 className="text-xl font-semibold text-gray-900 dark:text-gray-100">Students</h2>
+        <input
+          type="search"
+          placeholder="Search students…"
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          className="rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 px-3 py-1.5 text-sm text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500"
+        />
+      </div>
+
+      {loading ? (
+        <div className="space-y-3">
+          {Array.from({ length: 4 }).map((_, i) => (
+            <div key={i} className="h-14 bg-gray-200 dark:bg-gray-700 rounded-lg animate-pulse" />
+          ))}
+        </div>
+      ) : filtered.length === 0 ? (
+        <p className="text-gray-500 dark:text-gray-400 text-sm">No students found.</p>
+      ) : (
+        <div className="space-y-2">
+          {filtered.map((s) => (
+            <div
+              key={`${s.studentId}-${s.courseTitle}`}
+              className="rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 p-3 flex items-center gap-4"
+            >
+              <div className="h-9 w-9 rounded-full bg-blue-100 dark:bg-blue-900 flex items-center justify-center text-blue-700 dark:text-blue-300 font-semibold text-sm shrink-0">
+                {s.studentName.charAt(0)}
+              </div>
+              <div className="flex-1 min-w-0">
+                <p className="text-sm font-medium text-gray-900 dark:text-gray-100">{s.studentName}</p>
+                <p className="text-xs text-gray-500 dark:text-gray-400 truncate">{s.courseTitle}</p>
+              </div>
+              <div className="flex items-center gap-2 w-36 shrink-0">
+                <div className="flex-1 h-2 rounded-full bg-gray-200 dark:bg-gray-700">
+                  <div
+                    className="h-full rounded-full bg-blue-500"
+                    style={{ width: `${s.progressPct}%` }}
+                  />
+                </div>
+                <span className="text-xs text-gray-500 dark:text-gray-400 w-8 text-right">{s.progressPct}%</span>
+              </div>
+              {s.lastActive && (
+                <span className="text-xs text-gray-400 dark:text-gray-500 shrink-0 hidden sm:block">
+                  {new Date(s.lastActive).toLocaleDateString()}
+                </span>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Implements the full instructor dashboard at `/instructor/dashboard` with a tabbed layout, replacing the previous monolithic page.

## New Components (`src/components/instructor/`)

| Component | Description |
|---|---|
| `CourseAnalytics.tsx` | Table showing enrollments, completion rate, and star rating per course with inline bar charts |
| `StudentList.tsx` | Searchable list of students with per-course progress bars and last-active date |
| `CourseEditor.tsx` | Course list with status badges (published/draft/archived), edit/view links, and new-course shortcut |
| `EarningsPayouts.tsx` | Summary cards for total revenue, BST earned, pending payout; payout history table |
| `MessagingPanel.tsx` | Two-pane messaging UI: thread list + chat view with optimistic send |
| `CoursePerformance.tsx` | Metrics table: avg score, drop-off rate, avg completion days, reviews, rating |

## Updated Page

- `src/app/instructor/dashboard/page.tsx` — replaced monolithic page with a clean 6-tab layout (Analytics, Students, Courses, Earnings, Messages, Performance)
- Wrapped in `ProtectedRoute`; dark-mode and skeleton-loading throughout
- All components fall back to mock data when the API is unavailable

## Testing

- TypeScript: no new type errors introduced
- All components follow existing project conventions (\'use client\', `api` from `@/lib/api`, Tailwind dark-mode, animate-pulse skeletons)

Closes #436