### PR TITLE
feat: Stellar wallet integration, transaction UI, multi-wallet support & gamification dashboard

### DIFF
--- a/apps/frontend/src/__tests__/components/gamification/GamificationComponents.test.tsx
+++ b/apps/frontend/src/__tests__/components/gamification/GamificationComponents.test.tsx
@@ -1,0 +1,64 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { XpProgress } from '@/components/gamification/XpProgress';
+import { StreakIndicator } from '@/components/gamification/StreakIndicator';
+import { BadgeGrid } from '@/components/gamification/BadgeGrid';
+import type { Badge } from '@/components/gamification/BadgeGrid';
+
+describe('XpProgress', () => {
+  it('renders level and xp values', () => {
+    render(<XpProgress xp={250} level={3} xpForNextLevel={500} />);
+    expect(screen.getByText('Level 3')).toBeInTheDocument();
+    expect(screen.getByText('250 / 500 XP')).toBeInTheDocument();
+  });
+
+  it('calculates percentage correctly', () => {
+    render(<XpProgress xp={50} level={1} xpForNextLevel={100} />);
+    const bar = screen.getByRole('progressbar');
+    expect(bar).toHaveAttribute('aria-valuenow', '50');
+  });
+
+  it('clamps percentage at 100', () => {
+    render(<XpProgress xp={1000} level={10} xpForNextLevel={1000} />);
+    const bar = screen.getByRole('progressbar');
+    expect(bar).toHaveAttribute('aria-valuenow', '100');
+  });
+});
+
+describe('StreakIndicator', () => {
+  it('renders current streak and best streak', () => {
+    render(<StreakIndicator streak={7} longestStreak={21} />);
+    expect(screen.getByText('7')).toBeInTheDocument();
+    expect(screen.getByText('21')).toBeInTheDocument();
+    expect(screen.getByText('day streak')).toBeInTheDocument();
+    expect(screen.getByText('best streak')).toBeInTheDocument();
+  });
+
+  it('renders zero streak gracefully', () => {
+    render(<StreakIndicator streak={0} longestStreak={0} />);
+    expect(screen.getAllByText('0')).toHaveLength(2);
+  });
+});
+
+describe('BadgeGrid', () => {
+  const badges: Badge[] = [
+    { id: '1', name: 'First Steps', description: 'Complete lesson', icon: '⭐', unlockedAt: '2026-01-01T00:00:00Z' },
+    { id: '2', name: 'Scholar', description: 'Complete 10 courses', icon: '🎓', unlockedAt: null },
+  ];
+
+  it('renders all badges', () => {
+    render(<BadgeGrid badges={badges} />);
+    expect(screen.getByText('First Steps')).toBeInTheDocument();
+    expect(screen.getByText('Scholar')).toBeInTheDocument();
+  });
+
+  it('shows empty state when no badges', () => {
+    render(<BadgeGrid badges={[]} />);
+    expect(screen.getByText(/no badges yet/i)).toBeInTheDocument();
+  });
+
+  it('shows unlock date for unlocked badges', () => {
+    render(<BadgeGrid badges={badges} />);
+    expect(screen.getByText('1/1/2026')).toBeInTheDocument();
+  });
+});

--- a/apps/frontend/src/__tests__/components/wallet/TransactionModal.test.tsx
+++ b/apps/frontend/src/__tests__/components/wallet/TransactionModal.test.tsx
@@ -1,0 +1,59 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { TransactionModal } from '@/components/wallet/TransactionModal';
+
+// Stub the wallet hook
+vi.mock('@/hooks/useWallet', () => ({
+  useWallet: () => ({ walletType: 'freighter', address: 'GABC1234' }),
+}));
+
+// Stub toast
+vi.mock('@/lib/toast', () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
+
+describe('TransactionModal', () => {
+  const onClose = vi.fn();
+  const onSuccess = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders in build step with description', () => {
+    render(
+      <TransactionModal
+        xdr="AAAA=="
+        description="Enroll in course"
+        onClose={onClose}
+        onSuccess={onSuccess}
+      />
+    );
+    expect(screen.getByText('Review Transaction')).toBeInTheDocument();
+    expect(screen.getByText('Enroll in course')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /sign/i })).toBeInTheDocument();
+  });
+
+  it('shows the signing address', () => {
+    render(<TransactionModal xdr="AAAA==" onClose={onClose} />);
+    expect(screen.getByText('GABC1234')).toBeInTheDocument();
+  });
+
+  it('calls onClose when Cancel is clicked in build step', () => {
+    render(<TransactionModal xdr="AAAA==" onClose={onClose} />);
+    fireEvent.click(screen.getByRole('button', { name: /cancel/i }));
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('closes on Escape key in build step', () => {
+    render(<TransactionModal xdr="AAAA==" onClose={onClose} />);
+    fireEvent.keyDown(document, { key: 'Escape' });
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('renders step indicator with four steps', () => {
+    render(<TransactionModal xdr="AAAA==" onClose={onClose} />);
+    expect(screen.getByText('Review')).toBeInTheDocument();
+    expect(screen.getByText('Sign')).toBeInTheDocument();
+    expect(screen.getByText('Submit')).toBeInTheDocument();
+    expect(screen.getByText('Done')).toBeInTheDocument();
+  });
+});

--- a/apps/frontend/src/__tests__/hooks/useWallet.test.ts
+++ b/apps/frontend/src/__tests__/hooks/useWallet.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useWallet } from '@/hooks/useWallet';
+
+vi.mock('@/lib/walletApi', () => ({
+  isFreighterInstalled: vi.fn(() => true),
+  connectFreighter: vi.fn(() => Promise.resolve({ publicKey: 'GPUBKEY', network: 'testnet' })),
+  fetchXlmBalance: vi.fn(() => Promise.resolve('100.0')),
+  fetchBstBalance: vi.fn(() => Promise.resolve('50.0')),
+  truncateAddress: (addr: string) => `${addr.slice(0, 4)}…${addr.slice(-4)}`,
+}));
+
+vi.mock('@/lib/walletAdapters', () => ({
+  connectAlbedo: vi.fn(),
+  connectXbull: vi.fn(),
+  SUPPORTED_WALLETS: [],
+}));
+
+// Reset Zustand store between tests
+beforeEach(async () => {
+  const { useWalletStore } = await import('@/store/walletStore');
+  useWalletStore.getState().disconnect();
+});
+
+describe('useWallet', () => {
+  it('starts disconnected', () => {
+    const { result } = renderHook(() => useWallet());
+    expect(result.current.isConnected).toBe(false);
+    expect(result.current.address).toBeNull();
+  });
+
+  it('connects with freighter and populates address and balances', async () => {
+    const { result } = renderHook(() => useWallet());
+
+    await act(async () => {
+      await result.current.connect('freighter');
+    });
+
+    expect(result.current.isConnected).toBe(true);
+    expect(result.current.address).toBe('GPUBKEY');
+    expect(result.current.balance).toBe('100.0');
+    expect(result.current.bstBalance).toBe('50.0');
+    expect(result.current.network).toBe('testnet');
+  });
+
+  it('truncates address', async () => {
+    const { result } = renderHook(() => useWallet());
+
+    await act(async () => {
+      await result.current.connect('freighter');
+    });
+
+    expect(result.current.truncatedAddress).toBe('GPUB…BKEY');
+  });
+
+  it('disconnects and clears state', async () => {
+    const { result } = renderHook(() => useWallet());
+
+    await act(async () => {
+      await result.current.connect('freighter');
+    });
+
+    act(() => {
+      result.current.disconnect();
+    });
+
+    expect(result.current.isConnected).toBe(false);
+    expect(result.current.address).toBeNull();
+    expect(result.current.balance).toBeNull();
+  });
+
+  it('sets error when freighter not installed', async () => {
+    const walletApi = await import('@/lib/walletApi');
+    vi.mocked(walletApi.isFreighterInstalled).mockReturnValueOnce(false);
+
+    const { result } = renderHook(() => useWallet());
+
+    await act(async () => {
+      await result.current.connect('freighter');
+    });
+
+    expect(result.current.error).toBe('FREIGHTER_NOT_INSTALLED');
+    expect(result.current.isConnected).toBe(false);
+  });
+
+  it('clears error on clearError', async () => {
+    const walletApi = await import('@/lib/walletApi');
+    vi.mocked(walletApi.isFreighterInstalled).mockReturnValueOnce(false);
+
+    const { result } = renderHook(() => useWallet());
+
+    await act(async () => {
+      await result.current.connect('freighter');
+    });
+
+    act(() => {
+      result.current.clearError();
+    });
+
+    expect(result.current.error).toBeNull();
+  });
+});

--- a/apps/frontend/src/components/gamification/BadgeGrid.stories.tsx
+++ b/apps/frontend/src/components/gamification/BadgeGrid.stories.tsx
@@ -1,0 +1,31 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { BadgeGrid } from './BadgeGrid';
+import type { Badge } from './BadgeGrid';
+
+const meta: Meta<typeof BadgeGrid> = {
+  title: 'Gamification/BadgeGrid',
+  component: BadgeGrid,
+  parameters: { layout: 'padded' },
+  tags: ['autodocs'],
+};
+export default meta;
+
+type Story = StoryObj<typeof BadgeGrid>;
+
+const SAMPLE: Badge[] = [
+  { id: '1', name: 'First Steps', description: 'Complete your first lesson', icon: '⭐', unlockedAt: '2026-01-15T00:00:00Z' },
+  { id: '2', name: 'On Fire', description: '7-day streak', icon: '🔥', unlockedAt: '2026-02-01T00:00:00Z' },
+  { id: '3', name: 'Scholar', description: 'Complete 10 courses', icon: '🎓', unlockedAt: null },
+  { id: '4', name: 'Voter', description: 'Cast your first governance vote', icon: '🗳️', unlockedAt: null },
+  { id: '5', name: 'Mentor', description: 'Help 5 peers in the forum', icon: '🤝', unlockedAt: null },
+];
+
+export const PartialUnlock: Story = { args: { badges: SAMPLE } };
+
+export const AllUnlocked: Story = {
+  args: {
+    badges: SAMPLE.map((b) => ({ ...b, unlockedAt: b.unlockedAt ?? '2026-03-01T00:00:00Z' })),
+  },
+};
+
+export const Empty: Story = { args: { badges: [] } };

--- a/apps/frontend/src/components/gamification/BadgeGrid.tsx
+++ b/apps/frontend/src/components/gamification/BadgeGrid.tsx
@@ -1,0 +1,68 @@
+'use client';
+
+export interface Badge {
+  id: string;
+  name: string;
+  description: string;
+  icon: string;
+  unlockedAt: string | null;
+}
+
+interface BadgeGridProps {
+  badges: Badge[];
+}
+
+export function BadgeGrid({ badges }: BadgeGridProps) {
+  if (badges.length === 0) {
+    return (
+      <p className="text-sm text-gray-500 py-4 text-center">
+        No badges yet — keep learning to earn your first one!
+      </p>
+    );
+  }
+
+  return (
+    <ul
+      className="grid grid-cols-3 sm:grid-cols-4 md:grid-cols-6 gap-4"
+      role="list"
+      aria-label="Badges"
+    >
+      {badges.map((badge) => {
+        const unlocked = badge.unlockedAt !== null;
+        return (
+          <li key={badge.id} title={badge.description}>
+            <div
+              className={`flex flex-col items-center gap-1 p-2 rounded-lg transition-colors ${
+                unlocked
+                  ? 'cursor-default'
+                  : 'opacity-40 grayscale cursor-not-allowed'
+              }`}
+            >
+              <span
+                className={`text-3xl ${
+                  unlocked
+                    ? 'motion-safe:animate-[pop-in_0.3s_ease-out]'
+                    : ''
+                }`}
+                aria-hidden="true"
+              >
+                {badge.icon}
+              </span>
+              <p className="text-xs text-center text-gray-700 dark:text-gray-300 leading-tight line-clamp-2">
+                {badge.name}
+              </p>
+              {unlocked && badge.unlockedAt && (
+                <time
+                  dateTime={badge.unlockedAt}
+                  className="text-[10px] text-gray-400"
+                >
+                  {new Date(badge.unlockedAt).toLocaleDateString()}
+                </time>
+              )}
+            </div>
+          </li>
+        );
+      })}
+    </ul>
+  );
+}

--- a/apps/frontend/src/components/gamification/GamificationDashboard.stories.tsx
+++ b/apps/frontend/src/components/gamification/GamificationDashboard.stories.tsx
@@ -1,0 +1,16 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { XpProgress } from './XpProgress';
+
+const meta: Meta<typeof XpProgress> = {
+  title: 'Gamification/XpProgress',
+  component: XpProgress,
+  parameters: { layout: 'padded' },
+  tags: ['autodocs'],
+};
+export default meta;
+
+type Story = StoryObj<typeof XpProgress>;
+
+export const EarlyLevel: Story = { args: { xp: 40, level: 1, xpForNextLevel: 100 } };
+export const MidLevel: Story = { args: { xp: 820, level: 5, xpForNextLevel: 1000 } };
+export const MaxProgress: Story = { args: { xp: 1000, level: 10, xpForNextLevel: 1000 } };

--- a/apps/frontend/src/components/gamification/GamificationDashboard.tsx
+++ b/apps/frontend/src/components/gamification/GamificationDashboard.tsx
@@ -1,0 +1,69 @@
+'use client';
+
+import { useGamification } from '@/hooks/useGamification';
+import { XpProgress } from './XpProgress';
+import { StreakIndicator } from './StreakIndicator';
+import { BadgeGrid } from './BadgeGrid';
+
+interface GamificationDashboardProps {
+  userId: string;
+}
+
+export function GamificationDashboard({ userId }: GamificationDashboardProps) {
+  const { data, isLoading, error, refresh } = useGamification(userId);
+
+  if (isLoading) {
+    return (
+      <div className="space-y-6 animate-pulse" aria-busy="true" aria-label="Loading gamification data">
+        <div className="h-10 bg-gray-200 dark:bg-gray-700 rounded-lg w-3/4" />
+        <div className="h-6 bg-gray-200 dark:bg-gray-700 rounded-lg" />
+        <div className="grid grid-cols-3 gap-4">
+          {Array.from({ length: 6 }).map((_, i) => (
+            <div key={i} className="h-20 bg-gray-200 dark:bg-gray-700 rounded-lg" />
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="text-center py-8 space-y-3">
+        <p className="text-sm text-red-600">{error}</p>
+        <button
+          className="text-sm text-blue-600 underline"
+          onClick={refresh}
+        >
+          Retry
+        </button>
+      </div>
+    );
+  }
+
+  if (!data) return null;
+
+  return (
+    <div className="space-y-8">
+      <section aria-label="XP and level">
+        <h3 className="text-sm font-semibold text-gray-500 uppercase tracking-wide mb-3">
+          Level Progress
+        </h3>
+        <XpProgress xp={data.xp} level={data.level} xpForNextLevel={data.xpForNextLevel} />
+      </section>
+
+      <section aria-label="Streak">
+        <h3 className="text-sm font-semibold text-gray-500 uppercase tracking-wide mb-3">
+          Learning Streak
+        </h3>
+        <StreakIndicator streak={data.streak} longestStreak={data.longestStreak} />
+      </section>
+
+      <section aria-label="Badges">
+        <h3 className="text-sm font-semibold text-gray-500 uppercase tracking-wide mb-3">
+          Badges
+        </h3>
+        <BadgeGrid badges={data.badges} />
+      </section>
+    </div>
+  );
+}

--- a/apps/frontend/src/components/gamification/StreakIndicator.stories.tsx
+++ b/apps/frontend/src/components/gamification/StreakIndicator.stories.tsx
@@ -1,0 +1,16 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { StreakIndicator } from './StreakIndicator';
+
+const meta: Meta<typeof StreakIndicator> = {
+  title: 'Gamification/StreakIndicator',
+  component: StreakIndicator,
+  parameters: { layout: 'padded' },
+  tags: ['autodocs'],
+};
+export default meta;
+
+type Story = StoryObj<typeof StreakIndicator>;
+
+export const ActiveStreak: Story = { args: { streak: 7, longestStreak: 21 } };
+export const NoStreak: Story = { args: { streak: 0, longestStreak: 5 } };
+export const LongStreak: Story = { args: { streak: 100, longestStreak: 150 } };

--- a/apps/frontend/src/components/gamification/StreakIndicator.tsx
+++ b/apps/frontend/src/components/gamification/StreakIndicator.tsx
@@ -1,0 +1,30 @@
+'use client';
+
+interface StreakIndicatorProps {
+  streak: number;
+  longestStreak: number;
+}
+
+export function StreakIndicator({ streak, longestStreak }: StreakIndicatorProps) {
+  return (
+    <div className="flex items-center gap-6">
+      <div className="flex items-center gap-2">
+        <span
+          className="text-2xl motion-reduce:animate-none animate-[pulse_2s_ease-in-out_infinite]"
+          aria-hidden="true"
+        >
+          🔥
+        </span>
+        <div>
+          <p className="text-2xl font-bold leading-none">{streak}</p>
+          <p className="text-xs text-gray-500">day streak</p>
+        </div>
+      </div>
+      <div className="h-8 w-px bg-gray-200 dark:bg-gray-700" aria-hidden="true" />
+      <div>
+        <p className="text-lg font-semibold leading-none">{longestStreak}</p>
+        <p className="text-xs text-gray-500">best streak</p>
+      </div>
+    </div>
+  );
+}

--- a/apps/frontend/src/components/gamification/XpProgress.tsx
+++ b/apps/frontend/src/components/gamification/XpProgress.tsx
@@ -1,0 +1,43 @@
+'use client';
+
+interface XpProgressProps {
+  xp: number;
+  level: number;
+  xpForNextLevel: number;
+}
+
+export function XpProgress({ xp, level, xpForNextLevel }: XpProgressProps) {
+  const pct = xpForNextLevel > 0 ? Math.min(100, Math.round((xp / xpForNextLevel) * 100)) : 100;
+
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <span className="inline-flex items-center justify-center w-9 h-9 rounded-full bg-blue-600 text-white text-sm font-bold">
+            {level}
+          </span>
+          <div>
+            <p className="text-sm font-semibold leading-none">Level {level}</p>
+            <p className="text-xs text-gray-500">
+              {xp.toLocaleString()} / {xpForNextLevel.toLocaleString()} XP
+            </p>
+          </div>
+        </div>
+        <p className="text-sm font-medium text-blue-600">{pct}%</p>
+      </div>
+      <div
+        role="progressbar"
+        aria-valuenow={pct}
+        aria-valuemin={0}
+        aria-valuemax={100}
+        aria-label={`Level ${level} progress: ${pct}%`}
+        className="w-full h-2.5 bg-gray-200 dark:bg-gray-700 rounded-full overflow-hidden"
+      >
+        <div
+          className="h-full bg-blue-600 rounded-full transition-all duration-500 motion-reduce:transition-none"
+          style={{ width: `${pct}%` }}
+        />
+      </div>
+    </div>
+  );
+}

--- a/apps/frontend/src/components/layout/Navbar.tsx
+++ b/apps/frontend/src/components/layout/Navbar.tsx
@@ -7,6 +7,7 @@ import { useAuth } from '@/hooks/useAuth';
 import { useNotifications } from '@/hooks/useNotifications';
 import { ThemeToggle } from '@/components/ThemeToggle';
 import { LanguageSwitcher } from '@/components/LanguageSwitcher';
+import { WalletButton } from '@/components/wallet/WalletButton';
 
 export function Navbar() {
   const pathname = usePathname();
@@ -77,6 +78,7 @@ export function Navbar() {
           {navLinks}
           <LanguageSwitcher />
           <ThemeToggle />
+          <WalletButton />
           {isAuthenticated && user ? (
             <div className="flex items-center gap-2">
               {/* Notification bell */}

--- a/apps/frontend/src/components/wallet/TransactionModal.tsx
+++ b/apps/frontend/src/components/wallet/TransactionModal.tsx
@@ -1,0 +1,256 @@
+'use client';
+
+import { useState, useEffect, useCallback } from 'react';
+import { useWallet } from '@/hooks/useWallet';
+import { toast } from '@/lib/toast';
+
+type TxStep = 'build' | 'sign' | 'submit' | 'confirmed' | 'failed';
+
+interface TransactionModalProps {
+  xdr: string;
+  description?: string;
+  onClose: () => void;
+  onSuccess?: (txHash: string) => void;
+}
+
+const HORIZON_BASE =
+  process.env.NEXT_PUBLIC_STELLAR_NETWORK === 'mainnet'
+    ? 'https://horizon.stellar.org'
+    : 'https://horizon-testnet.stellar.org';
+
+const EXPLORER_BASE =
+  process.env.NEXT_PUBLIC_STELLAR_NETWORK === 'mainnet'
+    ? 'https://stellar.expert/explorer/public/tx'
+    : 'https://stellar.expert/explorer/testnet/tx';
+
+const STEP_LABELS: Record<TxStep, string> = {
+  build: 'Review Transaction',
+  sign: 'Signing…',
+  submit: 'Submitting…',
+  confirmed: 'Confirmed',
+  failed: 'Failed',
+};
+
+async function submitToHorizon(signedXdr: string): Promise<string> {
+  const body = new URLSearchParams({ tx: signedXdr });
+  const res = await fetch(`${HORIZON_BASE}/transactions`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body,
+  });
+  const data = await res.json();
+  if (!res.ok) {
+    const code = data?.extras?.result_codes?.transaction;
+    if (code === 'tx_insufficient_balance') throw new Error('Insufficient balance.');
+    if (code === 'tx_bad_seq') throw new Error('Sequence number mismatch. Retry the transaction.');
+    throw new Error(data?.title || 'Transaction failed.');
+  }
+  return data.hash as string;
+}
+
+async function pollForConfirmation(txHash: string, signal: AbortSignal): Promise<void> {
+  const deadline = Date.now() + 30_000;
+  while (Date.now() < deadline) {
+    if (signal.aborted) throw new Error('Cancelled.');
+    const res = await fetch(`${HORIZON_BASE}/transactions/${txHash}`);
+    if (res.ok) return;
+    await new Promise((r) => setTimeout(r, 2000));
+  }
+  throw new Error('Confirmation timeout. Check explorer for status.');
+}
+
+export function TransactionModal({ xdr, description, onClose, onSuccess }: TransactionModalProps) {
+  const { walletType, address } = useWallet();
+  const [step, setStep] = useState<TxStep>('build');
+  const [txHash, setTxHash] = useState<string | null>(null);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'Escape' && step === 'build') onClose();
+    };
+    document.addEventListener('keydown', handler);
+    return () => document.removeEventListener('keydown', handler);
+  }, [onClose, step]);
+
+  const run = useCallback(async () => {
+    const ac = new AbortController();
+    try {
+      setStep('sign');
+      let signedXdr: string;
+
+      if (walletType === 'freighter') {
+        const { signWithFreighter } = await import('@/lib/walletApi');
+        const network = process.env.NEXT_PUBLIC_STELLAR_NETWORK === 'mainnet' ? 'MAINNET' : 'TESTNET';
+        signedXdr = await signWithFreighter(xdr, network);
+      } else if (walletType === 'albedo') {
+        const { signWithAlbedo } = await import('@/lib/walletAdapters');
+        signedXdr = await signWithAlbedo(xdr);
+      } else if (walletType === 'xbull') {
+        const { signWithXbull } = await import('@/lib/walletAdapters');
+        signedXdr = await signWithXbull(xdr);
+      } else {
+        throw new Error('No wallet connected.');
+      }
+
+      setStep('submit');
+      const hash = await submitToHorizon(signedXdr);
+      setTxHash(hash);
+
+      await pollForConfirmation(hash, ac.signal);
+      setStep('confirmed');
+      toast.success('Transaction confirmed.');
+      onSuccess?.(hash);
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : 'Unknown error.';
+      setErrorMessage(msg);
+      setStep('failed');
+      toast.error(msg);
+    }
+    return () => ac.abort();
+  }, [walletType, xdr, onSuccess]);
+
+  const isInProgress = step === 'sign' || step === 'submit';
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center"
+      role="dialog"
+      aria-modal="true"
+      aria-label="Transaction"
+    >
+      <div className="fixed inset-0 bg-black/50" onClick={step === 'build' ? onClose : undefined} aria-hidden="true" />
+      <div className="relative bg-white dark:bg-gray-800 rounded-xl shadow-xl w-full max-w-md mx-4 p-6 space-y-5">
+        {/* Header */}
+        <div className="flex items-center justify-between">
+          <h2 className="text-lg font-semibold">{STEP_LABELS[step]}</h2>
+          {!isInProgress && (
+            <button
+              onClick={onClose}
+              className="text-gray-400 hover:text-gray-600 dark:hover:text-gray-200"
+              aria-label="Close"
+            >
+              ✕
+            </button>
+          )}
+        </div>
+
+        {/* Step progress */}
+        <StepIndicator current={step} />
+
+        {/* Content */}
+        {step === 'build' && (
+          <div className="space-y-3">
+            {description && <p className="text-sm text-gray-600 dark:text-gray-300">{description}</p>}
+            <div className="bg-gray-50 dark:bg-gray-900 rounded-lg p-3">
+              <p className="text-xs text-gray-500 mb-1">Signing as</p>
+              <p className="font-mono text-xs break-all text-gray-700 dark:text-gray-300">{address}</p>
+            </div>
+            <div className="flex gap-2 pt-1">
+              <button
+                className="flex-1 border border-gray-200 dark:border-gray-600 rounded-lg py-2 text-sm hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors"
+                onClick={onClose}
+              >
+                Cancel
+              </button>
+              <button
+                className="flex-1 bg-blue-600 text-white rounded-lg py-2 text-sm hover:bg-blue-700 transition-colors"
+                onClick={run}
+              >
+                Sign &amp; Submit
+              </button>
+            </div>
+          </div>
+        )}
+
+        {isInProgress && (
+          <div className="flex flex-col items-center gap-3 py-4">
+            <span className="w-8 h-8 border-4 border-blue-600 border-t-transparent rounded-full animate-spin" aria-hidden="true" />
+            <p className="text-sm text-gray-500">
+              {step === 'sign' ? 'Waiting for wallet signature…' : 'Broadcasting transaction…'}
+            </p>
+          </div>
+        )}
+
+        {step === 'confirmed' && txHash && (
+          <div className="space-y-3 text-center">
+            <p className="text-green-600 font-medium">Transaction confirmed!</p>
+            <a
+              href={`${EXPLORER_BASE}/${txHash}`}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-sm text-blue-600 underline"
+            >
+              View on Stellar Expert
+            </a>
+            <button
+              className="w-full border border-gray-200 dark:border-gray-600 rounded-lg py-2 text-sm hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors"
+              onClick={onClose}
+            >
+              Close
+            </button>
+          </div>
+        )}
+
+        {step === 'failed' && (
+          <div className="space-y-3">
+            <p className="text-red-600 text-sm">{errorMessage}</p>
+            <div className="flex gap-2">
+              <button
+                className="flex-1 border border-gray-200 dark:border-gray-600 rounded-lg py-2 text-sm hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors"
+                onClick={onClose}
+              >
+                Cancel
+              </button>
+              <button
+                className="flex-1 bg-blue-600 text-white rounded-lg py-2 text-sm hover:bg-blue-700 transition-colors"
+                onClick={() => { setErrorMessage(null); run(); }}
+              >
+                Retry
+              </button>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function StepIndicator({ current }: { current: TxStep }) {
+  const steps: { key: TxStep; label: string }[] = [
+    { key: 'build', label: 'Review' },
+    { key: 'sign', label: 'Sign' },
+    { key: 'submit', label: 'Submit' },
+    { key: 'confirmed', label: 'Done' },
+  ];
+  const order: TxStep[] = ['build', 'sign', 'submit', 'confirmed'];
+  const currentIndex = order.indexOf(current === 'failed' ? 'submit' : current);
+
+  return (
+    <div className="flex items-center gap-1" aria-hidden="true">
+      {steps.map((s, i) => (
+        <div key={s.key} className="flex items-center gap-1 flex-1 last:flex-none">
+          <div
+            className={`flex items-center justify-center w-6 h-6 rounded-full text-xs font-medium transition-colors ${
+              i < currentIndex
+                ? 'bg-blue-600 text-white'
+                : i === currentIndex
+                ? current === 'failed'
+                  ? 'bg-red-500 text-white'
+                  : 'bg-blue-600 text-white ring-2 ring-blue-200'
+                : 'bg-gray-100 dark:bg-gray-700 text-gray-400'
+            }`}
+          >
+            {i < currentIndex ? '✓' : i + 1}
+          </div>
+          <span className={`text-xs hidden sm:block ${i <= currentIndex ? 'text-gray-700 dark:text-gray-300' : 'text-gray-400'}`}>
+            {s.label}
+          </span>
+          {i < steps.length - 1 && (
+            <div className={`flex-1 h-px mx-1 ${i < currentIndex ? 'bg-blue-600' : 'bg-gray-200 dark:bg-gray-700'}`} />
+          )}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/apps/frontend/src/components/wallet/WalletButton.tsx
+++ b/apps/frontend/src/components/wallet/WalletButton.tsx
@@ -1,57 +1,34 @@
 'use client';
+
 import { useState } from 'react';
-import { useWalletStore } from '@/store/walletStore';
-import { connectFreighter, fetchXlmBalance, isFreighterInstalled, truncateAddress } from '@/lib/walletApi';
+import { useWallet } from '@/hooks/useWallet';
 import { WalletMenu } from './WalletMenu';
+import { WalletSelectModal } from './WalletSelectModal';
 
 export function WalletButton() {
-  const { address, isConnecting, error, setAddress, setBalance, setIsConnecting, setError, setBalanceError } = useWalletStore();
+  const { isConnected, truncatedAddress, isConnecting, error, networkMismatch, clearError } =
+    useWallet();
   const [showMenu, setShowMenu] = useState(false);
-  const [showInstallPrompt, setShowInstallPrompt] = useState(false);
+  const [showSelect, setShowSelect] = useState(false);
 
-  async function handleConnect() {
-    if (!isFreighterInstalled()) {
-      setShowInstallPrompt(true);
-      return;
-    }
-    setIsConnecting(true);
-    setError(null);
-    try {
-      const publicKey = await connectFreighter();
-      setAddress(publicKey);
-      // Fetch balance
-      try {
-        const bal = await fetchXlmBalance(publicKey);
-        setBalance(bal);
-        setBalanceError(false);
-      } catch {
-        setBalance(null);
-        setBalanceError(true);
-      }
-    } catch (err: unknown) {
-      const msg = err instanceof Error ? err.message : String(err);
-      if (msg === 'FREIGHTER_NOT_CONNECTED') {
-        setError('Connection cancelled.');
-      } else {
-        setError('Failed to connect wallet. Please try again.');
-      }
-    } finally {
-      setIsConnecting(false);
-    }
-  }
-
-  if (address) {
+  if (isConnected) {
     return (
       <div className="relative">
+        {networkMismatch && (
+          <span className="absolute -top-1 -right-1 w-2 h-2 rounded-full bg-amber-400" title="Network mismatch" />
+        )}
         <button
           data-tour="wallet-button"
-          className="flex items-center gap-2 border rounded-lg px-3 py-1.5 text-sm hover:bg-gray-50 transition-colors"
+          className="flex items-center gap-2 border rounded-lg px-3 py-1.5 text-sm hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors"
           onClick={() => setShowMenu((v) => !v)}
           aria-expanded={showMenu}
           aria-haspopup="true"
         >
-          <span className="w-2 h-2 rounded-full bg-green-500" aria-hidden="true" />
-          {truncateAddress(address)}
+          <span
+            className={`w-2 h-2 rounded-full ${networkMismatch ? 'bg-amber-400' : 'bg-green-500'}`}
+            aria-hidden="true"
+          />
+          {truncatedAddress}
         </button>
         {showMenu && <WalletMenu onClose={() => setShowMenu(false)} />}
       </div>
@@ -62,13 +39,16 @@ export function WalletButton() {
     <div>
       <button
         className="flex items-center gap-2 bg-blue-600 text-white rounded-lg px-3 py-1.5 text-sm hover:bg-blue-700 disabled:opacity-60 transition-colors"
-        onClick={handleConnect}
+        onClick={() => setShowSelect(true)}
         disabled={isConnecting}
         aria-busy={isConnecting}
       >
         {isConnecting ? (
           <>
-            <span className="w-3 h-3 border-2 border-white border-t-transparent rounded-full animate-spin" aria-hidden="true" />
+            <span
+              className="w-3 h-3 border-2 border-white border-t-transparent rounded-full animate-spin"
+              aria-hidden="true"
+            />
             Connecting…
           </>
         ) : (
@@ -77,25 +57,27 @@ export function WalletButton() {
       </button>
       {error && (
         <p className="text-xs text-red-600 mt-1">
-          {error}{' '}
-          <button className="underline" onClick={() => setError(null)}>Dismiss</button>
+          {error === 'FREIGHTER_NOT_INSTALLED' ? (
+            <>
+              Freighter not found.{' '}
+              <a
+                href="https://www.freighter.app/"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="underline"
+              >
+                Install Freighter
+              </a>{' '}
+            </>
+          ) : (
+            error
+          )}{' '}
+          <button className="underline" onClick={clearError}>
+            Dismiss
+          </button>
         </p>
       )}
-      {showInstallPrompt && (
-        <p className="text-xs text-gray-600 mt-1">
-          Freighter not found.{' '}
-          <a
-            href="https://www.freighter.app/"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="text-blue-600 underline"
-          >
-            Install Freighter
-          </a>
-          {' '}
-          <button className="underline text-gray-500" onClick={() => setShowInstallPrompt(false)}>Dismiss</button>
-        </p>
-      )}
+      {showSelect && <WalletSelectModal onClose={() => setShowSelect(false)} />}
     </div>
   );
 }

--- a/apps/frontend/src/components/wallet/WalletMenu.tsx
+++ b/apps/frontend/src/components/wallet/WalletMenu.tsx
@@ -1,17 +1,26 @@
 'use client';
+
 import { useEffect, useRef } from 'react';
-import { useWalletStore } from '@/store/walletStore';
-import { connectFreighter, fetchXlmBalance } from '@/lib/walletApi';
+import { useWallet } from '@/hooks/useWallet';
 
 interface WalletMenuProps {
   onClose: () => void;
 }
 
 export function WalletMenu({ onClose }: WalletMenuProps) {
-  const { address, balance, balanceError, disconnect, setAddress, setBalance, setBalanceError, setIsConnecting, setError } = useWalletStore();
+  const {
+    address,
+    balance,
+    bstBalance,
+    balanceError,
+    network,
+    networkMismatch,
+    walletType,
+    disconnect,
+    refreshBalances,
+  } = useWallet();
   const menuRef = useRef<HTMLDivElement>(null);
 
-  // Close on outside click
   useEffect(() => {
     function handleClick(e: MouseEvent) {
       if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
@@ -22,70 +31,59 @@ export function WalletMenu({ onClose }: WalletMenuProps) {
     return () => document.removeEventListener('mousedown', handleClick);
   }, [onClose]);
 
-  async function handleSwitch() {
-    onClose();
-    setIsConnecting(true);
-    setError(null);
-    try {
-      const publicKey = await connectFreighter();
-      setAddress(publicKey);
-      try {
-        const bal = await fetchXlmBalance(publicKey);
-        setBalance(bal);
-        setBalanceError(false);
-      } catch {
-        setBalance(null);
-        setBalanceError(true);
-      }
-    } catch {
-      setError('Failed to switch wallet.');
-    } finally {
-      setIsConnecting(false);
-    }
-  }
-
-  async function handleRetryBalance() {
-    if (!address) return;
-    try {
-      const bal = await fetchXlmBalance(address);
-      setBalance(bal);
-      setBalanceError(false);
-    } catch {
-      setBalanceError(true);
-    }
-  }
-
   return (
     <div
       ref={menuRef}
-      className="absolute right-0 top-full mt-1 w-72 bg-white border rounded-xl shadow-lg p-4 z-50 space-y-3"
+      className="absolute right-0 top-full mt-1 w-72 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-xl shadow-lg p-4 z-50 space-y-3"
       role="menu"
     >
       <div>
         <p className="text-xs text-gray-500 mb-0.5">Connected Wallet</p>
         <p className="font-mono text-xs break-all">{address}</p>
+        {walletType && (
+          <p className="text-xs text-gray-400 mt-0.5 capitalize">{walletType}</p>
+        )}
       </div>
+
+      {network && (
+        <div>
+          <p className="text-xs text-gray-500 mb-0.5">Network</p>
+          <p className={`text-xs font-medium ${networkMismatch ? 'text-amber-600' : 'text-gray-700 dark:text-gray-300'}`}>
+            {network}
+            {networkMismatch && ' — mismatch'}
+          </p>
+        </div>
+      )}
+
       <div>
         <p className="text-xs text-gray-500 mb-0.5">XLM Balance</p>
         {balanceError ? (
           <p className="text-sm text-gray-500">
             Balance unavailable{' '}
-            <button className="text-blue-600 underline text-xs" onClick={handleRetryBalance}>Retry</button>
+            <button className="text-blue-600 underline text-xs" onClick={refreshBalances}>
+              Retry
+            </button>
           </p>
         ) : (
           <p className="text-sm font-medium">{balance ?? '—'} XLM</p>
         )}
       </div>
-      <div className="flex gap-2 pt-2 border-t">
+
+      <div>
+        <p className="text-xs text-gray-500 mb-0.5">BST Balance</p>
+        <p className="text-sm font-medium">{bstBalance ?? '—'} BST</p>
+      </div>
+
+      <div className="flex gap-2 pt-2 border-t border-gray-100 dark:border-gray-700">
         <button
-          className="flex-1 text-sm border rounded-lg py-1.5 hover:bg-gray-50 transition-colors"
-          onClick={handleSwitch}
+          className="flex-1 text-sm border border-gray-200 dark:border-gray-600 rounded-lg py-1.5 hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors"
+          onClick={() => { onClose(); }}
           role="menuitem"
         >
-          Switch Wallet
+          Close
         </button>
         <button
-          className="flex-1 text-sm border border-red-200 text-red-600 rounded-lg py-1.5 hover:bg-red-50 transition-colors"
+          className="flex-1 text-sm border border-red-200 text-red-600 rounded-lg py-1.5 hover:bg-red-50 dark:hover:bg-red-900/20 transition-colors"
           onClick={() => { disconnect(); onClose(); }}
           role="menuitem"
         >

--- a/apps/frontend/src/components/wallet/WalletSelectModal.tsx
+++ b/apps/frontend/src/components/wallet/WalletSelectModal.tsx
@@ -1,0 +1,95 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+import { useWallet } from '@/hooks/useWallet';
+import { SUPPORTED_WALLETS } from '@/lib/walletAdapters';
+import type { WalletType } from '@/store/walletStore';
+
+interface WalletSelectModalProps {
+  onClose: () => void;
+}
+
+export function WalletSelectModal({ onClose }: WalletSelectModalProps) {
+  const { connect, isConnecting } = useWallet();
+  const overlayRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    document.addEventListener('keydown', handler);
+    return () => document.removeEventListener('keydown', handler);
+  }, [onClose]);
+
+  async function handleSelect(id: WalletType) {
+    await connect(id);
+    onClose();
+  }
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center"
+      role="dialog"
+      aria-modal="true"
+      aria-label="Select wallet"
+    >
+      <div
+        ref={overlayRef}
+        className="fixed inset-0 bg-black/50"
+        onClick={onClose}
+        aria-hidden="true"
+      />
+      <div className="relative bg-white dark:bg-gray-800 rounded-xl shadow-xl w-full max-w-sm mx-4 p-6">
+        <div className="flex items-center justify-between mb-5">
+          <h2 className="text-lg font-semibold">Select Wallet</h2>
+          <button
+            onClick={onClose}
+            className="text-gray-400 hover:text-gray-600 dark:hover:text-gray-200"
+            aria-label="Close"
+          >
+            ✕
+          </button>
+        </div>
+        <ul className="space-y-2" role="list">
+          {SUPPORTED_WALLETS.map((wallet) => {
+            const installed = wallet.isInstalled();
+            const comingSoon = wallet.id === 'walletconnect';
+            return (
+              <li key={wallet.id}>
+                <button
+                  className="w-full flex items-center justify-between gap-3 px-4 py-3 rounded-lg border border-gray-200 dark:border-gray-700 hover:bg-gray-50 dark:hover:bg-gray-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors text-left"
+                  onClick={() => handleSelect(wallet.id as WalletType)}
+                  disabled={isConnecting || comingSoon}
+                  aria-disabled={comingSoon}
+                >
+                  <div>
+                    <p className="text-sm font-medium">
+                      {wallet.name}
+                      {comingSoon && (
+                        <span className="ml-2 text-xs text-gray-400">(coming soon)</span>
+                      )}
+                    </p>
+                    <p className="text-xs text-gray-500">{wallet.description}</p>
+                  </div>
+                  {installed ? (
+                    <span className="shrink-0 text-xs text-green-600 font-medium">Detected</span>
+                  ) : !comingSoon ? (
+                    <a
+                      href={wallet.installUrl}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="shrink-0 text-xs text-blue-600 underline"
+                      onClick={(e) => e.stopPropagation()}
+                    >
+                      Install
+                    </a>
+                  ) : null}
+                </button>
+              </li>
+            );
+          })}
+        </ul>
+      </div>
+    </div>
+  );
+}

--- a/apps/frontend/src/hooks/useGamification.ts
+++ b/apps/frontend/src/hooks/useGamification.ts
@@ -1,0 +1,65 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import api from '@/lib/api';
+import type { Badge } from '@/components/gamification/BadgeGrid';
+
+export interface GamificationData {
+  xp: number;
+  level: number;
+  xpForNextLevel: number;
+  streak: number;
+  longestStreak: number;
+  badges: Badge[];
+}
+
+interface UseGamificationResult {
+  data: GamificationData | null;
+  isLoading: boolean;
+  error: string | null;
+  refresh: () => void;
+}
+
+const DEFAULT: GamificationData = {
+  xp: 0,
+  level: 1,
+  xpForNextLevel: 100,
+  streak: 0,
+  longestStreak: 0,
+  badges: [],
+};
+
+export function useGamification(userId?: string): UseGamificationResult {
+  const [data, setData] = useState<GamificationData | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [tick, setTick] = useState(0);
+
+  useEffect(() => {
+    if (!userId) return;
+    let cancelled = false;
+    setIsLoading(true);
+    setError(null);
+
+    api
+      .get(`/gamification/${userId}`)
+      .then((res) => {
+        if (!cancelled) setData(res.data ?? DEFAULT);
+      })
+      .catch(() => {
+        if (!cancelled) setError('Failed to load gamification data.');
+      })
+      .finally(() => {
+        if (!cancelled) setIsLoading(false);
+      });
+
+    return () => { cancelled = true; };
+  }, [userId, tick]);
+
+  return {
+    data,
+    isLoading,
+    error,
+    refresh: () => setTick((t) => t + 1),
+  };
+}

--- a/apps/frontend/src/hooks/useWallet.ts
+++ b/apps/frontend/src/hooks/useWallet.ts
@@ -1,0 +1,119 @@
+'use client';
+
+import { useWalletStore, WalletType } from '@/store/walletStore';
+import {
+  connectFreighter,
+  fetchXlmBalance,
+  fetchBstBalance,
+  isFreighterInstalled,
+  truncateAddress,
+} from '@/lib/walletApi';
+import { connectAlbedo, connectXbull } from '@/lib/walletAdapters';
+
+const EXPECTED_NETWORK = process.env.NEXT_PUBLIC_STELLAR_NETWORK || 'testnet';
+
+async function loadBalances(
+  address: string,
+  setBalance: (b: string | null) => void,
+  setBstBalance: (b: string | null) => void,
+  setBalanceError: (v: boolean) => void
+) {
+  try {
+    const [xlm, bst] = await Promise.all([
+      fetchXlmBalance(address),
+      fetchBstBalance(address),
+    ]);
+    setBalance(xlm);
+    setBstBalance(bst);
+    setBalanceError(false);
+  } catch {
+    setBalance(null);
+    setBstBalance(null);
+    setBalanceError(true);
+  }
+}
+
+export function useWallet() {
+  const store = useWalletStore();
+
+  const networkMismatch =
+    !!store.network &&
+    !store.network.toLowerCase().includes(EXPECTED_NETWORK.toLowerCase());
+
+  async function connect(type: WalletType = 'freighter') {
+    store.setIsConnecting(true);
+    store.setError(null);
+    try {
+      let publicKey: string;
+      let network: string;
+
+      if (type === 'freighter') {
+        if (!isFreighterInstalled()) {
+          store.setError('FREIGHTER_NOT_INSTALLED');
+          return;
+        }
+        const result = await connectFreighter();
+        publicKey = result.publicKey;
+        network = result.network;
+      } else if (type === 'albedo') {
+        const result = await connectAlbedo();
+        publicKey = result.publicKey;
+        network = result.network;
+      } else if (type === 'xbull') {
+        const result = await connectXbull();
+        publicKey = result.publicKey;
+        network = result.network;
+      } else {
+        store.setError('Wallet type not yet supported.');
+        return;
+      }
+
+      store.setAddress(publicKey);
+      store.setNetwork(network);
+      store.setWalletType(type);
+      await loadBalances(
+        publicKey,
+        store.setBalance,
+        store.setBstBalance,
+        store.setBalanceError
+      );
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : String(err);
+      if (msg === 'FREIGHTER_NOT_CONNECTED') {
+        store.setError('Connection cancelled.');
+      } else {
+        store.setError('Failed to connect wallet. Please try again.');
+      }
+    } finally {
+      store.setIsConnecting(false);
+    }
+  }
+
+  async function refreshBalances() {
+    if (!store.address) return;
+    await loadBalances(
+      store.address,
+      store.setBalance,
+      store.setBstBalance,
+      store.setBalanceError
+    );
+  }
+
+  return {
+    address: store.address,
+    truncatedAddress: store.address ? truncateAddress(store.address) : null,
+    network: store.network,
+    networkMismatch,
+    balance: store.balance,
+    bstBalance: store.bstBalance,
+    walletType: store.walletType,
+    isConnecting: store.isConnecting,
+    isConnected: !!store.address,
+    error: store.error,
+    balanceError: store.balanceError,
+    connect,
+    disconnect: store.disconnect,
+    clearError: () => store.setError(null),
+    refreshBalances,
+  };
+}

--- a/apps/frontend/src/lib/walletAdapters.ts
+++ b/apps/frontend/src/lib/walletAdapters.ts
@@ -1,0 +1,111 @@
+// Lightweight wallet adapter layer providing a normalized connect/sign interface
+// for wallets beyond Freighter (Albedo, xBull, WalletConnect).
+
+export interface WalletAdapter {
+  id: string;
+  name: string;
+  icon: string;
+  installUrl: string;
+  helpUrl: string;
+  isInstalled: () => boolean;
+  connect: () => Promise<{ publicKey: string; network: string }>;
+  sign: (xdr: string, network: string) => Promise<string>;
+}
+
+declare global {
+  interface Window {
+    freighter?: {
+      isConnected: () => Promise<boolean>;
+      getPublicKey: () => Promise<string>;
+      getNetwork: () => Promise<string>;
+    };
+    albedo?: {
+      publicKey: (opts: Record<string, unknown>) => Promise<{ pubkey: string }>;
+      tx: (opts: { xdr: string; network: string }) => Promise<{ signed_envelope_xdr: string }>;
+    };
+    xBull?: {
+      connect: () => Promise<{ publicKey: string }>;
+      sign: (params: { xdr: string; network: string }) => Promise<{ signedXDR: string }>;
+    };
+  }
+}
+
+const NETWORK = process.env.NEXT_PUBLIC_STELLAR_NETWORK || 'testnet';
+const NETWORK_PASSPHRASE =
+  NETWORK === 'mainnet'
+    ? 'Public Global Stellar Network ; September 2015'
+    : 'Test SDF Network ; September 2015';
+
+export async function connectAlbedo(): Promise<{ publicKey: string; network: string }> {
+  if (typeof window === 'undefined' || !window.albedo) {
+    throw new Error('Albedo extension not found.');
+  }
+  const { pubkey } = await window.albedo.publicKey({});
+  return { publicKey: pubkey, network: NETWORK_PASSPHRASE };
+}
+
+export async function signWithAlbedo(xdr: string): Promise<string> {
+  if (typeof window === 'undefined' || !window.albedo) {
+    throw new Error('Albedo extension not found.');
+  }
+  const { signed_envelope_xdr } = await window.albedo.tx({ xdr, network: NETWORK_PASSPHRASE });
+  return signed_envelope_xdr;
+}
+
+export async function connectXbull(): Promise<{ publicKey: string; network: string }> {
+  if (typeof window === 'undefined' || !window.xBull) {
+    throw new Error('xBull extension not found.');
+  }
+  const { publicKey } = await window.xBull.connect();
+  return { publicKey, network: NETWORK_PASSPHRASE };
+}
+
+export async function signWithXbull(xdr: string): Promise<string> {
+  if (typeof window === 'undefined' || !window.xBull) {
+    throw new Error('xBull extension not found.');
+  }
+  const { signedXDR } = await window.xBull.sign({ xdr, network: NETWORK_PASSPHRASE });
+  return signedXDR;
+}
+
+export const SUPPORTED_WALLETS: Array<{
+  id: 'freighter' | 'albedo' | 'xbull' | 'walletconnect';
+  name: string;
+  description: string;
+  installUrl: string;
+  helpUrl: string;
+  isInstalled: () => boolean;
+}> = [
+  {
+    id: 'freighter',
+    name: 'Freighter',
+    description: 'Official Stellar browser extension',
+    installUrl: 'https://www.freighter.app/',
+    helpUrl: 'https://docs.freighter.app/',
+    isInstalled: () => typeof window !== 'undefined' && !!window.freighter,
+  },
+  {
+    id: 'albedo',
+    name: 'Albedo',
+    description: 'Web-based Stellar signer',
+    installUrl: 'https://albedo.link/',
+    helpUrl: 'https://albedo.link/docs',
+    isInstalled: () => typeof window !== 'undefined' && !!window.albedo,
+  },
+  {
+    id: 'xbull',
+    name: 'xBull',
+    description: 'Advanced Stellar wallet extension',
+    installUrl: 'https://xbull.app/',
+    helpUrl: 'https://xbull.app/docs',
+    isInstalled: () => typeof window !== 'undefined' && !!window.xBull,
+  },
+  {
+    id: 'walletconnect',
+    name: 'WalletConnect',
+    description: 'Connect mobile wallets via QR code',
+    installUrl: 'https://walletconnect.com/',
+    helpUrl: 'https://docs.walletconnect.com/',
+    isInstalled: () => false,
+  },
+];

--- a/apps/frontend/src/lib/walletApi.ts
+++ b/apps/frontend/src/lib/walletApi.ts
@@ -1,30 +1,36 @@
-// Freighter wallet integration
-// Freighter exposes window.freighter (or @stellar/freighter-api package)
-
-declare global {
-  interface Window {
-    freighter?: {
-      isConnected: () => Promise<boolean>;
-      getPublicKey: () => Promise<string>;
-      getNetwork: () => Promise<string>;
-    };
-  }
-}
+import {
+  isConnected,
+  getPublicKey,
+  getNetwork,
+  signTransaction,
+} from '@stellar/freighter-api';
 
 export function isFreighterInstalled(): boolean {
   return typeof window !== 'undefined' && !!window.freighter;
 }
 
-export async function connectFreighter(): Promise<string> {
-  if (!isFreighterInstalled()) {
-    throw new Error('FREIGHTER_NOT_INSTALLED');
-  }
-  const connected = await window.freighter!.isConnected();
+export async function connectFreighter(): Promise<{ publicKey: string; network: string }> {
+  const { isConnected: connected } = await isConnected();
   if (!connected) {
     throw new Error('FREIGHTER_NOT_CONNECTED');
   }
-  const publicKey = await window.freighter!.getPublicKey();
-  return publicKey;
+  const { publicKey, error: pkError } = await getPublicKey();
+  if (pkError) throw new Error(pkError);
+  const { network, networkPassphrase, error: netError } = await getNetwork();
+  if (netError) throw new Error(netError);
+  return { publicKey, network: network || networkPassphrase };
+}
+
+export async function getFreighterNetwork(): Promise<string> {
+  const { network, networkPassphrase, error } = await getNetwork();
+  if (error) throw new Error(error);
+  return network || networkPassphrase;
+}
+
+export async function signWithFreighter(xdr: string, network: string): Promise<string> {
+  const { signedTransaction, error } = await signTransaction(xdr, { network });
+  if (error) throw new Error(error);
+  return signedTransaction;
 }
 
 export async function fetchXlmBalance(address: string): Promise<string> {
@@ -37,8 +43,26 @@ export async function fetchXlmBalance(address: string): Promise<string> {
   const res = await fetch(`${horizonUrl}/accounts/${address}`);
   if (!res.ok) throw new Error('BALANCE_FETCH_FAILED');
   const data = await res.json();
-  const xlmBalance = data.balances?.find((b: { asset_type: string }) => b.asset_type === 'native');
+  const xlmBalance = data.balances?.find(
+    (b: { asset_type: string }) => b.asset_type === 'native'
+  );
   return xlmBalance ? xlmBalance.balance : '0';
+}
+
+export async function fetchBstBalance(address: string): Promise<string> {
+  const network = process.env.NEXT_PUBLIC_STELLAR_NETWORK || 'testnet';
+  const horizonUrl =
+    network === 'mainnet'
+      ? 'https://horizon.stellar.org'
+      : 'https://horizon-testnet.stellar.org';
+
+  const res = await fetch(`${horizonUrl}/accounts/${address}`);
+  if (!res.ok) return '0';
+  const data = await res.json();
+  const bst = data.balances?.find(
+    (b: { asset_type: string; asset_code?: string }) => b.asset_code === 'BST'
+  );
+  return bst ? bst.balance : '0';
 }
 
 export function truncateAddress(address: string): string {

--- a/apps/frontend/src/store/walletStore.ts
+++ b/apps/frontend/src/store/walletStore.ts
@@ -1,29 +1,61 @@
 import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+
+export type WalletType = 'freighter' | 'albedo' | 'xbull' | 'walletconnect';
 
 interface WalletState {
   address: string | null;
+  network: string | null;
   balance: string | null;
+  bstBalance: string | null;
+  walletType: WalletType | null;
   isConnecting: boolean;
   error: string | null;
   balanceError: boolean;
   setAddress: (address: string | null) => void;
+  setNetwork: (network: string | null) => void;
   setBalance: (balance: string | null) => void;
+  setBstBalance: (balance: string | null) => void;
+  setWalletType: (type: WalletType | null) => void;
   setIsConnecting: (v: boolean) => void;
   setError: (error: string | null) => void;
   setBalanceError: (v: boolean) => void;
   disconnect: () => void;
 }
 
-export const useWalletStore = create<WalletState>((set) => ({
-  address: null,
-  balance: null,
-  isConnecting: false,
-  error: null,
-  balanceError: false,
-  setAddress: (address) => set({ address }),
-  setBalance: (balance) => set({ balance }),
-  setIsConnecting: (isConnecting) => set({ isConnecting }),
-  setError: (error) => set({ error }),
-  setBalanceError: (balanceError) => set({ balanceError }),
-  disconnect: () => set({ address: null, balance: null, error: null, balanceError: false }),
-}));
+export const useWalletStore = create<WalletState>()(
+  persist(
+    (set) => ({
+      address: null,
+      network: null,
+      balance: null,
+      bstBalance: null,
+      walletType: null,
+      isConnecting: false,
+      error: null,
+      balanceError: false,
+      setAddress: (address) => set({ address }),
+      setNetwork: (network) => set({ network }),
+      setBalance: (balance) => set({ balance }),
+      setBstBalance: (bstBalance) => set({ bstBalance }),
+      setWalletType: (walletType) => set({ walletType }),
+      setIsConnecting: (isConnecting) => set({ isConnecting }),
+      setError: (error) => set({ error }),
+      setBalanceError: (balanceError) => set({ balanceError }),
+      disconnect: () =>
+        set({
+          address: null,
+          network: null,
+          balance: null,
+          bstBalance: null,
+          walletType: null,
+          error: null,
+          balanceError: false,
+        }),
+    }),
+    {
+      name: 'wallet-store',
+      partialize: (s) => ({ address: s.address, network: s.network, walletType: s.walletType }),
+    }
+  )
+);


### PR DESCRIPTION
## Summary

---

### #586 — Freighter wallet connection

- Migrated `walletApi.ts` from raw `window.freighter` calls to the official `@stellar/freighter-api` package (`isConnected`, `getPublicKey`, `getNetwork`, `signTransaction`).
- Added `getFreighterNetwork()` and `fetchBstBalance()` to surface network info and BST token balance alongside XLM.
- Extended `walletStore` with `network`, `bstBalance`, and `walletType` fields; added `persist` middleware so the connected address and network survive page reloads.
- Created `src/hooks/useWallet.ts` — a stable hook over the store that exposes `connect`, `disconnect`, `refreshBalances`, `truncatedAddress`, `networkMismatch`, and `clearError`.
- Wired `<WalletButton>` into `<Navbar>` (desktop rail). `WalletMenu` now shows XLM balance, BST balance, detected network, and a network-mismatch warning.

closes #586 

### #587 — Transaction signing & status UI

- Added `src/components/wallet/TransactionModal.tsx`: a four-step modal (Review → Sign → Submit → Confirmed/Failed) reusable by any contract call.
- Signs via whichever wallet is currently active (`walletType` from the store); dispatches to Horizon and polls for confirmation with a 30-second timeout.
- Surfaces actionable error messages for insufficient balance, sequence mismatches, and timeouts.
- Integrates with the existing toast store (`toast.success` / `toast.error`) on completion.
- Covered by `TransactionModal.test.tsx` (build-step render, Escape/cancel, step indicator).

closes #587 

### #588 — Multi-wallet support

- Added `src/lib/walletAdapters.ts`: lightweight typed adapters for Albedo and xBull (both browser extension APIs), a `SUPPORTED_WALLETS` registry with install/help URLs for Freighter, Albedo, xBull, and WalletConnect (coming soon).
- `useWallet.connect(type)` dispatches to the correct adapter behind a uniform interface; callers never need to know which wallet is active.
- Added `src/components/wallet/WalletSelectModal.tsx`: a wallet-picker modal that shows installed/detected status per wallet and inline install links for wallets not yet present. `WalletButton` opens this modal instead of connecting Freighter directly.

closes #588 

### #589  — Gamification dashboard

- `src/components/gamification/XpProgress.tsx` — accessible progress bar (ARIA `role="progressbar"`) with level badge and XP counters; transition disabled via `motion-reduce:transition-none`.
- `src/components/gamification/StreakIndicator.tsx` — current streak, best streak; flame emoji animation respects `prefers-reduced-motion`.
- `src/components/gamification/BadgeGrid.tsx` — responsive grid; locked badges are greyed/desaturated; unlocked badges show their earned date.
- `src/components/gamification/GamificationDashboard.tsx` — composites the three components; handles loading skeleton, error + retry, and empty state.
- `src/hooks/useGamification.ts` — fetches `/gamification/:userId` from the backend with cancel-on-unmount and a manual refresh trigger.
- Storybook stories for all three presentational components (`XpProgress`, `StreakIndicator`, `BadgeGrid`).

closes #589 

## Tests added

| File | Covers |
|---|---|
| `__tests__/hooks/useWallet.test.ts` | connect, disconnect, balance load, not-installed error, clearError |
| `__tests__/components/wallet/TransactionModal.test.tsx` | render, cancel, Escape key, step indicator |
| `__tests__/components/gamification/GamificationComponents.test.tsx` | XpProgress percentage, StreakIndicator, BadgeGrid unlock/empty states |