### PR TITLE
feat(contracts): complete token restrictions, royalty, credential metadata & shared utilities

### DIFF
--- a/contracts/credential_metadata/src/lib.rs
+++ b/contracts/credential_metadata/src/lib.rs
@@ -8,6 +8,8 @@ pub enum DataKey {
     Admin,
     Metadata(u64),
     MetadataHash(u64),
+    MetadataHistory(u64, u32),
+    HistoryCount(u64),
 }
 
 #[contracttype]
@@ -21,11 +23,20 @@ pub struct MetadataRecord {
     pub ipfs_hash: String,
 }
 
+#[contracttype]
+#[derive(Clone)]
+pub struct MetadataHistoryEntry {
+    pub credential_id: u64,
+    pub course_name: String,
+    pub grade: String,
+    pub recorded_at: u64,
+}
+
 const STORE: Symbol = symbol_short!("store");
 const UPDATE: Symbol = symbol_short!("update");
 const EXPIRE: Symbol = symbol_short!("expire");
 const RENEW: Symbol = symbol_short!("renew");
-const GRACE_PERIOD_SECONDS: u64 = 30 * 24 * 60 * 60; // 30 days grace period
+const GRACE_PERIOD_SECONDS: u64 = 30 * 24 * 60 * 60;
 
 #[contract]
 pub struct CredentialMetadataContract;
@@ -88,6 +99,27 @@ impl CredentialMetadataContract {
             .persistent()
             .get(&DataKey::Metadata(credential_id))
             .expect("Metadata not found");
+
+        let history_count: u32 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::HistoryCount(credential_id))
+            .unwrap_or(0);
+
+        let history_entry = MetadataHistoryEntry {
+            credential_id,
+            course_name: metadata.course_name.clone(),
+            grade: metadata.grade.clone(),
+            recorded_at: env.ledger().timestamp(),
+        };
+
+        env.storage().persistent().set(
+            &DataKey::MetadataHistory(credential_id, history_count),
+            &history_entry,
+        );
+        env.storage()
+            .persistent()
+            .set(&DataKey::HistoryCount(credential_id), &(history_count + 1));
 
         metadata.course_name = course_name;
         metadata.grade = grade;
@@ -193,5 +225,22 @@ impl CredentialMetadataContract {
             Some(h) => h == hash,
             None => false,
         }
+    }
+
+    pub fn get_metadata_history(
+        env: Env,
+        credential_id: u64,
+        index: u32,
+    ) -> Option<MetadataHistoryEntry> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::MetadataHistory(credential_id, index))
+    }
+
+    pub fn get_history_count(env: Env, credential_id: u64) -> u32 {
+        env.storage()
+            .persistent()
+            .get(&DataKey::HistoryCount(credential_id))
+            .unwrap_or(0)
     }
 }

--- a/contracts/royalty_distribution/src/lib.rs
+++ b/contracts/royalty_distribution/src/lib.rs
@@ -11,6 +11,7 @@ pub enum DataKey {
     RecipientCount(u64),
     RoyaltyBalance(Address),
     PaymentRecord(u64),
+    PaymentCount,
 }
 
 #[contracttype]
@@ -181,6 +182,25 @@ impl RoyaltyDistributionContract {
             .persistent()
             .set(&DataKey::RoyaltyBalance(platform), &platform_balance);
 
+        let payment_id: u64 = env
+            .storage()
+            .instance()
+            .get(&DataKey::PaymentCount)
+            .unwrap_or(0);
+
+        let record = RoyaltyPayment {
+            course_id,
+            amount: total_amount,
+            timestamp: env.ledger().timestamp(),
+        };
+
+        env.storage()
+            .persistent()
+            .set(&DataKey::PaymentRecord(payment_id), &record);
+        env.storage()
+            .instance()
+            .set(&DataKey::PaymentCount, &(payment_id + 1));
+
         env.events()
             .publish((DISTRIBUTE, symbol_short!("crs")), (course_id, total_amount));
     }
@@ -217,5 +237,42 @@ impl RoyaltyDistributionContract {
         env.storage()
             .persistent()
             .get(&DataKey::RoyaltySplit(course_id))
+    }
+
+    pub fn get_payment_record(env: Env, payment_id: u64) -> Option<RoyaltyPayment> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::PaymentRecord(payment_id))
+    }
+
+    pub fn get_payment_count(env: Env) -> u64 {
+        env.storage()
+            .instance()
+            .get(&DataKey::PaymentCount)
+            .unwrap_or(0)
+    }
+
+    pub fn get_total_distributed(env: Env, course_id: u64) -> i128 {
+        let count: u64 = env
+            .storage()
+            .instance()
+            .get(&DataKey::PaymentCount)
+            .unwrap_or(0);
+
+        let mut total: i128 = 0;
+        let mut i: u64 = 0;
+        while i < count {
+            let record: Option<RoyaltyPayment> = env
+                .storage()
+                .persistent()
+                .get(&DataKey::PaymentRecord(i));
+            if let Some(r) = record {
+                if r.course_id == course_id {
+                    total += r.amount;
+                }
+            }
+            i += 1;
+        }
+        total
     }
 }

--- a/contracts/shared/src/errors.rs
+++ b/contracts/shared/src/errors.rs
@@ -1,0 +1,21 @@
+use soroban_sdk::contracterror;
+
+#[contracterror]
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[repr(u32)]
+pub enum SharedError {
+    NotInitialized = 1,
+    AlreadyInitialized = 2,
+    Unauthorized = 3,
+    InvalidAmount = 4,
+    InvalidPercentage = 5,
+    NotFound = 6,
+    AlreadyExists = 7,
+    ContractPaused = 8,
+    ReentrantCall = 9,
+    ProposalExpired = 10,
+    ProposalAlreadyExecuted = 11,
+    InsufficientApprovals = 12,
+    InvalidTimestamp = 13,
+    EmptyString = 14,
+}

--- a/contracts/shared/src/lib.rs
+++ b/contracts/shared/src/lib.rs
@@ -235,6 +235,45 @@ impl SharedContract {
     }
 
     // -------------------------------------------------------------------------
+    // Reentrancy Guard
+    // -------------------------------------------------------------------------
+
+    pub fn acquire_reentrancy_lock(env: Env) {
+        reentrancy::acquire_lock(&env);
+    }
+
+    pub fn release_reentrancy_lock(env: Env) {
+        reentrancy::release_lock(&env);
+    }
+
+    pub fn is_reentrancy_locked(env: Env) -> bool {
+        reentrancy::is_locked(&env)
+    }
+
+    // -------------------------------------------------------------------------
+    // Common Validation
+    // -------------------------------------------------------------------------
+
+    pub fn validate_positive_amount(env: Env, amount: i128) {
+        let _ = env;
+        validation::require_positive_amount(amount);
+    }
+
+    pub fn validate_percentage(env: Env, pct: u32) {
+        let _ = env;
+        validation::require_percentage_valid(pct);
+    }
+
+    pub fn validate_percentages_sum(env: Env, a: u32, b: u32, c: u32) {
+        let _ = env;
+        validation::require_percentages_sum_100(a, b, c);
+    }
+
+    pub fn validate_future_timestamp(env: Env, ts: u64) {
+        validation::require_future_timestamp(&env, ts);
+    }
+
+    // -------------------------------------------------------------------------
     // Emergency Pause
     // -------------------------------------------------------------------------
 
@@ -262,5 +301,8 @@ impl SharedContract {
 }
 
 pub mod multisig;
+pub mod reentrancy;
+pub mod validation;
+pub mod errors;
 
 mod tests;

--- a/contracts/shared/src/reentrancy.rs
+++ b/contracts/shared/src/reentrancy.rs
@@ -1,0 +1,35 @@
+use soroban_sdk::{contracttype, Env, symbol_short};
+
+#[contracttype]
+pub enum ReentrancyKey {
+    Locked,
+}
+
+pub fn acquire_lock(env: &Env) {
+    let locked: bool = env
+        .storage()
+        .instance()
+        .get(&ReentrancyKey::Locked)
+        .unwrap_or(false);
+    assert!(!locked, "Reentrant call detected");
+    env.storage()
+        .instance()
+        .set(&ReentrancyKey::Locked, &true);
+}
+
+pub fn release_lock(env: &Env) {
+    env.storage()
+        .instance()
+        .set(&ReentrancyKey::Locked, &false);
+    env.events().publish(
+        (symbol_short!("guard"), symbol_short!("unlock")),
+        env.ledger().timestamp(),
+    );
+}
+
+pub fn is_locked(env: &Env) -> bool {
+    env.storage()
+        .instance()
+        .get(&ReentrancyKey::Locked)
+        .unwrap_or(false)
+}

--- a/contracts/shared/src/validation.rs
+++ b/contracts/shared/src/validation.rs
@@ -1,0 +1,28 @@
+use soroban_sdk::{Env, String};
+
+pub fn require_positive_amount(amount: i128) {
+    assert!(amount > 0, "Amount must be positive");
+}
+
+pub fn require_non_zero_u64(value: u64) {
+    assert!(value > 0, "Value must be non-zero");
+}
+
+pub fn require_percentage_valid(pct: u32) {
+    assert!(pct <= 100, "Percentage must be 0-100");
+}
+
+pub fn require_percentages_sum_100(a: u32, b: u32, c: u32) {
+    assert!(a + b + c == 100, "Percentages must sum to 100");
+}
+
+pub fn require_future_timestamp(env: &Env, ts: u64) {
+    assert!(
+        ts > env.ledger().timestamp(),
+        "Timestamp must be in the future"
+    );
+}
+
+pub fn require_non_empty_string(s: &String) {
+    assert!(s.len() > 0, "String must not be empty");
+}

--- a/contracts/token_restrictions/src/lib.rs
+++ b/contracts/token_restrictions/src/lib.rs
@@ -10,12 +10,25 @@ pub enum DataKey {
     Blacklist(Address),
     TransferLimit(Address),
     PendingApprovals(Address, Address),
+    EmergencyOverride,
+    RestrictionLog(u64),
+    LogCount,
+}
+
+#[contracttype]
+#[derive(Clone)]
+pub struct RestrictionLogEntry {
+    pub id: u64,
+    pub account: Address,
+    pub action: Symbol,
+    pub timestamp: u64,
 }
 
 const WHITELIST_ADD: Symbol = symbol_short!("wl_add");
 const BLACKLIST_ADD: Symbol = symbol_short!("bl_add");
 const LIMIT_SET: Symbol = symbol_short!("limit");
 const APPROVAL_REQ: Symbol = symbol_short!("appr");
+const EMERGENCY: Symbol = symbol_short!("emrg");
 
 #[contract]
 pub struct TokenRestrictionsContract;
@@ -153,5 +166,87 @@ impl TokenRestrictionsContract {
             .instance()
             .get::<_, bool>(&DataKey::PendingApprovals(from, to))
             .unwrap_or(true)
+    }
+
+    pub fn activate_emergency_override(env: Env, admin: Address) {
+        admin.require_auth();
+        let stored_admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
+        assert!(admin == stored_admin, "Only admin can activate override");
+
+        env.storage()
+            .instance()
+            .set(&DataKey::EmergencyOverride, &true);
+
+        Self::log_restriction_event(env.clone(), admin, symbol_short!("emrg_on"));
+        env.events()
+            .publish((EMERGENCY, symbol_short!("on")), env.ledger().timestamp());
+    }
+
+    pub fn deactivate_emergency_override(env: Env, admin: Address) {
+        admin.require_auth();
+        let stored_admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
+        assert!(admin == stored_admin, "Only admin can deactivate override");
+
+        env.storage()
+            .instance()
+            .set(&DataKey::EmergencyOverride, &false);
+
+        Self::log_restriction_event(env.clone(), admin, symbol_short!("emrg_off"));
+        env.events()
+            .publish((EMERGENCY, symbol_short!("off")), env.ledger().timestamp());
+    }
+
+    pub fn is_emergency_override_active(env: Env) -> bool {
+        env.storage()
+            .instance()
+            .get(&DataKey::EmergencyOverride)
+            .unwrap_or(false)
+    }
+
+    pub fn can_transfer(env: Env, from: Address, to: Address) -> bool {
+        if Self::is_emergency_override_active(env.clone()) {
+            return true;
+        }
+        if Self::is_blacklisted(env.clone(), from.clone())
+            || Self::is_blacklisted(env.clone(), to.clone())
+        {
+            return false;
+        }
+        true
+    }
+
+    fn log_restriction_event(env: Env, account: Address, action: Symbol) {
+        let id: u64 = env
+            .storage()
+            .instance()
+            .get(&DataKey::LogCount)
+            .unwrap_or(0);
+
+        let entry = RestrictionLogEntry {
+            id,
+            account,
+            action,
+            timestamp: env.ledger().timestamp(),
+        };
+
+        env.storage()
+            .persistent()
+            .set(&DataKey::RestrictionLog(id), &entry);
+        env.storage()
+            .instance()
+            .set(&DataKey::LogCount, &(id + 1));
+    }
+
+    pub fn get_restriction_log(env: Env, log_id: u64) -> Option<RestrictionLogEntry> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::RestrictionLog(log_id))
+    }
+
+    pub fn get_log_count(env: Env) -> u64 {
+        env.storage()
+            .instance()
+            .get(&DataKey::LogCount)
+            .unwrap_or(0)
     }
 }


### PR DESCRIPTION
## Summary

- **#476 Token Restrictions** — added emergency override (activate/deactivate/query), `can_transfer` helper, and restriction event logging with `RestrictionLogEntry`
- **#477 Royalty Distribution** — completed `PaymentRecord` tracking on every `distribute_royalties` call; added `get_payment_record`, `get_payment_count`, `get_total_distributed` reporting functions
- **#478 Credential Metadata** — added `MetadataHistoryEntry` struct, snapshot of previous values saved on every `update_metadata`; added `get_metadata_history` and `get_history_count`
- **#479 Shared Utilities** — added `reentrancy.rs` (acquire/release/query lock), `validation.rs` (amount, percentage, timestamp, string validators), `errors.rs` (`SharedError` contracterror enum with 14 typed codes); wired all into `SharedContract` public API

## Test plan
- [ ] Verify `token_restrictions`: call `activate_emergency_override`, confirm `can_transfer` returns `true` even for blacklisted accounts; deactivate and confirm restrictions resume
- [ ] Verify `royalty_distribution`: distribute royalties, confirm `get_payment_record(0)` returns correct course/amount/timestamp and `get_total_distributed` accumulates correctly
- [ ] Verify `credential_metadata`: call `update_metadata` twice, confirm `get_history_count` = 2 and `get_metadata_history(id, 0)` returns original values
- [ ] Verify `shared`: call `acquire_reentrancy_lock`, confirm `is_reentrancy_locked` = true; `validate_percentages_sum(30, 30, 40)` panics; `validate_future_timestamp` accepts future timestamp

Closes #476 
closes #477 
closes #478 
closes #479 

🤖 Generated with [Claude Code](https://claude.com/claude-code)