### PR TITLE
feat: implement staking pool, analytics access controls, cert transfer, governance queries

### DIFF
--- a/contracts/analytics/src/lib.rs
+++ b/contracts/analytics/src/lib.rs
@@ -16,6 +16,7 @@ pub enum DataKey {
     Admin,
     Progress(Address, Symbol),   // persistent: ProgressRecord
     StudentCourses(Address),     // persistent: Vec<Symbol> — secondary index
+    CourseStudents(Symbol),      // persistent: Vec<Address> — reverse index
     TotalStudents,
     TotalCourses,
     CompletionStats,
@@ -25,6 +26,7 @@ pub enum DataKey {
     TopPerformers,
     Milestone(Address, Symbol, u32), // (student, course, milestone_pct) → MilestoneRecord
     StudentMilestones(Address, Symbol), // (student, course) → Vec<u32> (achieved milestones)
+    AuthorizedCaller(Address),   // instance: bool — access control whitelist
 }
 
 // =============================================================================
@@ -106,11 +108,51 @@ impl AnalyticsContract {
     }
 
     // -------------------------------------------------------------------------
+    // Access controls — authorized callers
+    // -------------------------------------------------------------------------
+
+    /// Grant a contract/address permission to record progress on behalf of students.
+    pub fn authorize_caller(env: Env, admin: Address, caller: Address) {
+        admin.require_auth();
+        let stored_admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
+        assert!(admin == stored_admin, "Only admin can authorize callers");
+        env.storage()
+            .instance()
+            .set(&DataKey::AuthorizedCaller(caller.clone()), &true);
+        env.events().publish(
+            (symbol_short!("analytics"), symbol_short!("auth_add")),
+            caller,
+        );
+    }
+
+    /// Revoke a previously authorized caller.
+    pub fn revoke_caller(env: Env, admin: Address, caller: Address) {
+        admin.require_auth();
+        let stored_admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
+        assert!(admin == stored_admin, "Only admin can revoke callers");
+        env.storage()
+            .instance()
+            .remove(&DataKey::AuthorizedCaller(caller.clone()));
+        env.events().publish(
+            (symbol_short!("analytics"), symbol_short!("auth_rm")),
+            caller,
+        );
+    }
+
+    /// Check whether an address is an authorized caller.
+    pub fn is_authorized_caller(env: Env, caller: Address) -> bool {
+        env.storage()
+            .instance()
+            .get(&DataKey::AuthorizedCaller(caller))
+            .unwrap_or(false)
+    }
+
+    // -------------------------------------------------------------------------
     // Progress
     // -------------------------------------------------------------------------
 
     /// Record or update a student's course progress.
-    /// Callable by the student themselves OR the admin.
+    /// Callable by the student themselves, the admin, or an authorized caller.
     pub fn record_progress(
         env: Env,
         caller: Address,
@@ -120,9 +162,14 @@ impl AnalyticsContract {
     ) {
         caller.require_auth();
         let admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
+        let is_authorized: bool = env
+            .storage()
+            .instance()
+            .get(&DataKey::AuthorizedCaller(caller.clone()))
+            .unwrap_or(false);
         assert!(
-            caller == student || caller == admin,
-            "Unauthorized: must be student or admin"
+            caller == student || caller == admin || is_authorized,
+            "Unauthorized: must be student, admin, or authorized caller"
         );
         assert!(progress_pct <= 100, "Progress must be 0-100");
 
@@ -156,6 +203,21 @@ impl AnalyticsContract {
         env.storage()
             .persistent()
             .extend_ttl(&index_key, TTL_THRESHOLD, TTL_EXTEND_TO);
+
+        // Update reverse index: course → [students]
+        let course_index_key = DataKey::CourseStudents(course_id.clone());
+        let mut students: Vec<Address> = env
+            .storage()
+            .persistent()
+            .get(&course_index_key)
+            .unwrap_or_else(|| vec![&env]);
+        if !students.contains(&student) {
+            students.push_back(student.clone());
+            env.storage().persistent().set(&course_index_key, &students);
+            env.storage()
+                .persistent()
+                .extend_ttl(&course_index_key, TTL_THRESHOLD, TTL_EXTEND_TO);
+        }
 
         // Check and record milestone achievements
         Self::check_milestones(&env, &student, &course_id, progress_pct);
@@ -377,7 +439,7 @@ impl AnalyticsContract {
         assert!(admin == stored_admin, "Only admin can update aggregates");
 
         // Update completion stats
-        let mut stats = CompletionStats {
+        let stats = CompletionStats {
             total_completions: 0,
             avg_completion_rate: 0,
         };
@@ -392,6 +454,65 @@ impl AnalyticsContract {
             (symbol_short!("analytics"), symbol_short!("agg_upd")),
             stats.total_completions,
         );
+    }
+
+    // -------------------------------------------------------------------------
+    // Course-level aggregation queries
+    // -------------------------------------------------------------------------
+
+    /// Get all students enrolled in a course (via reverse index).
+    pub fn get_students_by_course(env: Env, course_id: Symbol) -> Vec<Address> {
+        let key = DataKey::CourseStudents(course_id);
+        match env.storage().persistent().get(&key) {
+            Some(students) => {
+                env.storage()
+                    .persistent()
+                    .extend_ttl(&key, TTL_THRESHOLD, TTL_EXTEND_TO);
+                students
+            }
+            None => vec![&env],
+        }
+    }
+
+    /// Get all progress records for a specific course across all enrolled students.
+    pub fn get_course_progress(env: Env, course_id: Symbol) -> Vec<ProgressRecord> {
+        let students = Self::get_students_by_course(env.clone(), course_id.clone());
+        let mut results = vec![&env];
+        for student in students.iter() {
+            let key = DataKey::Progress(student.clone(), course_id.clone());
+            if let Some(record) = env.storage().persistent().get::<DataKey, ProgressRecord>(&key) {
+                env.storage()
+                    .persistent()
+                    .extend_ttl(&key, TTL_THRESHOLD, TTL_EXTEND_TO);
+                results.push_back(record);
+            }
+        }
+        results
+    }
+
+    /// Get the number of students who completed a course.
+    pub fn get_course_completion_count(env: Env, course_id: Symbol) -> u32 {
+        let records = Self::get_course_progress(env, course_id);
+        let mut count: u32 = 0;
+        for record in records.iter() {
+            if record.completed {
+                count += 1;
+            }
+        }
+        count
+    }
+
+    /// Get the average progress percentage across all students in a course.
+    pub fn get_course_average_progress(env: Env, course_id: Symbol) -> u32 {
+        let records = Self::get_course_progress(env, course_id);
+        if records.len() == 0 {
+            return 0;
+        }
+        let mut total: u64 = 0;
+        for record in records.iter() {
+            total += record.progress_pct as u64;
+        }
+        (total / records.len() as u64) as u32
     }
 
     // -------------------------------------------------------------------------

--- a/contracts/certificate/src/lib.rs
+++ b/contracts/certificate/src/lib.rs
@@ -14,6 +14,8 @@ pub enum DataKey {
     OwnerCertificates(Address),          // owner → Vec<u64>
     NextId,                              // u64 counter
     Revocation(u64),                     // id → RevocationRecord
+    Transferable(u64),                   // id → bool (opt-in transferability)
+    CertificateMetadata(u64),            // id → CertificateMetadata (extended metadata)
 }
 
 // =============================================================================
@@ -38,12 +40,24 @@ pub struct RevocationRecord {
     pub reason: String,
 }
 
+/// Extended on-chain metadata for a certificate (optional, set by admin).
+#[contracttype]
+#[derive(Clone)]
+pub struct CertificateMetadata {
+    pub certificate_id: u64,
+    pub issuer_name: String,
+    pub skills: String,       // comma-separated skill tags
+    pub grade: String,        // e.g. "A", "Pass", "Distinction"
+    pub expiry_timestamp: u64, // 0 = no expiry
+}
+
 // =============================================================================
 // Events
 // =============================================================================
 
 const MINT: Symbol = symbol_short!("mint");
 const REVOKE: Symbol = symbol_short!("revoke");
+const TRANSFER: Symbol = symbol_short!("transfer");
 
 // =============================================================================
 // Contract
@@ -195,11 +209,164 @@ impl CertificateContract {
     }
 
     // -------------------------------------------------------------------------
-    // Transfer (soulbound — panics)
+    // Transfer
     // -------------------------------------------------------------------------
 
-    pub fn transfer(_env: Env, _from: Address, _to: Address, _id: u64) {
-        panic!("soulbound");
+    /// Enable transferability for a specific certificate (admin only).
+    /// By default certificates are soulbound; this opt-in allows transfer.
+    pub fn enable_transfer(env: Env, admin: Address, cert_id: u64) {
+        admin.require_auth();
+        let stored_admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
+        assert!(admin == stored_admin, "Only admin can enable transfer");
+        assert!(
+            env.storage().persistent().has(&DataKey::Certificate(cert_id)),
+            "Certificate not found"
+        );
+        env.storage()
+            .persistent()
+            .set(&DataKey::Transferable(cert_id), &true);
+    }
+
+    /// Transfer a certificate from `from` to `to`.
+    /// Requires the certificate to have transferability enabled and not be revoked.
+    pub fn transfer(env: Env, from: Address, to: Address, cert_id: u64) {
+        from.require_auth();
+
+        let transferable: bool = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Transferable(cert_id))
+            .unwrap_or(false);
+        assert!(transferable, "Certificate is soulbound and cannot be transferred");
+        assert!(
+            !env.storage().persistent().has(&DataKey::Revocation(cert_id)),
+            "Revoked certificate cannot be transferred"
+        );
+
+        let mut cert: CertificateRecord = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Certificate(cert_id))
+            .expect("Certificate not found");
+
+        assert!(cert.owner == from, "Caller is not the certificate owner");
+
+        // Remove from sender's list
+        let from_key = DataKey::OwnerCertificates(from.clone());
+        if let Some(mut ids) = env
+            .storage()
+            .persistent()
+            .get::<DataKey, soroban_sdk::Vec<u64>>(&from_key)
+        {
+            let pos = ids.iter().position(|id| id == cert_id);
+            if let Some(i) = pos {
+                ids.remove(i as u32);
+                env.storage().persistent().set(&from_key, &ids);
+            }
+        }
+
+        // Add to recipient's list
+        let to_key = DataKey::OwnerCertificates(to.clone());
+        let mut to_ids: soroban_sdk::Vec<u64> = env
+            .storage()
+            .persistent()
+            .get(&to_key)
+            .unwrap_or_else(|| soroban_sdk::vec![&env]);
+        to_ids.push_back(cert_id);
+        env.storage().persistent().set(&to_key, &to_ids);
+
+        // Update owner
+        cert.owner = to.clone();
+        env.storage()
+            .persistent()
+            .set(&DataKey::Certificate(cert_id), &cert);
+
+        env.events()
+            .publish((TRANSFER, symbol_short!("from"), from), (to, cert_id));
+    }
+
+    // -------------------------------------------------------------------------
+    // Metadata storage
+    // -------------------------------------------------------------------------
+
+    /// Store extended metadata for a certificate (admin only).
+    pub fn set_metadata(
+        env: Env,
+        admin: Address,
+        cert_id: u64,
+        issuer_name: String,
+        skills: String,
+        grade: String,
+        expiry_timestamp: u64,
+    ) {
+        admin.require_auth();
+        let stored_admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
+        assert!(admin == stored_admin, "Only admin can set metadata");
+        assert!(
+            env.storage().persistent().has(&DataKey::Certificate(cert_id)),
+            "Certificate not found"
+        );
+
+        let metadata = CertificateMetadata {
+            certificate_id: cert_id,
+            issuer_name,
+            skills,
+            grade,
+            expiry_timestamp,
+        };
+        env.storage()
+            .persistent()
+            .set(&DataKey::CertificateMetadata(cert_id), &metadata);
+    }
+
+    pub fn get_metadata(env: Env, cert_id: u64) -> Option<CertificateMetadata> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::CertificateMetadata(cert_id))
+    }
+
+    // -------------------------------------------------------------------------
+    // Queries
+    // -------------------------------------------------------------------------
+
+    /// Check whether a certificate is valid (exists, not revoked, not expired).
+    pub fn is_valid(env: Env, cert_id: u64) -> bool {
+        if !env.storage().persistent().has(&DataKey::Certificate(cert_id)) {
+            return false;
+        }
+        if env.storage().persistent().has(&DataKey::Revocation(cert_id)) {
+            return false;
+        }
+        // Check expiry if metadata exists
+        if let Some(meta) = env
+            .storage()
+            .persistent()
+            .get::<DataKey, CertificateMetadata>(&DataKey::CertificateMetadata(cert_id))
+        {
+            if meta.expiry_timestamp > 0 && env.ledger().timestamp() > meta.expiry_timestamp {
+                return false;
+            }
+        }
+        true
+    }
+
+    /// Count certificates owned by an address.
+    pub fn count_certificates(env: Env, owner: Address) -> u32 {
+        let key = DataKey::OwnerCertificates(owner);
+        let ids: soroban_sdk::Vec<u64> = env
+            .storage()
+            .persistent()
+            .get(&key)
+            .unwrap_or_else(|| soroban_sdk::vec![&env]);
+        ids.len() as u32
+    }
+
+    /// Check whether a certificate is transferable.
+    pub fn is_transferable(env: Env, cert_id: u64) -> bool {
+        env.storage()
+            .persistent()
+            .get(&DataKey::Transferable(cert_id))
+            .unwrap_or(false)
     }
 }
 
@@ -305,7 +472,7 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "soulbound")]
+    #[should_panic(expected = "Certificate is soulbound and cannot be transferred")]
     fn test_transfer_panics() {
         let (env, client, admin) = setup();
         let owner = Address::generate(&env);

--- a/contracts/governance/src/lib.rs
+++ b/contracts/governance/src/lib.rs
@@ -413,6 +413,85 @@ impl GovernanceContract {
             .persistent()
             .has(&DataKey::Vote(proposal_id, voter))
     }
+
+    // -------------------------------------------------------------------------
+    // Voting power calculation
+    // -------------------------------------------------------------------------
+
+    /// Get the voting power (BST balance) of an address via cross-contract call.
+    pub fn get_voting_power(env: Env, voter: Address) -> i128 {
+        let token_contract: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::TokenContract)
+            .unwrap();
+        env.invoke_contract(
+            &token_contract,
+            &symbol_short!("balance"),
+            soroban_sdk::vec![&env, voter.into_val(&env)],
+        )
+    }
+
+    /// Check whether a voter meets the minimum voting power threshold.
+    pub fn has_voting_power(env: Env, voter: Address, min_power: i128) -> bool {
+        Self::get_voting_power(env, voter) >= min_power
+    }
+
+    // -------------------------------------------------------------------------
+    // Governance queries
+    // -------------------------------------------------------------------------
+
+    /// Get the current vote tally for a proposal.
+    /// Returns (votes_for, votes_against, total, quorum_met).
+    pub fn get_vote_tally(env: Env, proposal_id: u64) -> (i128, i128, i128, bool) {
+        let proposal: ProposalRecord = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Proposal(proposal_id))
+            .expect("Proposal not found");
+        let total = proposal.votes_for + proposal.votes_against;
+        // Quorum: total votes must exceed 20% of token supply (approximated via votes_for > 0)
+        // In production this would compare against total token supply
+        let quorum_met = proposal.votes_for > proposal.votes_against && total > 0;
+        (proposal.votes_for, proposal.votes_against, total, quorum_met)
+    }
+
+    /// Check whether a proposal passed (voting ended, votes_for > votes_against).
+    pub fn did_proposal_pass(env: Env, proposal_id: u64) -> bool {
+        let proposal: ProposalRecord = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Proposal(proposal_id))
+            .expect("Proposal not found");
+        env.ledger().sequence() >= proposal.voting_end_ledger
+            && proposal.votes_for > proposal.votes_against
+    }
+
+    /// Check whether a proposal's voting period is still active.
+    pub fn is_voting_active(env: Env, proposal_id: u64) -> bool {
+        let proposal: ProposalRecord = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Proposal(proposal_id))
+            .expect("Proposal not found");
+        env.ledger().sequence() < proposal.voting_end_ledger && !proposal.executed
+    }
+
+    /// Get the next proposal ID (useful for off-chain indexing).
+    pub fn get_next_proposal_id(env: Env) -> u64 {
+        env.storage()
+            .instance()
+            .get(&DataKey::NextProposalId)
+            .unwrap_or(1)
+    }
+
+    /// Get the vote cast by a specific voter on a proposal.
+    /// Returns Some(true) = voted for, Some(false) = voted against, None = not voted.
+    pub fn get_vote(env: Env, proposal_id: u64, voter: Address) -> Option<bool> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::Vote(proposal_id, voter))
+    }
 }
 
 // =============================================================================

--- a/contracts/token/src/lib.rs
+++ b/contracts/token/src/lib.rs
@@ -613,6 +613,106 @@ impl TokenContract {
     }
 
     // -------------------------------------------------------------------------
+    // Staking pool management
+    // -------------------------------------------------------------------------
+
+    /// Configure the staking reward rate (admin only). Rate is in basis points per ledger
+    /// e.g. 500 = 0.005% per ledger.
+    pub fn set_reward_rate(env: Env, admin: Address, rate: i128) {
+        admin.require_auth();
+        let stored_admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
+        assert!(admin == stored_admin, "Only admin can set reward rate");
+        assert!(rate >= 0, "Rate must be non-negative");
+        env.storage()
+            .instance()
+            .set(&staking::StakingKey::RewardRate, &rate);
+    }
+
+    /// Configure the early withdrawal penalty (admin only). Penalty in basis points.
+    pub fn set_early_withdrawal_penalty(env: Env, admin: Address, penalty: i128) {
+        admin.require_auth();
+        let stored_admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
+        assert!(admin == stored_admin, "Only admin can set penalty");
+        assert!(penalty >= 0 && penalty <= 10_000, "Penalty must be 0-10000 bps");
+        env.storage()
+            .instance()
+            .set(&staking::StakingKey::EarlyWithdrawalPenalty, &penalty);
+    }
+
+    /// Stake tokens. Locks `amount` from the caller's balance for `lock_periods`.
+    pub fn stake(env: Env, staker: Address, amount: i128, lock_periods: u32) {
+        assert!(amount > 0, "Stake amount must be positive");
+        let bal = Self::balance(env.clone(), staker.clone());
+        assert!(bal >= amount, "Insufficient balance to stake");
+
+        // Deduct from balance
+        Self::sub_balance(&env, &staker, amount);
+
+        staking::stake(&env, staker, amount, lock_periods);
+    }
+
+    /// Withdraw staked tokens. Pass `early = true` to withdraw before lock expiry (penalty applies).
+    pub fn unstake(env: Env, staker: Address, early: bool) {
+        let withdrawal_amount = staking::withdraw(&env, staker.clone(), early);
+        // Mint the withdrawal amount back to the staker
+        Self::add_balance(&env, &staker, withdrawal_amount);
+    }
+
+    /// Claim accumulated staking rewards without unstaking.
+    pub fn claim_staking_rewards(env: Env, staker: Address) {
+        let rewards = staking::claim_rewards(&env, staker.clone());
+        assert!(rewards > 0, "No rewards to claim");
+        Self::add_balance(&env, &staker, rewards);
+        Self::add_supply(&env, rewards);
+    }
+
+    /// Emergency withdrawal: admin can force-return staked tokens to a staker (no rewards, no penalty).
+    pub fn emergency_withdraw(env: Env, admin: Address, staker: Address) {
+        admin.require_auth();
+        let stored_admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
+        assert!(admin == stored_admin, "Only admin can emergency withdraw");
+
+        let record = staking::get_stake(&env, staker.clone())
+            .expect("No stake found for staker");
+
+        // Remove stake record and return principal only
+        env.storage()
+            .instance()
+            .remove(&staking::StakingKey::Stake(staker.clone()));
+
+        let total_staked: i128 = env
+            .storage()
+            .instance()
+            .get(&staking::StakingKey::TotalStaked)
+            .unwrap_or(0);
+        env.storage()
+            .instance()
+            .set(&staking::StakingKey::TotalStaked, &(total_staked - record.amount));
+
+        Self::add_balance(&env, &staker, record.amount);
+
+        env.events().publish(
+            (symbol_short!("emerg_wd"),),
+            (staker, record.amount),
+        );
+    }
+
+    /// Get a staker's current stake record.
+    pub fn get_stake(env: Env, staker: Address) -> Option<staking::StakeRecord> {
+        staking::get_stake(&env, staker)
+    }
+
+    /// Get total tokens currently staked in the pool.
+    pub fn get_total_staked(env: Env) -> i128 {
+        staking::get_total_staked(&env)
+    }
+
+    /// Calculate pending rewards for a staker without claiming.
+    pub fn get_pending_rewards(env: Env, staker: Address) -> i128 {
+        staking::calculate_rewards(&env, &staker)
+    }
+
+    // -------------------------------------------------------------------------
     // Legacy mint_reward (kept for backward compat)
     // -------------------------------------------------------------------------
 

--- a/contracts/token/src/staking.rs
+++ b/contracts/token/src/staking.rs
@@ -1,4 +1,4 @@
-use soroban_sdk::{contracttype, Address, Env, Symbol, symbol_short, i128};
+use soroban_sdk::{contracttype, Address, Env, Symbol, symbol_short};
 
 #[contracttype]
 #[derive(Clone)]


### PR DESCRIPTION
## Summary

Implements issues #466, #467, #468, #469.

Closes #466 Token — Staking Pool
- Expose stake/unstake/emergency_withdraw
- Reward distribution: set_reward_rate, claim_staking_rewards, get_pending_rewards
- Admin force-return principal via emergency withdrawal
- Fix incorrect i128 import in staking.rs

Closes #467 Analytics — Access Controls & Course Aggregation
- Authorized caller access control (authorize_caller/revoke_caller/is_authorized_caller)
- Course→students reverse index (CourseStudents key)
- Course-level queries: get_students_by_course, get_course_progress, get_course_completion_count, get_course_average_progress

Closes #468 Certificate — Transfer & Metadata
- Opt-in transferability (enable_transfer/transfer)
- Extended metadata storage (CertificateMetadata, set_metadata/get_metadata)
- Queries: is_valid, count_certificates, is_transferable

Closes #469 Governance — Voting Power & Queries
- get_voting_power, has_voting_power
- get_vote_tally, did_proposal_pass, is_voting_active, get_next_proposal_id, get_vote