### PR TITLE
feat: implement contract monitoring, docs, Docker setup, and CI/CD pipeline

### DIFF
--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -88,3 +88,117 @@ jobs:
           name: wasm-contracts
           path: contracts/**/target/wasm32-unknown-unknown/release/*.wasm
           retention-days: 7
+
+  contracts-deploy-testnet:
+    name: Contracts - Deploy to Testnet
+    runs-on: ubuntu-latest
+    needs: [contracts-test, contracts-build-wasm]
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    environment:
+      name: testnet
+      url: https://stellar.expert/explorer/testnet
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: |
+            contracts
+
+      - name: Install Stellar CLI
+        run: |
+          curl -sSL https://github.com/stellar/stellar-cli/releases/download/v21.5.0/stellar-cli-21.5.0-x86_64-unknown-linux-gnu.tar.gz | tar xz
+          sudo mv stellar /usr/local/bin/
+          stellar --version
+
+      - name: Download WASM artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: wasm-contracts
+          path: wasm-artifacts
+
+      - name: Deploy contracts to testnet
+        id: deploy
+        run: |
+          DEPLOYED=()
+          FAILED=()
+
+          for wasm in wasm-artifacts/*.wasm; do
+            CONTRACT_NAME=$(basename "$wasm" .wasm | sed 's/brain_storm_//')
+            echo "Deploying $CONTRACT_NAME..."
+
+            CONTRACT_ID=$(stellar contract deploy \
+              --wasm "$wasm" \
+              --source "${{ secrets.STELLAR_SECRET_KEY }}" \
+              --network testnet 2>&1 | grep -oP '[A-Z0-9]{56}' | head -1 || echo "")
+
+            if [ -n "$CONTRACT_ID" ]; then
+              echo "$CONTRACT_NAME=$CONTRACT_ID" >> "$GITHUB_OUTPUT"
+              DEPLOYED+=("$CONTRACT_NAME:$CONTRACT_ID")
+              echo "✅ $CONTRACT_NAME deployed: $CONTRACT_ID"
+            else
+              FAILED+=("$CONTRACT_NAME")
+              echo "❌ $CONTRACT_NAME deployment failed"
+            fi
+          done
+
+          echo "deployed_count=${#DEPLOYED[@]}" >> "$GITHUB_OUTPUT"
+          echo "failed_count=${#FAILED[@]}" >> "$GITHUB_OUTPUT"
+
+          if [ ${#FAILED[@]} -gt 0 ]; then
+            echo "Failed contracts: ${FAILED[*]}"
+            exit 1
+          fi
+        env:
+          STELLAR_SECRET_KEY: ${{ secrets.STELLAR_SECRET_KEY }}
+
+      - name: Verify deployments
+        run: |
+          for wasm in wasm-artifacts/*.wasm; do
+            CONTRACT_NAME=$(basename "$wasm" .wasm | sed 's/brain_storm_//')
+            CONTRACT_ID="${{ steps.deploy.outputs[CONTRACT_NAME] }}"
+
+            if [ -n "$CONTRACT_ID" ]; then
+              echo "🔍 Verifying $CONTRACT_NAME ($CONTRACT_ID)..."
+              stellar contract info \
+                --id "$CONTRACT_ID" \
+                --network testnet || echo "⚠️  Verification pending for $CONTRACT_NAME"
+            fi
+          done
+
+      - name: Update deployed-contracts.json
+        run: |
+          cd scripts
+          for wasm in ../wasm-artifacts/*.wasm; do
+            CONTRACT_NAME=$(basename "$wasm" .wasm | sed 's/brain_storm_//')
+            CONTRACT_ID="${{ steps.deploy.outputs[CONTRACT_NAME] }}"
+            if [ -n "$CONTRACT_ID" ]; then
+              jq ".testnet.\"$CONTRACT_NAME\" = \"$CONTRACT_ID\"" deployed-contracts.json \
+                > deployed-contracts.json.tmp && mv deployed-contracts.json.tmp deployed-contracts.json
+            fi
+          done
+
+      - name: Commit updated contract registry
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          if ! git diff --quiet scripts/deployed-contracts.json; then
+            git add scripts/deployed-contracts.json
+            git commit -m "chore: update testnet contract addresses [skip ci]"
+            git push
+          fi
+
+      - name: Deployment summary
+        run: |
+          echo "## Contract Deployment Summary" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **Network:** testnet" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **Deployed:** ${{ steps.deploy.outputs.deployed_count }} contracts" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **Explorer:** https://stellar.expert/explorer/testnet" >> "$GITHUB_STEP_SUMMARY"

--- a/contracts/Dockerfile
+++ b/contracts/Dockerfile
@@ -1,0 +1,21 @@
+# Multi-stage contract build container
+FROM rust:1.82-slim AS builder
+
+WORKDIR /contracts
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    pkg-config \
+    libssl-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN rustup target add wasm32-unknown-unknown && \
+    cargo install --locked stellar-cli --features opt
+
+COPY Cargo.toml Cargo.lock ./
+COPY contracts/ ./contracts/
+COPY scripts/build.sh ./scripts/
+
+RUN chmod +x scripts/build.sh && ./scripts/build.sh
+
+FROM scratch AS artifacts
+COPY --from=builder /contracts/contracts/*/target/wasm32-unknown-unknown/release/*.wasm /wasm/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,12 @@ services:
       - '5432:5432'
     networks:
       - brain-storm
+    healthcheck:
+      test: ['CMD-SHELL', 'pg_isready -U brain-storm -d brain-storm']
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
 
   redis:
     image: redis:7-alpine
@@ -24,6 +30,11 @@ services:
       - '6379:6379'
     networks:
       - brain-storm
+    healthcheck:
+      test: ['CMD', 'redis-cli', 'ping']
+      interval: 10s
+      timeout: 3s
+      retries: 5
 
   backend:
     build:
@@ -43,12 +54,53 @@ services:
       REDIS_HOST: redis
       REDIS_PORT: 6379
     volumes:
-      - /app/node_modules  # Prevent host node_modules override
+      - /app/node_modules
     depends_on:
       postgres:
         condition: service_healthy
       redis:
-        condition: service_started
+        condition: service_healthy
+    networks:
+      - brain-storm
+    healthcheck:
+      test: ['CMD-SHELL', 'wget -qO- http://localhost:3000/health || exit 1']
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
+
+  frontend:
+    build:
+      context: .
+      dockerfile: apps/frontend/Dockerfile
+    restart: unless-stopped
+    ports:
+      - '3001:3001'
+    env_file:
+      - .env
+    environment:
+      NEXT_PUBLIC_API_URL: http://backend:3000
+    depends_on:
+      backend:
+        condition: service_healthy
+    networks:
+      - brain-storm
+    healthcheck:
+      test: ['CMD-SHELL', 'wget -qO- http://localhost:3001/api/health || exit 1']
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
+
+  contracts-builder:
+    build:
+      context: .
+      dockerfile: contracts/Dockerfile
+      target: builder
+    profiles:
+      - contracts
+    volumes:
+      - wasm_artifacts:/contracts/contracts
     networks:
       - brain-storm
 
@@ -56,6 +108,8 @@ volumes:
   postgres_data:
     driver: local
   redis_data:
+    driver: local
+  wasm_artifacts:
     driver: local
 
 networks:

--- a/docs/contract-interfaces.md
+++ b/docs/contract-interfaces.md
@@ -1,0 +1,350 @@
+# Brain-Storm Smart Contract Reference
+
+Complete interface documentation for all Soroban smart contracts on the Stellar network.
+
+## Table of Contents
+
+1. [Architecture Overview](#architecture-overview)
+2. [Analytics Contract](#analytics-contract)
+3. [Token Contract (BST)](#token-contract-bst)
+4. [Certificate Contract](#certificate-contract)
+5. [Badge Contract](#badge-contract)
+6. [Governance Contract](#governance-contract)
+7. [Reputation Contract](#reputation-contract)
+8. [Scholarship Fund Contract](#scholarship-fund-contract)
+9. [Liquidity Pool Contract](#liquidity-pool-contract)
+10. [Shared / RBAC Contract](#shared--rbac-contract)
+11. [Security Considerations](#security-considerations)
+12. [Upgrade Guide](#upgrade-guide)
+
+---
+
+## Architecture Overview
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                    Brain-Storm Contracts                     │
+│                                                             │
+│  ┌───────────┐   ┌──────────┐   ┌──────────────────────┐   │
+│  │ Analytics │   │  Token   │   │     Certificate      │   │
+│  │  (progress│   │  (BST)   │   │   (soulbound NFT)    │   │
+│  │   & stats)│   │          │   │                      │   │
+│  └─────┬─────┘   └────┬─────┘   └──────────────────────┘   │
+│        │              │                                     │
+│  ┌─────▼─────┐   ┌────▼──────┐   ┌──────────────────────┐  │
+│  │   Badge   │   │Governance │   │      Reputation      │  │
+│  │           │   │           │   │                      │  │
+│  └───────────┘   └───────────┘   └──────────────────────┘  │
+│                                                             │
+│  ┌──────────────────┐   ┌────────────────────────────────┐  │
+│  │  Scholarship Fund│   │       Liquidity Pool           │  │
+│  └──────────────────┘   └────────────────────────────────┘  │
+└─────────────────────────────────────────────────────────────┘
+```
+
+All contracts follow the same initialization pattern:
+- `initialize(admin)` — one-time setup, panics if called again
+- `get_admin()` / `set_admin(new_admin)` — admin key rotation
+
+---
+
+## Analytics Contract
+
+Tracks per-student course progress and emits Soroban events for off-chain indexers.
+
+### Functions
+
+| Function | Auth | Description |
+|---|---|---|
+| `initialize(admin)` | none | One-time setup |
+| `set_admin(new_admin)` | admin | Transfer admin role |
+| `get_admin()` | — | Read current admin |
+| `record_progress(caller, student, course_id, progress_pct)` | caller | Record/update progress (0–100) |
+| `reset_progress(admin, student, course_id)` | admin | Reset a student's progress |
+| `get_progress(student, course_id)` | — | Read a progress record |
+| `get_all_progress(student)` | — | All progress records for a student |
+| `get_completed_courses(student)` | — | Completed courses list |
+| `get_in_progress_courses(student)` | — | In-progress courses list |
+| `get_progress_paginated(student, start, limit)` | — | Paginated progress records |
+| `get_progress_above_threshold(student, threshold)` | — | Records above a progress % |
+| `count_completed_courses(student)` | — | Count of completions |
+| `get_average_progress(student)` | — | Average progress across all courses |
+| `get_milestone(student, course_id, milestone_pct)` | — | Read a milestone record |
+| `get_achieved_milestones(student, course_id)` | — | All achieved milestones |
+| `get_total_students()` | — | Total students tracked |
+| `get_total_courses()` | — | Total courses tracked |
+| `get_completion_stats()` | — | Aggregate completion statistics |
+| `get_daily_stats(day)` | — | Stats for a specific day |
+| `get_weekly_stats(week)` | — | Stats for a specific week |
+| `get_monthly_stats(month)` | — | Stats for a specific month |
+| `get_top_performers(limit)` | — | Top students by completion count |
+| `update_aggregates(admin)` | admin | Recalculate aggregate stats |
+
+### Events
+
+| Topics | Data | Condition |
+|--------|------|-----------|
+| `("analytics", "prog_upd")` | `(student, course_id, progress_pct)` | every `record_progress` call |
+| `("analytics", "completed")` | `(student, course_id)` | when `progress_pct == 100` |
+| `("analytics", "milestone")` | `(student, course_id, milestone_pct)` | when a milestone is first achieved |
+
+### Usage Example
+
+```bash
+stellar contract invoke \
+  --id $ANALYTICS_CONTRACT_ID \
+  --source backend-keypair \
+  --network testnet \
+  -- record_progress \
+  --caller $STUDENT_ADDRESS \
+  --student $STUDENT_ADDRESS \
+  --course_id RUST101 \
+  --progress_pct 75
+```
+
+---
+
+## Token Contract (BST)
+
+ERC-20-compatible fungible token with vesting, staking, airdrop, and burn mechanics.
+
+### Functions
+
+| Function | Auth | Description |
+|---|---|---|
+| `initialize(admin, name, symbol, decimals, initial_supply)` | none | Deploy and mint initial supply to admin |
+| `mint(admin, to, amount)` | admin | Mint new tokens |
+| `burn(from, amount)` | from | Burn tokens (updates burn stats) |
+| `transfer(from, to, amount)` | from | Transfer tokens |
+| `approve(owner, spender, amount, expiry)` | owner | Set allowance |
+| `transfer_from(spender, from, to, amount)` | spender | Transfer using allowance |
+| `balance(account)` | — | Read balance |
+| `allowance(owner, spender)` | — | Read allowance |
+| `total_supply()` | — | Read total supply |
+| `get_burn_stats()` | — | Cumulative burn data |
+| `create_vesting(admin, beneficiary, amount, start, cliff, end)` | admin | Create vesting schedule |
+| `claim_vesting(beneficiary, schedule_id)` | beneficiary | Claim vested tokens |
+| `get_vesting(beneficiary, schedule_id)` | — | Read vesting schedule |
+
+### Staking (via `staking` module)
+
+| Function | Auth | Description |
+|---|---|---|
+| `stake(user, amount, lock_period)` | user | Stake BST tokens |
+| `unstake(user)` | user | Unstake after lock period |
+| `claim_staking_rewards(user)` | user | Claim accrued rewards |
+| `get_stake(user)` | — | Read stake record |
+
+### Airdrop (via `airdrop` module)
+
+| Function | Auth | Description |
+|---|---|---|
+| `create_airdrop(admin, total, per_claim, merkle_root, expiry)` | admin | Set up airdrop |
+| `claim_airdrop(claimer, proof)` | claimer | Claim from airdrop with Merkle proof |
+
+---
+
+## Certificate Contract
+
+Issues soulbound (non-transferable) NFT certificates upon course completion.
+
+### Functions
+
+| Function | Auth | Description |
+|---|---|---|
+| `initialize(admin)` | none | One-time setup |
+| `set_admin(new_admin)` | admin | Transfer admin role |
+| `get_admin()` | — | Read admin |
+| `mint_certificate(admin, recipient, course_id, metadata_url)` | admin | Issue certificate; returns `cert_id` |
+| `get_certificate(id)` | — | Read a certificate by ID |
+| `get_certificates_by_owner(owner)` | — | All certificates for an address |
+| `revoke_certificate(admin, cert_id, reason)` | admin | Revoke a certificate |
+| `is_revoked(cert_id)` | — | Check revocation status |
+| `get_revocation(cert_id)` | — | Read revocation details |
+| `transfer(...)` | — | Always panics — certificates are soulbound |
+
+### Events
+
+| Topics | Data | Condition |
+|--------|------|-----------|
+| `("cert", "mint")` | `(id, recipient, course_id)` | on mint |
+| `("cert", "revoke")` | `(id, reason)` | on revocation |
+
+### Usage Example
+
+```bash
+# Mint a certificate
+stellar contract invoke \
+  --id $CERTIFICATE_CONTRACT_ID \
+  --source admin \
+  --network testnet \
+  -- mint_certificate \
+  --admin $ADMIN_ADDRESS \
+  --recipient $STUDENT_ADDRESS \
+  --course_id RUST101 \
+  --metadata_url "https://api.brain-storm.com/v1/certs/1"
+```
+
+---
+
+## Badge Contract
+
+Issues achievement badges (non-transferable) tied to badge type definitions.
+
+### Functions
+
+| Function | Auth | Description |
+|---|---|---|
+| `initialize(admin)` | none | One-time setup |
+| `get_admin()` | — | Read admin |
+| `create_badge_type(admin, badge_type, name, description, criteria)` | admin | Define a new badge type |
+| `get_badge_type(badge_type)` | — | Read badge type definition |
+| `mint_badge(admin, recipient, badge_type)` | admin | Issue badge; returns `badge_id` |
+| `get_badge(id)` | — | Read badge by ID |
+| `get_badges_by_owner(owner)` | — | All badges for an address |
+| `verify_badge(owner, badge_type)` | — | Check if owner holds a badge type |
+| `transfer(...)` | — | Always panics — badges are soulbound |
+
+---
+
+## Governance Contract
+
+On-chain proposal voting and contract upgrade governance.
+
+### Functions
+
+| Function | Auth | Description |
+|---|---|---|
+| `initialize(admin, token_contract)` | none | One-time setup; links BST token for voting weight |
+| `get_admin()` | — | Read admin |
+| `create_proposal(proposer, title, description, voting_end)` | proposer | Submit a proposal |
+| `vote(voter, proposal_id, support)` | voter | Cast vote (true = for, false = against) |
+| `execute_proposal(proposal_id)` | — | Execute a passed proposal after voting ends |
+| `get_proposal(proposal_id)` | — | Read proposal details |
+| `has_voted(proposal_id, voter)` | — | Check if address voted |
+| `propose_upgrade(proposer, new_wasm_hash, description)` | proposer | Propose contract upgrade |
+| `vote_upgrade(voter, upgrade_id, support)` | voter | Vote on upgrade proposal |
+| `approve_upgrade(upgrade_id)` | admin | Admin approval gate |
+| `execute_upgrade(upgrade_id)` | — | Execute approved upgrade |
+| `get_upgrade_proposal(upgrade_id)` | — | Read upgrade proposal |
+
+---
+
+## Reputation Contract
+
+Tracks on-chain reputation scores with decay mechanics and threshold gating.
+
+### Functions
+
+| Function | Auth | Description |
+|---|---|---|
+| `initialize(admin)` | none | One-time setup |
+| `get_admin()` | — | Read admin |
+| `update_reputation(admin, user, delta, reason)` | admin | Add or subtract reputation points |
+| `get_reputation(user)` | — | Read current score |
+| `get_reputation_record(user)` | — | Full record with metadata |
+| `get_reputation_level(user)` | — | Level (0–5) derived from score |
+| `apply_decay(admin, user)` | admin | Apply time-based decay to a user |
+| `set_decay_config(admin, rate, period)` | admin | Configure decay parameters |
+| `get_decay_config()` | — | Read current decay config |
+| `claim_reputation_reward(user)` | user | Claim token reward for reputation milestone |
+| `verify_reputation_threshold(user, min_score)` | — | Boolean gate check |
+| `verify_reputation_level(user, min_level)` | — | Boolean gate check |
+| `get_reputation_history(user, start, limit)` | — | Paginated update history |
+| `get_total_reputation()` | — | Sum of all reputation scores |
+
+---
+
+## Scholarship Fund Contract
+
+Community-funded scholarships with application and approval workflow.
+
+### Functions
+
+| Function | Auth | Description |
+|---|---|---|
+| `initialize(admin)` | none | One-time setup |
+| `donate(donor, amount)` | donor | Donate BST tokens to the fund |
+| `apply_for_scholarship(applicant, course_id, amount, reason)` | applicant | Submit application |
+| `approve_application(admin, app_id)` | admin | Approve and disburse tokens |
+| `reject_application(admin, app_id)` | admin | Reject application |
+
+---
+
+## Liquidity Pool Contract
+
+AMM-style BST/XLM liquidity pool with LP mining rewards.
+
+### Functions
+
+| Function | Auth | Description |
+|---|---|---|
+| `initialize(admin, token_a, token_b, fee_bps)` | none | One-time setup |
+| `add_liquidity(user, amount_a, amount_b, min_lp)` | user | Provide liquidity; receive LP tokens |
+| `remove_liquidity(user, lp_amount, min_a, min_b)` | user | Redeem LP tokens for underlying |
+| `swap(user, token_in, amount_in, min_amount_out)` | user | Swap tokens via constant-product formula |
+| `claim_mining_rewards(user)` | user | Claim accrued LP mining rewards |
+| `get_pool_stats()` | — | Reserves, fee rate, total LP |
+| `get_user_liquidity(user)` | — | User's LP token balance |
+| `get_swap_history(start_index, limit)` | — | Paginated swap records |
+
+---
+
+## Shared / RBAC Contract
+
+Role-based access control library used by other contracts for cross-contract authorization checks.
+
+---
+
+## Security Considerations
+
+### Admin Key Management
+
+- Admin addresses are stored in persistent contract storage.
+- Use a hardware wallet or multi-sig Stellar account for the admin key.
+- Rotate the admin key periodically via `set_admin`.
+
+### Soulbound Tokens
+
+Certificate and Badge contracts disable `transfer` by always panicking. This prevents secondary-market circumvention of credentials.
+
+### Reentrancy Protection
+
+The Token contract uses a `Locked` storage key as a reentrancy guard around state-mutating operations.
+
+### Integer Overflow
+
+All arithmetic uses Soroban SDK types with `overflow-checks = true` in the release profile (see `Cargo.toml`).
+
+### Storage TTL
+
+Persistent storage entries use `TTL_THRESHOLD` / `TTL_EXTEND_TO` ledger constants. Callers must ensure entry TTLs are extended for long-lived data (e.g., via `extend_ttl`).
+
+### Event Integrity
+
+Events are emitted by the contract address. Off-chain indexers should verify the emitting contract ID against the known deployed address before trusting event data.
+
+---
+
+## Upgrade Guide
+
+Brain-Storm contracts use Soroban's built-in `update_current_contract_wasm` mechanism gated through the Governance contract.
+
+### Process
+
+1. **Build new WASM** — run `./scripts/build.sh` and note the new hash.
+2. **Submit upgrade proposal** — call `propose_upgrade(proposer, new_wasm_hash, description)` on the Governance contract.
+3. **Community voting** — token holders call `vote_upgrade(voter, upgrade_id, support)` during the voting window.
+4. **Admin approval** — admin calls `approve_upgrade(upgrade_id)` if quorum is reached.
+5. **Execute upgrade** — anyone calls `execute_upgrade(upgrade_id)`; the on-chain WASM is atomically replaced.
+6. **Verify** — run `stellar contract info --id <CONTRACT_ID> --network testnet` to confirm the new hash.
+
+### Storage Migration
+
+If the new WASM introduces new storage keys, initialize them in the contract's first invocation after upgrade. Existing keys remain untouched.
+
+### Rollback
+
+Soroban does not natively support rollback. Keep the previous WASM hash and re-submit a new upgrade proposal pointing to it if a critical bug is discovered.
+
+See also: [Smart Contract Upgrade Guide](./smart-contract-upgrade-guide.md)

--- a/docs/docker-guide.md
+++ b/docs/docker-guide.md
@@ -1,0 +1,131 @@
+# Docker Setup Guide
+
+Complete Docker containerization for the Brain-Storm full stack: backend (NestJS), frontend (Next.js), Postgres, Redis, and Soroban smart contract build container.
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────┐
+│                   brain-storm network                │
+│                                                     │
+│  ┌──────────┐    ┌──────────┐    ┌───────────────┐  │
+│  │ postgres │    │  redis   │    │    backend    │  │
+│  │  :5432   │◄───│  :6379   │◄───│    :3000      │  │
+│  └──────────┘    └──────────┘    └───────┬───────┘  │
+│                                          │           │
+│                                  ┌───────▼───────┐  │
+│                                  │   frontend    │  │
+│                                  │    :3001      │  │
+│                                  └───────────────┘  │
+└─────────────────────────────────────────────────────┘
+
+  ┌──────────────────────────────┐
+  │     contracts-builder        │  (profile: contracts)
+  │   Rust + Stellar CLI         │
+  │   outputs: *.wasm artifacts  │
+  └──────────────────────────────┘
+```
+
+## Quick Start
+
+### Full stack (development)
+
+```bash
+# Copy environment file
+cp .env.example .env
+
+# Start all services
+docker compose up -d
+
+# View logs
+docker compose logs -f
+
+# Stop all services
+docker compose down
+```
+
+### Build smart contracts
+
+```bash
+# Build WASM artifacts using the contract build container
+docker compose --profile contracts run --rm contracts-builder
+
+# Artifacts are placed in the wasm_artifacts volume
+```
+
+## Services
+
+| Service | Port | Health Check |
+|---------|------|-------------|
+| postgres | 5432 | `pg_isready` |
+| redis | 6379 | `redis-cli ping` |
+| backend | 3000 | `GET /health` |
+| frontend | 3001 | `GET /api/health` |
+
+## Dockerfiles
+
+### Backend (`apps/backend/Dockerfile`)
+
+Multi-stage build:
+1. **deps** — installs production dependencies
+2. **build** — compiles TypeScript
+3. **runner** — minimal production image
+
+### Frontend (`apps/frontend/Dockerfile`)
+
+Multi-stage build:
+1. **builder** — runs `next build` with standalone output
+2. **runner** — copies only the standalone bundle; no Node modules needed
+
+### Contracts (`contracts/Dockerfile`)
+
+Multi-stage build:
+1. **builder** — Rust stable + `wasm32-unknown-unknown` target + Stellar CLI; runs `scripts/build.sh`
+2. **artifacts** — `scratch` image containing only the compiled `.wasm` files
+
+## Health Checks
+
+All services declare `healthcheck` blocks. `depends_on` conditions use `service_healthy` so containers only start once their dependencies are ready.
+
+```yaml
+healthcheck:
+  test: ['CMD-SHELL', 'pg_isready -U brain-storm -d brain-storm']
+  interval: 10s
+  timeout: 5s
+  retries: 5
+  start_period: 10s
+```
+
+## Container Networking
+
+All services share the `brain-storm` bridge network. Services reference each other by service name (e.g., `DATABASE_HOST: postgres`). The frontend calls the backend via `http://backend:3000` inside the network.
+
+## Production Overrides
+
+Use `docker-compose.prod.yml` for production-specific settings:
+
+```bash
+docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d
+```
+
+## Useful Commands
+
+```bash
+# Rebuild a single service
+docker compose build backend
+
+# Scale backend (multiple replicas)
+docker compose up -d --scale backend=3
+
+# Check service health
+docker compose ps
+
+# Access postgres shell
+docker compose exec postgres psql -U brain-storm -d brain-storm
+
+# Access redis CLI
+docker compose exec redis redis-cli
+
+# View container resource usage
+docker stats
+```

--- a/infra/monitoring/contracts/alerting-rules.yml
+++ b/infra/monitoring/contracts/alerting-rules.yml
@@ -1,0 +1,107 @@
+groups:
+  - name: contract_health
+    interval: 60s
+    rules:
+      # Alert when no contract events have been received in 10 minutes
+      - alert: ContractEventSilence
+        expr: |
+          (time() - contract_last_event_timestamp) > 600
+        for: 2m
+        labels:
+          severity: warning
+          team: contracts
+        annotations:
+          summary: "No contract events received for {{ $labels.contract }}"
+          description: >
+            Contract {{ $labels.contract }} has not emitted any events for more
+            than 10 minutes. This may indicate a monitoring connectivity issue
+            or unexpected contract inactivity.
+
+      # Alert when contract transaction error rate exceeds 5%
+      - alert: ContractHighErrorRate
+        expr: |
+          rate(contract_transaction_errors_total[5m])
+            / rate(contract_transactions_total[5m]) > 0.05
+        for: 3m
+        labels:
+          severity: critical
+          team: contracts
+        annotations:
+          summary: "High error rate on {{ $labels.contract }}"
+          description: >
+            Contract {{ $labels.contract }} is experiencing {{ $value | humanizePercentage }}
+            transaction errors over the last 5 minutes.
+
+      # Alert when transaction latency p95 exceeds 5 seconds
+      - alert: ContractHighLatency
+        expr: |
+          histogram_quantile(0.95,
+            rate(contract_transaction_duration_seconds_bucket[10m])
+          ) > 5
+        for: 5m
+        labels:
+          severity: warning
+          team: contracts
+        annotations:
+          summary: "High latency on {{ $labels.contract }}"
+          description: >
+            p95 transaction latency for {{ $labels.contract }} is
+            {{ $value | humanizeDuration }}, exceeding the 5s threshold.
+
+  - name: contract_anomaly
+    interval: 120s
+    rules:
+      # Alert when event rate spikes more than 10x the 1-hour baseline
+      - alert: ContractEventSpike
+        expr: |
+          rate(contract_events_total[5m])
+            > 10 * avg_over_time(rate(contract_events_total[5m])[1h:5m])
+        for: 5m
+        labels:
+          severity: warning
+          team: contracts
+        annotations:
+          summary: "Unusual event spike on {{ $labels.contract }}"
+          description: >
+            Event rate for {{ $labels.contract }} is {{ $value }} events/s,
+            which is more than 10x above the 1-hour baseline.
+
+      # Alert when no progress events are recorded for 30 minutes during business hours
+      - alert: AnalyticsProgressStall
+        expr: |
+          rate(contract_events_total{contract="analytics",event="prog_upd"}[30m]) == 0
+        for: 10m
+        labels:
+          severity: info
+          team: contracts
+        annotations:
+          summary: "No progress updates recorded in 30 minutes"
+          description: >
+            The analytics contract has not received any progress_update events
+            in the past 30 minutes. Verify the backend is submitting transactions.
+
+  - name: contract_performance
+    interval: 60s
+    rules:
+      # Record p50/p95/p99 transaction duration per contract
+      - record: contract:transaction_duration_p50
+        expr: |
+          histogram_quantile(0.50,
+            rate(contract_transaction_duration_seconds_bucket[10m])
+          )
+
+      - record: contract:transaction_duration_p95
+        expr: |
+          histogram_quantile(0.95,
+            rate(contract_transaction_duration_seconds_bucket[10m])
+          )
+
+      - record: contract:transaction_duration_p99
+        expr: |
+          histogram_quantile(0.99,
+            rate(contract_transaction_duration_seconds_bucket[10m])
+          )
+
+      # Record per-contract event rate
+      - record: contract:event_rate_5m
+        expr: rate(contract_events_total[5m])

--- a/infra/monitoring/grafana/dashboards/contracts-monitoring.json
+++ b/infra/monitoring/grafana/dashboards/contracts-monitoring.json
@@ -1,0 +1,158 @@
+{
+  "id": null,
+  "uid": "brain-storm-contracts",
+  "title": "Brain-Storm — Contract Monitoring",
+  "description": "Event monitoring, transaction tracking, performance metrics and anomaly detection for all Soroban smart contracts.",
+  "tags": ["contracts", "soroban", "stellar"],
+  "timezone": "browser",
+  "refresh": "30s",
+  "schemaVersion": 39,
+  "time": { "from": "now-1h", "to": "now" },
+  "templating": {
+    "list": [
+      {
+        "name": "contract",
+        "label": "Contract",
+        "type": "query",
+        "datasource": { "type": "prometheus" },
+        "query": "label_values(contract_events_total, contract)",
+        "multi": true,
+        "includeAll": true,
+        "current": { "text": "All", "value": "$__all" }
+      }
+    ]
+  },
+  "panels": [
+    {
+      "id": 1,
+      "title": "Contract Event Rate (events/s)",
+      "type": "timeseries",
+      "gridPos": { "x": 0, "y": 0, "w": 12, "h": 8 },
+      "targets": [
+        {
+          "expr": "rate(contract_events_total{contract=~\"$contract\"}[5m])",
+          "legendFormat": "{{contract}} / {{event}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": { "unit": "short", "color": { "mode": "palette-classic" } }
+      }
+    },
+    {
+      "id": 2,
+      "title": "Transaction Success vs Error Rate",
+      "type": "timeseries",
+      "gridPos": { "x": 12, "y": 0, "w": 12, "h": 8 },
+      "targets": [
+        {
+          "expr": "rate(contract_transactions_total{contract=~\"$contract\",status=\"success\"}[5m])",
+          "legendFormat": "{{contract}} success"
+        },
+        {
+          "expr": "rate(contract_transaction_errors_total{contract=~\"$contract\"}[5m])",
+          "legendFormat": "{{contract}} errors"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": { "unit": "reqps" },
+        "overrides": [
+          {
+            "matcher": { "id": "byRegexp", "options": ".*errors.*" },
+            "properties": [{ "id": "color", "value": { "fixedColor": "red", "mode": "fixed" } }]
+          }
+        ]
+      }
+    },
+    {
+      "id": 3,
+      "title": "Transaction Latency (p50 / p95 / p99)",
+      "type": "timeseries",
+      "gridPos": { "x": 0, "y": 8, "w": 12, "h": 8 },
+      "targets": [
+        {
+          "expr": "contract:transaction_duration_p50{contract=~\"$contract\"}",
+          "legendFormat": "{{contract}} p50"
+        },
+        {
+          "expr": "contract:transaction_duration_p95{contract=~\"$contract\"}",
+          "legendFormat": "{{contract}} p95"
+        },
+        {
+          "expr": "contract:transaction_duration_p99{contract=~\"$contract\"}",
+          "legendFormat": "{{contract}} p99"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": { "unit": "s" }
+      }
+    },
+    {
+      "id": 4,
+      "title": "Analytics — Progress Updates (24h)",
+      "type": "stat",
+      "gridPos": { "x": 12, "y": 8, "w": 6, "h": 4 },
+      "targets": [
+        {
+          "expr": "increase(contract_events_total{contract=\"analytics\",event=\"prog_upd\"}[24h])",
+          "legendFormat": "Progress Updates"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": { "unit": "short", "thresholds": {
+          "steps": [
+            { "color": "red", "value": null },
+            { "color": "yellow", "value": 10 },
+            { "color": "green", "value": 100 }
+          ]
+        }}
+      }
+    },
+    {
+      "id": 5,
+      "title": "Certificates Minted (24h)",
+      "type": "stat",
+      "gridPos": { "x": 18, "y": 8, "w": 6, "h": 4 },
+      "targets": [
+        {
+          "expr": "increase(contract_events_total{contract=\"certificate\",event=\"mint\"}[24h])",
+          "legendFormat": "Certs Minted"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": { "unit": "short", "color": { "fixedColor": "green", "mode": "fixed" } }
+      }
+    },
+    {
+      "id": 6,
+      "title": "Active Alerts",
+      "type": "alertlist",
+      "gridPos": { "x": 0, "y": 16, "w": 24, "h": 6 },
+      "options": {
+        "alertInstanceLabelFilter": "team=\"contracts\"",
+        "dashboardAlerts": false,
+        "maxItems": 20,
+        "sortOrder": 1,
+        "stateFilter": { "firing": true, "pending": true }
+      }
+    },
+    {
+      "id": 7,
+      "title": "Event Anomaly Detection — Rate vs Baseline",
+      "type": "timeseries",
+      "gridPos": { "x": 0, "y": 22, "w": 24, "h": 8 },
+      "targets": [
+        {
+          "expr": "contract:event_rate_5m{contract=~\"$contract\"}",
+          "legendFormat": "{{contract}} current rate"
+        },
+        {
+          "expr": "avg_over_time(contract:event_rate_5m{contract=~\"$contract\"}[1h])",
+          "legendFormat": "{{contract}} 1h baseline"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": { "unit": "short" }
+      }
+    }
+  ]
+}

--- a/infra/monitoring/prometheus.yml
+++ b/infra/monitoring/prometheus.yml
@@ -1,6 +1,11 @@
 global:
   scrape_interval: 15s
   evaluation_interval: 15s
+  external_labels:
+    project: brain-storm
+
+rule_files:
+  - 'contracts/alerting-rules.yml'
 
 scrape_configs:
   - job_name: 'brain-storm-backend'
@@ -8,3 +13,13 @@ scrape_configs:
       - targets: ['host.docker.internal:3000']
     metrics_path: '/metrics'
     scrape_interval: 10s
+
+  - job_name: 'brain-storm-contracts'
+    static_configs:
+      - targets: ['host.docker.internal:9101']
+    metrics_path: '/metrics'
+    scrape_interval: 30s
+    relabel_configs:
+      - source_labels: [__address__]
+        target_label: instance
+        replacement: 'contract-monitor'

--- a/scripts/contract-event-monitor.sh
+++ b/scripts/contract-event-monitor.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+# Contract event monitor — streams Soroban events from all deployed contracts
+# and exposes Prometheus metrics on port 9101.
+set -euo pipefail
+
+NETWORK="${STELLAR_NETWORK:-testnet}"
+CONTRACTS_JSON="${CONTRACTS_JSON:-scripts/deployed-contracts.json}"
+METRICS_PORT="${METRICS_PORT:-9101}"
+POLL_INTERVAL="${POLL_INTERVAL:-15}"
+
+# Temporary files
+METRICS_FILE="/tmp/contract_metrics.prom"
+CURSOR_FILE="/tmp/contract_event_cursor"
+
+# ── Helpers ──────────────────────────────────────────────────────────────────
+
+log() { echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] $*" >&2; }
+
+require() {
+  for cmd in "$@"; do
+    command -v "$cmd" >/dev/null || { log "Missing required command: $cmd"; exit 1; }
+  done
+}
+
+# Write a metrics snapshot to the temp file (atomic swap via tmp)
+write_metrics() {
+  local tmp; tmp=$(mktemp)
+  cat > "$tmp" <<EOF
+# HELP contract_events_total Total number of events emitted per contract and event type.
+# TYPE contract_events_total counter
+$(cat "${METRICS_FILE}.events" 2>/dev/null)
+
+# HELP contract_transactions_total Total transactions submitted per contract.
+# TYPE contract_transactions_total counter
+$(cat "${METRICS_FILE}.txns" 2>/dev/null)
+
+# HELP contract_transaction_errors_total Total failed transactions per contract.
+# TYPE contract_transaction_errors_total counter
+$(cat "${METRICS_FILE}.errors" 2>/dev/null)
+
+# HELP contract_last_event_timestamp Unix timestamp of the last event received per contract.
+# TYPE contract_last_event_timestamp gauge
+$(cat "${METRICS_FILE}.timestamps" 2>/dev/null)
+EOF
+  mv "$tmp" "$METRICS_FILE"
+}
+
+# Serve metrics over HTTP on $METRICS_PORT using a simple while loop
+serve_metrics() {
+  log "Serving Prometheus metrics on :${METRICS_PORT}/metrics"
+  while true; do
+    { echo -e "HTTP/1.1 200 OK\r\nContent-Type: text/plain; version=0.0.4\r\n\r\n$(cat "$METRICS_FILE" 2>/dev/null)"; } \
+      | nc -l -p "$METRICS_PORT" -q 1 2>/dev/null || true
+  done
+}
+
+# ── Event polling ─────────────────────────────────────────────────────────────
+
+poll_contract_events() {
+  local contract_id="$1"
+  local contract_name="$2"
+  local cursor="${3:-0}"
+
+  local events
+  events=$(stellar events \
+    --id "$contract_id" \
+    --network "$NETWORK" \
+    --start-ledger "$cursor" \
+    --output json 2>/dev/null) || { log "Failed to fetch events for $contract_name"; return 1; }
+
+  local count; count=$(echo "$events" | jq 'length' 2>/dev/null || echo 0)
+  [ "$count" -eq 0 ] && return 0
+
+  # Parse and accumulate event metrics
+  while IFS= read -r event; do
+    local event_type; event_type=$(echo "$event" | jq -r '.topic[1] // "unknown"')
+    local ledger; ledger=$(echo "$event" | jq -r '.ledger // 0')
+
+    # Increment counter
+    local key="contract_events_total{contract=\"${contract_name}\",event=\"${event_type}\"}"
+    local current; current=$(grep -oP "(?<=${key} )\d+" "${METRICS_FILE}.events" 2>/dev/null || echo 0)
+    grep -v "$key" "${METRICS_FILE}.events" 2>/dev/null > "${METRICS_FILE}.events.tmp" || true
+    echo "$key $((current + 1))" >> "${METRICS_FILE}.events.tmp"
+    mv "${METRICS_FILE}.events.tmp" "${METRICS_FILE}.events"
+
+    # Update last-seen timestamp
+    {
+      grep -v "contract=\"${contract_name}\"" "${METRICS_FILE}.timestamps" 2>/dev/null || true
+      echo "contract_last_event_timestamp{contract=\"${contract_name}\"} $(date +%s)"
+    } > "${METRICS_FILE}.timestamps.tmp"
+    mv "${METRICS_FILE}.timestamps.tmp" "${METRICS_FILE}.timestamps"
+
+    # Advance cursor
+    echo "$ledger" > "${CURSOR_FILE}.${contract_name}"
+  done < <(echo "$events" | jq -c '.[]')
+
+  log "$contract_name: processed $count events"
+}
+
+# ── Main ──────────────────────────────────────────────────────────────────────
+
+require stellar jq nc
+
+# Load contract IDs from deployed-contracts.json
+if [ ! -f "$CONTRACTS_JSON" ]; then
+  log "Contract registry not found: $CONTRACTS_JSON"
+  exit 1
+fi
+
+declare -A CONTRACTS
+while IFS="=" read -r name id; do
+  CONTRACTS["$name"]="$id"
+done < <(jq -r ".\"${NETWORK}\" | to_entries[] | \"\(.key)=\(.value)\"" "$CONTRACTS_JSON")
+
+if [ "${#CONTRACTS[@]}" -eq 0 ]; then
+  log "No contracts found for network: $NETWORK"
+  exit 1
+fi
+
+log "Monitoring ${#CONTRACTS[@]} contracts on $NETWORK: ${!CONTRACTS[*]}"
+
+# Initialize metric files
+for f in events txns errors timestamps; do
+  touch "${METRICS_FILE}.${f}"
+done
+write_metrics
+
+# Start metrics HTTP server in background
+serve_metrics &
+METRICS_PID=$!
+trap 'kill $METRICS_PID 2>/dev/null; exit 0' SIGINT SIGTERM
+
+# Event polling loop
+while true; do
+  for name in "${!CONTRACTS[@]}"; do
+    id="${CONTRACTS[$name]}"
+    cursor_file="${CURSOR_FILE}.${name}"
+    cursor=$(cat "$cursor_file" 2>/dev/null || echo 0)
+
+    poll_contract_events "$id" "$name" "$cursor" || true
+  done
+
+  write_metrics
+  sleep "$POLL_INTERVAL"
+done


### PR DESCRIPTION
## Summary

Implements all four Stellar Wave issues in a single PR:

- **#484 — Contract Monitoring**: Prometheus alerting rules (`infra/monitoring/contracts/alerting-rules.yml`) covering event silence, high error rate, high latency, and anomaly/spike detection. Grafana dashboard (`infra/monitoring/grafana/dashboards/contracts-monitoring.json`) with event rate panels, transaction success/error rate, p50/p95/p99 latency, and anomaly detection. `scripts/contract-event-monitor.sh` polls Stellar events for all deployed contracts and exposes Prometheus metrics on port 9101.
- **#485 — Contract Documentation**: `docs/contract-interfaces.md` — full reference for all Soroban contracts (Analytics, Token/BST, Certificate, Badge, Governance, Reputation, Scholarship Fund, Liquidity Pool, Shared/RBAC) with function tables, event schemas, CLI usage examples, security considerations, and a step-by-step upgrade guide.
- **#486 — Docker Setup**: `contracts/Dockerfile` multi-stage build container. `docker-compose.yml` updated to add `frontend` service and `contracts-builder` (profile: contracts), plus `healthcheck` blocks on every service. `docs/docker-guide.md` covers architecture, quick start, service table, and useful commands.
- **#487 — CI/CD Pipeline**: `contracts.yml` extended with a `contracts-deploy-testnet` job that runs after both CI jobs pass on `main` pushes — installs Stellar CLI, deploys each WASM, verifies deployments, and commits the updated contract registry.

## Closes

Closes #484
Closes #485
Closes #486
Closes #487

## Test plan

- [ ] Verify `contracts.yml` testnet deploy job triggers only on `main` branch pushes (not PRs)
- [ ] Run `docker compose up -d` and confirm all services become healthy
- [ ] Run `docker compose --profile contracts run --rm contracts-builder` and confirm WASM artifacts are produced
- [ ] Start Prometheus + Grafana and import `contracts-monitoring.json` dashboard
- [ ] Run `scripts/contract-event-monitor.sh` against testnet and confirm metrics appear at `:9101/metrics`

🤖 Generated with [Claude Code](https://claude.com/claude-code)