### PR TITLE
feat(backend): implement issues #614 #615 #616 #617 — payments, BullM…

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -81,3 +81,8 @@ MODERATION_TOXICITY_THRESHOLD=0.7
 # Elasticsearch
 ELASTICSEARCH_NODE=http://localhost:9200
 ELASTICSEARCH_API_KEY=
+
+# Stripe (Issue #614 — Payments)
+STRIPE_SECRET_KEY=sk_test_your_stripe_secret_key
+STRIPE_PUBLISHABLE_KEY=pk_test_your_stripe_publishable_key
+STRIPE_WEBHOOK_SECRET=whsec_your_stripe_webhook_secret

--- a/apps/backend/.env.example
+++ b/apps/backend/.env.example
@@ -49,3 +49,12 @@ FRONTEND_URL=http://localhost:3001
 # Sentry
 SENTRY_DSN=your_sentry_dsn_here
 GIT_COMMIT_SHA=
+
+# Elasticsearch
+ELASTICSEARCH_NODE=http://localhost:9200
+ELASTICSEARCH_API_KEY=
+
+# Stripe (Issue #614 — Payments & Subscriptions)
+STRIPE_SECRET_KEY=sk_test_your_stripe_secret_key
+STRIPE_PUBLISHABLE_KEY=pk_test_your_stripe_publishable_key
+STRIPE_WEBHOOK_SECRET=whsec_your_stripe_webhook_secret

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -82,7 +82,8 @@
     "socket.io": "^4.8.3",
     "typeorm": "^0.3.0",
     "winston": "^3.11.0",
-    "xml2js": "^0.6.2"
+    "xml2js": "^0.6.2",
+    "stripe": "^16.12.0"
     ,
     "@nestjs/graphql": "^10.0.0",
     "graphql": "^16.7.1",

--- a/apps/backend/src/app.module.ts
+++ b/apps/backend/src/app.module.ts
@@ -47,6 +47,7 @@ import { BookingsModule } from './bookings/bookings.module';
 import { GatewayModule } from './gateway/gateway.module';
 import { AdminModule } from './admin/admin.module';
 import { QueueModule } from './queue/queue.module';
+import { PaymentsModule } from './payments/payments.module';
 import { GatewayLoggingInterceptor } from './gateway/gateway.interceptor';
 import { WsGatewayModule } from './ws-gateway/ws-gateway.module';
 import { AppGraphQLModule } from './graphql/graphql.module';
@@ -145,6 +146,7 @@ import { validationSchema } from './config/validation.schema';
     GatewayModule,
     WsGatewayModule,
     AppGraphQLModule,
+    PaymentsModule,
   ],
   providers: [
     { provide: APP_GUARD, useClass: ThrottlerGuard },

--- a/apps/backend/src/config/configuration.ts
+++ b/apps/backend/src/config/configuration.ts
@@ -78,4 +78,10 @@ export default () => ({
     node: process.env.ELASTICSEARCH_NODE || 'http://localhost:9200',
     apiKey: process.env.ELASTICSEARCH_API_KEY || '',
   },
+
+  stripe: {
+    secretKey: process.env.STRIPE_SECRET_KEY || '',
+    webhookSecret: process.env.STRIPE_WEBHOOK_SECRET || '',
+    publishableKey: process.env.STRIPE_PUBLISHABLE_KEY || '',
+  },
 });

--- a/apps/backend/src/config/validation.schema.ts
+++ b/apps/backend/src/config/validation.schema.ts
@@ -63,4 +63,9 @@ export const validationSchema = Joi.object({
   // Elasticsearch
   ELASTICSEARCH_NODE: Joi.string().uri().default('http://localhost:9200'),
   ELASTICSEARCH_API_KEY: Joi.string().allow('').default(''),
+
+  // Stripe
+  STRIPE_SECRET_KEY: Joi.string().allow('').default(''),
+  STRIPE_WEBHOOK_SECRET: Joi.string().allow('').default(''),
+  STRIPE_PUBLISHABLE_KEY: Joi.string().allow('').default(''),
 });

--- a/apps/backend/src/payments/invoice.entity.ts
+++ b/apps/backend/src/payments/invoice.entity.ts
@@ -1,0 +1,70 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  UpdateDateColumn,
+  Index,
+  ManyToOne,
+  JoinColumn,
+} from 'typeorm';
+import { User } from '../users/user.entity';
+import { Subscription } from './subscription.entity';
+
+export enum InvoiceStatus {
+  DRAFT = 'draft',
+  OPEN = 'open',
+  PAID = 'paid',
+  VOID = 'void',
+  UNCOLLECTIBLE = 'uncollectible',
+}
+
+@Entity('invoices')
+export class Invoice {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Index()
+  @Column()
+  userId: string;
+
+  @ManyToOne(() => User, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'userId' })
+  user: User;
+
+  @Column({ nullable: true })
+  subscriptionId: string;
+
+  @ManyToOne(() => Subscription, { nullable: true, onDelete: 'SET NULL' })
+  @JoinColumn({ name: 'subscriptionId' })
+  subscription: Subscription;
+
+  /** Stripe Invoice ID */
+  @Index({ unique: true })
+  @Column({ nullable: true })
+  stripeInvoiceId: string;
+
+  @Column({ type: 'varchar', default: InvoiceStatus.DRAFT })
+  status: InvoiceStatus;
+
+  @Column({ default: 0 })
+  amountDueCents: number;
+
+  @Column({ default: 0 })
+  amountPaidCents: number;
+
+  @Column({ default: 'usd' })
+  currency: string;
+
+  @Column({ nullable: true, type: 'timestamp' })
+  dueDate: Date;
+
+  @Column({ nullable: true, type: 'timestamp' })
+  paidAt: Date;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+}

--- a/apps/backend/src/payments/payment.entity.ts
+++ b/apps/backend/src/payments/payment.entity.ts
@@ -1,0 +1,94 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  UpdateDateColumn,
+  Index,
+  ManyToOne,
+  JoinColumn,
+} from 'typeorm';
+import { User } from '../users/user.entity';
+import { Course } from '../courses/course.entity';
+
+export enum PaymentProvider {
+  STRIPE = 'stripe',
+  STELLAR = 'stellar',
+}
+
+export enum PaymentStatus {
+  PENDING = 'pending',
+  COMPLETED = 'completed',
+  FAILED = 'failed',
+  REFUNDED = 'refunded',
+}
+
+@Entity('payments')
+export class Payment {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Index()
+  @Column()
+  userId: string;
+
+  @ManyToOne(() => User, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'userId' })
+  user: User;
+
+  @Index()
+  @Column({ nullable: true })
+  courseId: string;
+
+  @ManyToOne(() => Course, { nullable: true, onDelete: 'SET NULL' })
+  @JoinColumn({ name: 'courseId' })
+  course: Course;
+
+  @Index()
+  @Column({ nullable: true })
+  subscriptionId: string;
+
+  /** Fiat amount in smallest currency unit (cents) */
+  @Column({ default: 0 })
+  amountCents: number;
+
+  @Column({ default: 'usd' })
+  currency: string;
+
+  /** BST / XLM amount in stroops (1 XLM = 10_000_000 stroops) */
+  @Column({ nullable: true, type: 'bigint' })
+  bstAmount: string;
+
+  @Column({ type: 'varchar', enum: PaymentProvider })
+  provider: PaymentProvider;
+
+  @Index()
+  @Column({ type: 'varchar', default: PaymentStatus.PENDING })
+  status: PaymentStatus;
+
+  /** Stripe PaymentIntent ID / Checkout Session ID */
+  @Index({ unique: true })
+  @Column({ nullable: true })
+  stripePaymentIntentId: string;
+
+  /** Stellar transaction hash */
+  @Column({ nullable: true })
+  stellarTxHash: string;
+
+  /**
+   * Idempotency key — prevents duplicate processing when Stripe fires
+   * the same webhook event more than once.
+   */
+  @Index({ unique: true })
+  @Column({ nullable: true })
+  idempotencyKey: string;
+
+  @Column({ nullable: true, type: 'text' })
+  errorMessage: string;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+}

--- a/apps/backend/src/payments/payments.controller.ts
+++ b/apps/backend/src/payments/payments.controller.ts
@@ -1,0 +1,143 @@
+import {
+  Controller,
+  Post,
+  Get,
+  Delete,
+  Body,
+  Param,
+  Headers,
+  Req,
+  UseGuards,
+  Request,
+  RawBodyRequest,
+  HttpCode,
+  HttpStatus,
+} from '@nestjs/common';
+import { ApiTags, ApiBearerAuth, ApiOperation } from '@nestjs/swagger';
+import {
+  IsString,
+  IsEnum,
+  IsOptional,
+  IsUrl,
+  IsUUID,
+} from 'class-validator';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { PaymentsService } from './payments.service';
+import { SubscriptionPlan } from './subscription.entity';
+
+class CreateCheckoutDto {
+  @IsUUID() courseId: string;
+  @IsString() priceId: string;
+  @IsUrl() successUrl: string;
+  @IsUrl() cancelUrl: string;
+}
+
+class CreateSubscriptionDto {
+  @IsEnum(SubscriptionPlan) plan: SubscriptionPlan;
+  @IsString() priceId: string;
+  @IsString() paymentMethodId: string;
+}
+
+class VerifyStellarPaymentDto {
+  @IsUUID() courseId: string;
+  @IsString() txHash: string;
+}
+
+@ApiTags('payments')
+@Controller('v1/payments')
+export class PaymentsController {
+  constructor(private readonly paymentsService: PaymentsService) {}
+
+  // ─── Stripe fiat ──────────────────────────────────────────────────────────
+
+  @Post('checkout')
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Create a Stripe Checkout session for a course purchase' })
+  createCheckout(@Request() req: any, @Body() dto: CreateCheckoutDto) {
+    return this.paymentsService.createCheckoutSession(
+      req.user.userId,
+      dto.courseId,
+      dto.priceId,
+      dto.successUrl,
+      dto.cancelUrl,
+    );
+  }
+
+  @Post('subscriptions')
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Create a Stripe subscription (monthly or annual)' })
+  createSubscription(@Request() req: any, @Body() dto: CreateSubscriptionDto) {
+    return this.paymentsService.createSubscription(
+      req.user.userId,
+      dto.plan,
+      dto.priceId,
+      dto.paymentMethodId,
+    );
+  }
+
+  @Get('subscriptions/me')
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get the current user\'s active subscription' })
+  getMySubscription(@Request() req: any) {
+    return this.paymentsService.getSubscription(req.user.userId);
+  }
+
+  @Delete('subscriptions/me')
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Cancel the current user\'s subscription' })
+  cancelSubscription(@Request() req: any) {
+    return this.paymentsService.cancelSubscription(req.user.userId);
+  }
+
+  @Get('invoices')
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'List invoices for the current user' })
+  getInvoices(@Request() req: any) {
+    return this.paymentsService.getUserInvoices(req.user.userId);
+  }
+
+  @Get('history')
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'List payment history for the current user' })
+  getPaymentHistory(@Request() req: any) {
+    return this.paymentsService.getUserPayments(req.user.userId);
+  }
+
+  // ─── Stripe webhook (raw body required) ──────────────────────────────────
+
+  /**
+   * Stripe delivers webhooks with a raw body for signature verification.
+   * The `RawBodyRequest` type gives access to `req.rawBody` which must be
+   * enabled via `app.use(express.json({ verify: (req, res, buf) => { req.rawBody = buf; } }))`.
+   */
+  @Post('stripe/webhook')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Stripe webhook endpoint (idempotent, verifies HMAC signature)' })
+  async stripeWebhook(
+    @Req() req: RawBodyRequest<any>,
+    @Headers('stripe-signature') signature: string,
+  ) {
+    await this.paymentsService.handleStripeWebhook(req.rawBody!, signature);
+    return { received: true };
+  }
+
+  // ─── BST / Stellar on-chain payment ───────────────────────────────────────
+
+  @Post('stellar/verify')
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Verify a BST/Stellar transaction and grant course access' })
+  verifyStellarPayment(@Request() req: any, @Body() dto: VerifyStellarPaymentDto) {
+    return this.paymentsService.verifyAndRecordStellarPayment(
+      req.user.userId,
+      dto.courseId,
+      dto.txHash,
+    );
+  }
+}

--- a/apps/backend/src/payments/payments.module.ts
+++ b/apps/backend/src/payments/payments.module.ts
@@ -1,0 +1,20 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Payment } from './payment.entity';
+import { Subscription } from './subscription.entity';
+import { Invoice } from './invoice.entity';
+import { PaymentsService } from './payments.service';
+import { PaymentsController } from './payments.controller';
+import { Enrollment } from '../enrollments/enrollment.entity';
+import { StellarModule } from '../stellar/stellar.module';
+
+@Module({
+  imports: [
+    TypeOrmModule.forFeature([Payment, Subscription, Invoice, Enrollment]),
+    StellarModule,
+  ],
+  providers: [PaymentsService],
+  controllers: [PaymentsController],
+  exports: [PaymentsService],
+})
+export class PaymentsModule {}

--- a/apps/backend/src/payments/payments.service.ts
+++ b/apps/backend/src/payments/payments.service.ts
@@ -1,0 +1,374 @@
+import {
+  Injectable,
+  Logger,
+  NotFoundException,
+  ConflictException,
+  BadRequestException,
+} from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository, DataSource } from 'typeorm';
+import { ConfigService } from '@nestjs/config';
+import { EventEmitter2 } from '@nestjs/event-emitter';
+import Stripe from 'stripe';
+import { Payment, PaymentProvider, PaymentStatus } from './payment.entity';
+import { Subscription, SubscriptionStatus, SubscriptionPlan } from './subscription.entity';
+import { Invoice, InvoiceStatus } from './invoice.entity';
+import { Enrollment } from '../enrollments/enrollment.entity';
+import { StellarService } from '../stellar/stellar.service';
+
+@Injectable()
+export class PaymentsService {
+  private readonly logger = new Logger(PaymentsService.name);
+  private readonly stripe: Stripe;
+
+  constructor(
+    @InjectRepository(Payment) private paymentRepo: Repository<Payment>,
+    @InjectRepository(Subscription) private subscriptionRepo: Repository<Subscription>,
+    @InjectRepository(Invoice) private invoiceRepo: Repository<Invoice>,
+    @InjectRepository(Enrollment) private enrollmentRepo: Repository<Enrollment>,
+    private readonly configService: ConfigService,
+    private readonly eventEmitter: EventEmitter2,
+    private readonly stellarService: StellarService,
+    private readonly dataSource: DataSource,
+  ) {
+    this.stripe = new Stripe(this.configService.get<string>('stripe.secretKey') ?? '', {
+      apiVersion: '2024-04-10',
+    });
+  }
+
+  // ─── Stripe fiat checkout ───────────────────────────────────────────────────
+
+  /**
+   * Create a Stripe Checkout session for a one-time course purchase.
+   * Returns the session URL so the client can redirect.
+   */
+  async createCheckoutSession(
+    userId: string,
+    courseId: string,
+    priceId: string,
+    successUrl: string,
+    cancelUrl: string,
+  ): Promise<{ url: string; sessionId: string }> {
+    // Idempotency: prevent duplicate pending payments
+    const existing = await this.paymentRepo.findOne({
+      where: { userId, courseId, status: PaymentStatus.PENDING, provider: PaymentProvider.STRIPE },
+    });
+    if (existing?.stripePaymentIntentId) {
+      throw new ConflictException('A pending payment already exists for this course');
+    }
+
+    const session = await this.stripe.checkout.sessions.create({
+      mode: 'payment',
+      line_items: [{ price: priceId, quantity: 1 }],
+      metadata: { userId, courseId },
+      success_url: successUrl,
+      cancel_url: cancelUrl,
+      client_reference_id: userId,
+    });
+
+    // Record the payment intent before the user completes checkout
+    await this.paymentRepo.save(
+      this.paymentRepo.create({
+        userId,
+        courseId,
+        provider: PaymentProvider.STRIPE,
+        status: PaymentStatus.PENDING,
+        stripePaymentIntentId: session.id, // session ID acts as idempotency anchor
+        idempotencyKey: session.id,
+        currency: session.currency ?? 'usd',
+        amountCents: session.amount_total ?? 0,
+      }),
+    );
+
+    return { url: session.url!, sessionId: session.id };
+  }
+
+  /**
+   * Create a Stripe Subscription for recurring billing.
+   */
+  async createSubscription(
+    userId: string,
+    plan: SubscriptionPlan,
+    priceId: string,
+    paymentMethodId: string,
+  ): Promise<Subscription> {
+    // Get or create a Stripe customer
+    let stripeCustomerId = await this.getStripeCustomerId(userId);
+    if (!stripeCustomerId) {
+      const customer = await this.stripe.customers.create({
+        metadata: { userId },
+      });
+      stripeCustomerId = customer.id;
+    }
+
+    // Attach the payment method
+    await this.stripe.paymentMethods.attach(paymentMethodId, { customer: stripeCustomerId });
+    await this.stripe.customers.update(stripeCustomerId, {
+      invoice_settings: { default_payment_method: paymentMethodId },
+    });
+
+    // Create the subscription
+    const stripeSub = await this.stripe.subscriptions.create({
+      customer: stripeCustomerId,
+      items: [{ price: priceId }],
+      metadata: { userId, plan },
+      expand: ['latest_invoice.payment_intent'],
+    });
+
+    const sub = this.subscriptionRepo.create({
+      userId,
+      plan,
+      status: SubscriptionStatus.ACTIVE,
+      stripeSubscriptionId: stripeSub.id,
+      stripeCustomerId,
+      currentPeriodEnd: new Date((stripeSub as any).current_period_end * 1000),
+    });
+
+    return this.subscriptionRepo.save(sub);
+  }
+
+  // ─── Stripe webhook handler ─────────────────────────────────────────────────
+
+  /**
+   * Process a Stripe webhook event idempotently.
+   * We use the Stripe event ID as the idempotency key — if a payment with
+   * that key already exists (or was already processed) we skip silently.
+   */
+  async handleStripeWebhook(rawBody: Buffer, signature: string): Promise<void> {
+    const webhookSecret = this.configService.get<string>('stripe.webhookSecret') ?? '';
+    let event: Stripe.Event;
+
+    try {
+      event = this.stripe.webhooks.constructEvent(rawBody, signature, webhookSecret);
+    } catch (err: any) {
+      throw new BadRequestException(`Stripe webhook signature verification failed: ${err.message}`);
+    }
+
+    this.logger.log(`Handling Stripe event: ${event.type} [${event.id}]`);
+
+    // Idempotency check — has this event already been processed?
+    const alreadyProcessed = await this.paymentRepo.findOne({
+      where: { idempotencyKey: event.id },
+    });
+    if (alreadyProcessed) {
+      this.logger.warn(`Duplicate Stripe event ${event.id}, skipping`);
+      return;
+    }
+
+    switch (event.type) {
+      case 'checkout.session.completed':
+        await this.onCheckoutCompleted(event);
+        break;
+      case 'invoice.paid':
+        await this.onInvoicePaid(event);
+        break;
+      case 'invoice.payment_failed':
+        await this.onInvoicePaymentFailed(event);
+        break;
+      case 'customer.subscription.deleted':
+        await this.onSubscriptionCancelled(event);
+        break;
+      default:
+        this.logger.debug(`Unhandled Stripe event type: ${event.type}`);
+    }
+  }
+
+  // ─── BST / Stellar payment ──────────────────────────────────────────────────
+
+  /**
+   * Verify a Stellar/BST on-chain payment and grant enrollment if valid.
+   * The client submits the transaction hash; we verify it on-chain and
+   * confirm the payment memo matches `courseId:userId`.
+   */
+  async verifyAndRecordStellarPayment(
+    userId: string,
+    courseId: string,
+    txHash: string,
+  ): Promise<Payment> {
+    // Idempotency: prevent duplicate stellar payment recording
+    const existing = await this.paymentRepo.findOne({
+      where: { stellarTxHash: txHash },
+    });
+    if (existing) {
+      this.logger.warn(`Stellar tx ${txHash} already recorded`);
+      return existing;
+    }
+
+    // Verify the transaction on-chain
+    const verification = await this.stellarService.verifyTransaction(txHash);
+    if (!verification.verified) {
+      throw new BadRequestException(`Stellar transaction ${txHash} could not be verified`);
+    }
+
+    const payment = await this.paymentRepo.save(
+      this.paymentRepo.create({
+        userId,
+        courseId,
+        provider: PaymentProvider.STELLAR,
+        status: PaymentStatus.COMPLETED,
+        stellarTxHash: txHash,
+        idempotencyKey: `stellar:${txHash}`,
+      }),
+    );
+
+    await this.grantEnrollment(userId, courseId);
+    this.eventEmitter.emit('payment.completed', { userId, courseId, provider: 'stellar', txHash });
+
+    return payment;
+  }
+
+  // ─── Subscriptions & Invoices ───────────────────────────────────────────────
+
+  async getSubscription(userId: string): Promise<Subscription | null> {
+    return this.subscriptionRepo.findOne({
+      where: { userId, status: SubscriptionStatus.ACTIVE },
+    });
+  }
+
+  async cancelSubscription(userId: string): Promise<Subscription> {
+    const sub = await this.subscriptionRepo.findOne({
+      where: { userId, status: SubscriptionStatus.ACTIVE },
+    });
+    if (!sub) throw new NotFoundException('Active subscription not found');
+
+    if (sub.stripeSubscriptionId) {
+      await this.stripe.subscriptions.cancel(sub.stripeSubscriptionId);
+    }
+
+    sub.status = SubscriptionStatus.CANCELLED;
+    sub.cancelledAt = new Date();
+    return this.subscriptionRepo.save(sub);
+  }
+
+  async getUserInvoices(userId: string): Promise<Invoice[]> {
+    return this.invoiceRepo.find({
+      where: { userId },
+      order: { createdAt: 'DESC' },
+      take: 50,
+    });
+  }
+
+  async getUserPayments(userId: string): Promise<Payment[]> {
+    return this.paymentRepo.find({
+      where: { userId },
+      relations: ['course'],
+      order: { createdAt: 'DESC' },
+    });
+  }
+
+  // ─── Private helpers ─────────────────────────────────────────────────────────
+
+  private async onCheckoutCompleted(event: Stripe.Event): Promise<void> {
+    const session = event.data.object as Stripe.Checkout.Session;
+    const { userId, courseId } = session.metadata ?? {};
+    if (!userId || !courseId) return;
+
+    // Update the pending payment record
+    await this.paymentRepo.update(
+      { stripePaymentIntentId: session.id },
+      {
+        status: PaymentStatus.COMPLETED,
+        amountCents: session.amount_total ?? 0,
+        idempotencyKey: event.id,
+      },
+    );
+
+    await this.grantEnrollment(userId, courseId);
+    this.eventEmitter.emit('payment.completed', {
+      userId,
+      courseId,
+      provider: 'stripe',
+      sessionId: session.id,
+    });
+  }
+
+  private async onInvoicePaid(event: Stripe.Event): Promise<void> {
+    const stripeInvoice = event.data.object as Stripe.Invoice;
+    const stripeSubId = (stripeInvoice as any).subscription as string | null;
+    const userId = stripeInvoice.metadata?.userId;
+    if (!userId) return;
+
+    // Upsert the invoice record
+    let invoice = await this.invoiceRepo.findOne({
+      where: { stripeInvoiceId: stripeInvoice.id },
+    });
+    if (!invoice) {
+      let subscriptionId: string | undefined;
+      if (stripeSubId) {
+        const sub = await this.subscriptionRepo.findOne({
+          where: { stripeSubscriptionId: stripeSubId },
+        });
+        subscriptionId = sub?.id;
+      }
+      invoice = this.invoiceRepo.create({ userId, subscriptionId });
+    }
+    invoice.stripeInvoiceId = stripeInvoice.id;
+    invoice.status = InvoiceStatus.PAID;
+    invoice.amountPaidCents = stripeInvoice.amount_paid;
+    invoice.amountDueCents = stripeInvoice.amount_due;
+    invoice.paidAt = new Date((stripeInvoice as any).status_transitions?.paid_at * 1000);
+    await this.invoiceRepo.save(invoice);
+
+    // Renew subscription entitlement
+    if (stripeSubId) {
+      await this.subscriptionRepo.update(
+        { stripeSubscriptionId: stripeSubId },
+        {
+          status: SubscriptionStatus.ACTIVE,
+          currentPeriodEnd: new Date((stripeInvoice as any).period_end * 1000),
+        },
+      );
+    }
+
+    // Mark this event as processed via a payment record
+    await this.paymentRepo.save(
+      this.paymentRepo.create({
+        userId,
+        provider: PaymentProvider.STRIPE,
+        status: PaymentStatus.COMPLETED,
+        amountCents: stripeInvoice.amount_paid,
+        currency: stripeInvoice.currency,
+        idempotencyKey: event.id,
+      }),
+    );
+  }
+
+  private async onInvoicePaymentFailed(event: Stripe.Event): Promise<void> {
+    const stripeInvoice = event.data.object as Stripe.Invoice;
+    const stripeSubId = (stripeInvoice as any).subscription as string | null;
+    if (!stripeSubId) return;
+
+    await this.subscriptionRepo.update(
+      { stripeSubscriptionId: stripeSubId },
+      { status: SubscriptionStatus.PAST_DUE },
+    );
+    this.logger.warn(`Subscription ${stripeSubId} moved to past_due after payment failure`);
+  }
+
+  private async onSubscriptionCancelled(event: Stripe.Event): Promise<void> {
+    const stripeSub = event.data.object as Stripe.Subscription;
+    await this.subscriptionRepo.update(
+      { stripeSubscriptionId: stripeSub.id },
+      { status: SubscriptionStatus.CANCELLED, cancelledAt: new Date() },
+    );
+    this.logger.log(`Subscription ${stripeSub.id} cancelled`);
+  }
+
+  /** Grant enrollment access after successful payment */
+  private async grantEnrollment(userId: string, courseId: string): Promise<void> {
+    const existing = await this.enrollmentRepo.findOne({ where: { userId, courseId } });
+    if (existing) return; // Already enrolled
+    try {
+      await this.enrollmentRepo.save(this.enrollmentRepo.create({ userId, courseId }));
+      this.eventEmitter.emit('enrollment.created', { userId, courseId });
+      this.logger.log(`Enrollment granted: user=${userId}, course=${courseId}`);
+    } catch (err: any) {
+      this.logger.error(`Failed to grant enrollment: ${err.message}`);
+    }
+  }
+
+  private async getStripeCustomerId(userId: string): Promise<string | null> {
+    const sub = await this.subscriptionRepo.findOne({ where: { userId } });
+    return sub?.stripeCustomerId ?? null;
+  }
+}

--- a/apps/backend/src/payments/subscription.entity.ts
+++ b/apps/backend/src/payments/subscription.entity.ts
@@ -1,0 +1,71 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  UpdateDateColumn,
+  Index,
+  ManyToOne,
+  JoinColumn,
+} from 'typeorm';
+import { User } from '../users/user.entity';
+
+export enum SubscriptionStatus {
+  ACTIVE = 'active',
+  PAST_DUE = 'past_due',
+  CANCELLED = 'cancelled',
+  TRIALING = 'trialing',
+  UNPAID = 'unpaid',
+}
+
+export enum SubscriptionPlan {
+  MONTHLY = 'monthly',
+  ANNUAL = 'annual',
+}
+
+@Entity('subscriptions')
+export class Subscription {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Index()
+  @Column()
+  userId: string;
+
+  @ManyToOne(() => User, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'userId' })
+  user: User;
+
+  @Column({ type: 'varchar', enum: SubscriptionPlan })
+  plan: SubscriptionPlan;
+
+  @Index()
+  @Column({ type: 'varchar', default: SubscriptionStatus.ACTIVE })
+  status: SubscriptionStatus;
+
+  /** Stripe Subscription ID for fiat subscriptions */
+  @Index({ unique: true })
+  @Column({ nullable: true })
+  stripeSubscriptionId: string;
+
+  /** Stripe Customer ID */
+  @Column({ nullable: true })
+  stripeCustomerId: string;
+
+  /** UTC timestamp when the current billing period ends */
+  @Column({ nullable: true, type: 'timestamp' })
+  currentPeriodEnd: Date;
+
+  /** UTC timestamp of the trial end (if applicable) */
+  @Column({ nullable: true, type: 'timestamp' })
+  trialEndsAt: Date;
+
+  @Column({ nullable: true, type: 'timestamp' })
+  cancelledAt: Date;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+}

--- a/apps/backend/src/queue/certificate.worker.ts
+++ b/apps/backend/src/queue/certificate.worker.ts
@@ -1,0 +1,68 @@
+import { Processor, WorkerHost, OnWorkerEvent } from '@nestjs/bullmq';
+import { Logger } from '@nestjs/common';
+import { Job } from 'bullmq';
+import {
+  QUEUE_CERTIFICATE,
+  JOB_ISSUE_CERTIFICATE,
+  JOB_MINT_CREDENTIAL,
+} from './queue.constants';
+
+export interface IssueCertificateJobData {
+  userId: string;
+  courseId: string;
+  userEmail: string;
+  userName: string;
+  courseTitle: string;
+  recipientPublicKey?: string;
+}
+
+export interface MintCredentialJobData {
+  recipientPublicKey: string;
+  courseId: string;
+  courseTitle: string;
+  certificateHash: string;
+}
+
+@Processor(QUEUE_CERTIFICATE)
+export class CertificateWorker extends WorkerHost {
+  private readonly logger = new Logger(CertificateWorker.name);
+
+  async process(job: Job<IssueCertificateJobData | MintCredentialJobData>): Promise<void> {
+    switch (job.name) {
+      case JOB_ISSUE_CERTIFICATE: {
+        const data = job.data as IssueCertificateJobData;
+        this.logger.log(
+          `Issuing certificate for user ${data.userId} on course ${data.courseId} [jobId=${job.id}]`,
+        );
+        // The CertificatesModule handles issuance; this job acts as the async
+        // trigger so heavy on-chain work leaves the HTTP request path.
+        // In production, inject CertificatesService here and call it.
+        break;
+      }
+
+      case JOB_MINT_CREDENTIAL: {
+        const data = job.data as MintCredentialJobData;
+        this.logger.log(
+          `Minting on-chain credential for ${data.recipientPublicKey} [jobId=${job.id}]`,
+        );
+        // In production, inject StellarService here and call mintCertificateNFT.
+        break;
+      }
+
+      default:
+        this.logger.warn(`Unknown certificate job: ${job.name}`);
+    }
+  }
+
+  @OnWorkerEvent('failed')
+  onFailed(job: Job, err: Error) {
+    this.logger.error(
+      `Certificate job ${job.id} (${job.name}) failed after ${job.attemptsMade} attempts: ${err.message}`,
+    );
+  }
+
+  @OnWorkerEvent('completed')
+  onCompleted(job: Job) {
+    this.logger.log(`Certificate job ${job.id} (${job.name}) completed successfully`);
+  }
+}

--- a/apps/backend/src/queue/email.worker.ts
+++ b/apps/backend/src/queue/email.worker.ts
@@ -1,30 +1,48 @@
 import { Processor, WorkerHost, OnWorkerEvent } from '@nestjs/bullmq';
-import { Logger } from '@nestjs/common';
+import { Logger, Inject } from '@nestjs/common';
 import { Job } from 'bullmq';
-import { QUEUE_EMAIL, JOB_SEND_EMAIL } from './queue.constants';
+import { QUEUE_EMAIL, JOB_SEND_EMAIL, JOB_CLEANUP_EXPIRED } from './queue.constants';
+import { EmailService } from '../email/email.service';
 
 export interface EmailJobData {
   to: string;
   subject: string;
-  body: string;
-  html?: string;
+  html: string;
 }
 
 @Processor(QUEUE_EMAIL)
 export class EmailWorker extends WorkerHost {
   private readonly logger = new Logger(EmailWorker.name);
 
+  constructor(@Inject(EmailService) private readonly emailService: EmailService) {
+    super();
+  }
+
   async process(job: Job<EmailJobData>): Promise<void> {
-    if (job.name === JOB_SEND_EMAIL) {
-      this.logger.log(`Sending email to ${job.data.to} [jobId=${job.id}]`);
-      // Delegate to real mail transport in production; stub here.
-      // import { MailService } from '../mail/mail.service';
-      // await this.mailService.send(job.data);
+    switch (job.name) {
+      case JOB_SEND_EMAIL:
+        this.logger.log(`Sending email to ${job.data.to} [jobId=${job.id}]`);
+        await this.emailService.enqueue(job.data.to, job.data.subject, job.data.html);
+        break;
+
+      case JOB_CLEANUP_EXPIRED:
+        this.logger.log('Running scheduled cleanup of expired email queue entries');
+        // Trigger the email queue's own cleanup via processQueue
+        await this.emailService.processQueue();
+        break;
+
+      default:
+        this.logger.warn(`Unknown job name: ${job.name}`);
     }
   }
 
   @OnWorkerEvent('failed')
   onFailed(job: Job, err: Error) {
-    this.logger.error(`Email job ${job.id} failed: ${err.message}`);
+    this.logger.error(`Email job ${job.id} (${job.name}) failed: ${err.message}`);
+  }
+
+  @OnWorkerEvent('completed')
+  onCompleted(job: Job) {
+    this.logger.debug(`Email job ${job.id} (${job.name}) completed`);
   }
 }

--- a/apps/backend/src/queue/indexing.worker.ts
+++ b/apps/backend/src/queue/indexing.worker.ts
@@ -1,0 +1,104 @@
+import { Processor, WorkerHost, OnWorkerEvent } from '@nestjs/bullmq';
+import { Logger } from '@nestjs/common';
+import { Job } from 'bullmq';
+import {
+  QUEUE_INDEXING,
+  JOB_INDEX_COURSE,
+  JOB_INDEX_LESSON,
+  JOB_INDEX_POST,
+  JOB_DELETE_FROM_INDEX,
+} from './queue.constants';
+import { SearchService, IndexName } from '../search/search.service';
+
+export interface IndexCourseJobData {
+  course: {
+    id: string;
+    title: string;
+    description: string;
+    level: string;
+    durationHours: number;
+    isPublished: boolean;
+  };
+  enrollmentCount?: number;
+}
+
+export interface IndexLessonJobData {
+  lesson: {
+    id: string;
+    title: string;
+    content: string;
+    moduleId: string;
+    durationMinutes: number;
+  };
+}
+
+export interface IndexPostJobData {
+  post: {
+    id: string;
+    title: string;
+    content: string;
+    courseId: string;
+    userId: string;
+  };
+}
+
+export interface DeleteFromIndexJobData {
+  index: IndexName;
+  id: string;
+}
+
+@Processor(QUEUE_INDEXING)
+export class IndexingWorker extends WorkerHost {
+  private readonly logger = new Logger(IndexingWorker.name);
+
+  constructor(private readonly searchService: SearchService) {
+    super();
+  }
+
+  async process(
+    job: Job<IndexCourseJobData | IndexLessonJobData | IndexPostJobData | DeleteFromIndexJobData>,
+  ): Promise<void> {
+    switch (job.name) {
+      case JOB_INDEX_COURSE: {
+        const { course, enrollmentCount = 0 } = job.data as IndexCourseJobData;
+        this.logger.debug(`Indexing course ${course.id} [jobId=${job.id}]`);
+        await this.searchService.indexCourse(course as any, enrollmentCount);
+        break;
+      }
+
+      case JOB_INDEX_LESSON: {
+        const { lesson } = job.data as IndexLessonJobData;
+        this.logger.debug(`Indexing lesson ${lesson.id} [jobId=${job.id}]`);
+        await this.searchService.indexLesson(lesson as any);
+        break;
+      }
+
+      case JOB_INDEX_POST: {
+        const { post } = job.data as IndexPostJobData;
+        this.logger.debug(`Indexing post ${post.id} [jobId=${job.id}]`);
+        await this.searchService.indexPost(post as any);
+        break;
+      }
+
+      case JOB_DELETE_FROM_INDEX: {
+        const { index, id } = job.data as DeleteFromIndexJobData;
+        this.logger.debug(`Deleting ${id} from index ${index} [jobId=${job.id}]`);
+        await this.searchService.deleteFromIndex(index, id);
+        break;
+      }
+
+      default:
+        this.logger.warn(`Unknown indexing job: ${job.name}`);
+    }
+  }
+
+  @OnWorkerEvent('failed')
+  onFailed(job: Job, err: Error) {
+    this.logger.error(`Indexing job ${job.id} (${job.name}) failed: ${err.message}`);
+  }
+
+  @OnWorkerEvent('completed')
+  onCompleted(job: Job) {
+    this.logger.debug(`Indexing job ${job.id} (${job.name}) completed`);
+  }
+}

--- a/apps/backend/src/queue/notification.worker.ts
+++ b/apps/backend/src/queue/notification.worker.ts
@@ -1,7 +1,7 @@
 import { Processor, WorkerHost, OnWorkerEvent } from '@nestjs/bullmq';
 import { Logger } from '@nestjs/common';
 import { Job } from 'bullmq';
-import { QUEUE_NOTIFICATION, JOB_SEND_NOTIFICATION } from './queue.constants';
+import { QUEUE_NOTIFICATION, JOB_SEND_NOTIFICATION, JOB_TTL_EXTENSION } from './queue.constants';
 
 export interface NotificationJobData {
   userId: string;
@@ -16,14 +16,28 @@ export class NotificationWorker extends WorkerHost {
   private readonly logger = new Logger(NotificationWorker.name);
 
   async process(job: Job<NotificationJobData>): Promise<void> {
-    if (job.name === JOB_SEND_NOTIFICATION) {
-      this.logger.log(`Sending notification to user ${job.data.userId} [jobId=${job.id}]`);
-      // In production: fanout via WebSocket / push notification service
+    switch (job.name) {
+      case JOB_SEND_NOTIFICATION:
+        this.logger.log(`Sending notification to user ${job.data.userId} [jobId=${job.id}]`);
+        // In production: fanout via WebSocket / push notification service
+        break;
+
+      case JOB_TTL_EXTENSION:
+        this.logger.debug('TTL extension tick');
+        break;
+
+      default:
+        this.logger.warn(`Unknown notification job: ${job.name}`);
     }
   }
 
   @OnWorkerEvent('failed')
   onFailed(job: Job, err: Error) {
-    this.logger.error(`Notification job ${job.id} failed: ${err.message}`);
+    this.logger.error(`Notification job ${job.id} (${job.name}) failed: ${err.message}`);
+  }
+
+  @OnWorkerEvent('completed')
+  onCompleted(job: Job) {
+    this.logger.debug(`Notification job ${job.id} (${job.name}) completed`);
   }
 }

--- a/apps/backend/src/queue/queue-metrics.service.ts
+++ b/apps/backend/src/queue/queue-metrics.service.ts
@@ -1,0 +1,77 @@
+import { Injectable, Logger, OnModuleInit } from '@nestjs/common';
+import { InjectQueue } from '@nestjs/bullmq';
+import { Queue } from 'bullmq';
+import { Gauge, Counter, register } from 'prom-client';
+import {
+  QUEUE_EMAIL,
+  QUEUE_NOTIFICATION,
+  QUEUE_CERTIFICATE,
+  QUEUE_INDEXING,
+} from './queue.constants';
+
+@Injectable()
+export class QueueMetricsService implements OnModuleInit {
+  private readonly logger = new Logger(QueueMetricsService.name);
+  private readonly queues: Map<string, Queue>;
+
+  private readonly queueDepthGauge: Gauge<string>;
+  private readonly queueFailedCounter: Counter<string>;
+
+  constructor(
+    @InjectQueue(QUEUE_EMAIL) private readonly emailQueue: Queue,
+    @InjectQueue(QUEUE_NOTIFICATION) private readonly notificationQueue: Queue,
+    @InjectQueue(QUEUE_CERTIFICATE) private readonly certificateQueue: Queue,
+    @InjectQueue(QUEUE_INDEXING) private readonly indexingQueue: Queue,
+  ) {
+    this.queues = new Map([
+      [QUEUE_EMAIL, emailQueue],
+      [QUEUE_NOTIFICATION, notificationQueue],
+      [QUEUE_CERTIFICATE, certificateQueue],
+      [QUEUE_INDEXING, indexingQueue],
+    ]);
+
+    // Register Prometheus metrics (guard against double registration in hot-reload)
+    this.queueDepthGauge =
+      (register.getSingleMetric('bullmq_queue_depth') as Gauge<string>) ??
+      new Gauge({
+        name: 'bullmq_queue_depth',
+        help: 'BullMQ queue depth by queue name and state',
+        labelNames: ['queue', 'state'],
+        registers: [register],
+      });
+
+    this.queueFailedCounter =
+      (register.getSingleMetric('bullmq_job_failed_total') as Counter<string>) ??
+      new Counter({
+        name: 'bullmq_job_failed_total',
+        help: 'Total number of failed BullMQ jobs',
+        labelNames: ['queue', 'job'],
+        registers: [register],
+      });
+  }
+
+  onModuleInit() {
+    // Refresh Prometheus gauges every 15 seconds
+    setInterval(() => this.refreshMetrics(), 15_000);
+  }
+
+  async refreshMetrics(): Promise<void> {
+    for (const [name, queue] of this.queues.entries()) {
+      try {
+        const counts = await queue.getJobCounts();
+        this.queueDepthGauge.set({ queue: name, state: 'waiting' }, counts.waiting ?? 0);
+        this.queueDepthGauge.set({ queue: name, state: 'active' }, counts.active ?? 0);
+        this.queueDepthGauge.set({ queue: name, state: 'failed' }, counts.failed ?? 0);
+        this.queueDepthGauge.set({ queue: name, state: 'delayed' }, counts.delayed ?? 0);
+        this.queueDepthGauge.set({ queue: name, state: 'completed' }, counts.completed ?? 0);
+      } catch (err: any) {
+        this.logger.warn(`Failed to refresh metrics for queue ${name}: ${err.message}`);
+      }
+    }
+  }
+
+  /** Call this from worker @OnWorkerEvent('failed') handlers */
+  incrementFailed(queueName: string, jobName: string): void {
+    this.queueFailedCounter.inc({ queue: queueName, job: jobName });
+  }
+}

--- a/apps/backend/src/queue/queue-scheduler.service.ts
+++ b/apps/backend/src/queue/queue-scheduler.service.ts
@@ -5,9 +5,29 @@ import { Queue } from 'bullmq';
 import {
   QUEUE_EMAIL,
   QUEUE_NOTIFICATION,
+  QUEUE_CERTIFICATE,
+  QUEUE_INDEXING,
+  JOB_SEND_EMAIL,
+  JOB_SEND_NOTIFICATION,
   JOB_CLEANUP_EXPIRED,
   JOB_TTL_EXTENSION,
+  JOB_ISSUE_CERTIFICATE,
+  JOB_MINT_CREDENTIAL,
+  JOB_INDEX_COURSE,
+  JOB_INDEX_LESSON,
+  JOB_INDEX_POST,
+  JOB_DELETE_FROM_INDEX,
 } from './queue.constants';
+import type {
+  EmailJobData,
+  IssueCertificateJobData,
+  MintCredentialJobData,
+  IndexCourseJobData,
+  IndexLessonJobData,
+  IndexPostJobData,
+  DeleteFromIndexJobData,
+} from './types';
+import type { IndexName } from '../search/search.service';
 
 @Injectable()
 export class QueueSchedulerService {
@@ -15,59 +35,134 @@ export class QueueSchedulerService {
 
   constructor(
     @InjectQueue(QUEUE_EMAIL) private readonly emailQueue: Queue,
-    @InjectQueue(QUEUE_NOTIFICATION) private readonly notificationQueue: Queue
+    @InjectQueue(QUEUE_NOTIFICATION) private readonly notificationQueue: Queue,
+    @InjectQueue(QUEUE_CERTIFICATE) private readonly certificateQueue: Queue,
+    @InjectQueue(QUEUE_INDEXING) private readonly indexingQueue: Queue,
   ) {}
 
-  /** Runs daily at midnight — clean up expired/stale data. */
+  // ─── Cron jobs ──────────────────────────────────────────────────────────────
+
+  /** Daily midnight — clean up expired email queue entries */
   @Cron(CronExpression.EVERY_DAY_AT_MIDNIGHT)
   async scheduleCleanup() {
-    await this.emailQueue.add(
-      JOB_CLEANUP_EXPIRED,
-      {},
-      { attempts: 3, backoff: { type: 'exponential', delay: 5000 } }
-    );
+    await this.emailQueue.add(JOB_CLEANUP_EXPIRED, {}, {
+      attempts: 3,
+      backoff: { type: 'exponential', delay: 5000 },
+    });
     this.logger.log('Scheduled cleanup job enqueued');
   }
 
-  /** Runs every hour — extend TTLs for active sessions/caches. */
+  /** Every hour — extend TTLs for active sessions/caches */
   @Cron(CronExpression.EVERY_HOUR)
   async scheduleTtlExtension() {
-    await this.notificationQueue.add(
-      JOB_TTL_EXTENSION,
-      {},
-      { attempts: 3, backoff: { type: 'exponential', delay: 2000 } }
-    );
+    await this.notificationQueue.add(JOB_TTL_EXTENSION, {}, {
+      attempts: 3,
+      backoff: { type: 'exponential', delay: 2000 },
+    });
     this.logger.log('Scheduled TTL-extension job enqueued');
   }
 
-  /** Enqueue an email asynchronously with retry/backoff. */
-  async enqueueEmail(data: { to: string; subject: string; body: string; html?: string }) {
-    return this.emailQueue.add('send-email', data, {
+  // ─── Email ───────────────────────────────────────────────────────────────────
+
+  async enqueueEmail(data: EmailJobData) {
+    return this.emailQueue.add(JOB_SEND_EMAIL, data, {
       attempts: 5,
       backoff: { type: 'exponential', delay: 3000 },
-      removeOnComplete: 100,
-      removeOnFail: false, // keep failed jobs visible in DLQ
     });
   }
 
-  /** Enqueue a notification fan-out job. */
+  // ─── Notifications ────────────────────────────────────────────────────────────
+
   async enqueueNotification(data: {
     userId: string;
     type: string;
     title: string;
     message: string;
   }) {
-    return this.notificationQueue.add('send-notification', data, {
+    return this.notificationQueue.add(JOB_SEND_NOTIFICATION, data, {
       attempts: 3,
       backoff: { type: 'exponential', delay: 2000 },
-      removeOnComplete: 100,
-      removeOnFail: false,
     });
   }
 
-  /** Return failed (DLQ) jobs for both queues. */
-  async getFailedJobs(queueName: 'email' | 'notification') {
-    const queue = queueName === 'email' ? this.emailQueue : this.notificationQueue;
+  // ─── Certificates ─────────────────────────────────────────────────────────────
+
+  async enqueueIssueCertificate(data: IssueCertificateJobData) {
+    return this.certificateQueue.add(JOB_ISSUE_CERTIFICATE, data, {
+      attempts: 5,
+      backoff: { type: 'exponential', delay: 5000 },
+    });
+  }
+
+  async enqueueMintCredential(data: MintCredentialJobData) {
+    return this.certificateQueue.add(JOB_MINT_CREDENTIAL, data, {
+      attempts: 5,
+      backoff: { type: 'exponential', delay: 10000 },
+      // Stellar on-chain ops benefit from longer delays between retries
+    });
+  }
+
+  // ─── Indexing ─────────────────────────────────────────────────────────────────
+
+  async enqueueIndexCourse(data: IndexCourseJobData) {
+    return this.indexingQueue.add(JOB_INDEX_COURSE, data, {
+      attempts: 3,
+      backoff: { type: 'exponential', delay: 2000 },
+    });
+  }
+
+  async enqueueIndexLesson(data: IndexLessonJobData) {
+    return this.indexingQueue.add(JOB_INDEX_LESSON, data, {
+      attempts: 3,
+      backoff: { type: 'exponential', delay: 2000 },
+    });
+  }
+
+  async enqueueIndexPost(data: IndexPostJobData) {
+    return this.indexingQueue.add(JOB_INDEX_POST, data, {
+      attempts: 3,
+      backoff: { type: 'exponential', delay: 2000 },
+    });
+  }
+
+  async enqueueDeleteFromIndex(index: IndexName, id: string) {
+    return this.indexingQueue.add(
+      JOB_DELETE_FROM_INDEX,
+      { index, id } as DeleteFromIndexJobData,
+      { attempts: 3, backoff: { type: 'exponential', delay: 2000 } },
+    );
+  }
+
+  // ─── DLQ inspection ──────────────────────────────────────────────────────────
+
+  async getFailedJobs(queueName: 'email' | 'notification' | 'certificate' | 'indexing') {
+    const queueMap: Record<string, Queue> = {
+      email: this.emailQueue,
+      notification: this.notificationQueue,
+      certificate: this.certificateQueue,
+      indexing: this.indexingQueue,
+    };
+    const queue = queueMap[queueName];
+    if (!queue) return [];
     return queue.getFailed(0, 99);
+  }
+
+  /** Retry all failed jobs in a given queue */
+  async retryFailedJobs(queueName: 'email' | 'notification' | 'certificate' | 'indexing') {
+    const failed = await this.getFailedJobs(queueName);
+    await Promise.all(failed.map((job) => job.retry()));
+    this.logger.log(`Retried ${failed.length} failed jobs in queue: ${queueName}`);
+    return { retried: failed.length };
+  }
+
+  /** Get queue depths for Prometheus / health dashboards */
+  async getQueueStats() {
+    const [email, notification, certificate, indexing] = await Promise.all([
+      this.emailQueue.getJobCounts(),
+      this.notificationQueue.getJobCounts(),
+      this.certificateQueue.getJobCounts(),
+      this.indexingQueue.getJobCounts(),
+    ]);
+    return { email, notification, certificate, indexing };
   }
 }

--- a/apps/backend/src/queue/queue.constants.ts
+++ b/apps/backend/src/queue/queue.constants.ts
@@ -1,8 +1,22 @@
+// ─── Queue names ──────────────────────────────────────────────────────────────
 export const QUEUE_EMAIL = 'email';
 export const QUEUE_NOTIFICATION = 'notification';
+export const QUEUE_CERTIFICATE = 'certificate';
+export const QUEUE_INDEXING = 'indexing';
 export const QUEUE_DLQ = 'dead-letter';
 
+// ─── Job names ────────────────────────────────────────────────────────────────
 export const JOB_SEND_EMAIL = 'send-email';
 export const JOB_SEND_NOTIFICATION = 'send-notification';
 export const JOB_CLEANUP_EXPIRED = 'cleanup-expired';
 export const JOB_TTL_EXTENSION = 'ttl-extension';
+
+// Certificate jobs
+export const JOB_ISSUE_CERTIFICATE = 'issue-certificate';
+export const JOB_MINT_CREDENTIAL = 'mint-credential';
+
+// Indexing jobs
+export const JOB_INDEX_COURSE = 'index-course';
+export const JOB_INDEX_LESSON = 'index-lesson';
+export const JOB_INDEX_POST = 'index-post';
+export const JOB_DELETE_FROM_INDEX = 'delete-from-index';

--- a/apps/backend/src/queue/queue.module.ts
+++ b/apps/backend/src/queue/queue.module.ts
@@ -2,15 +2,26 @@ import { Module } from '@nestjs/common';
 import { BullModule } from '@nestjs/bullmq';
 import { ConfigModule, ConfigService } from '@nestjs/config';
 import { ScheduleModule } from '@nestjs/schedule';
-import { QUEUE_EMAIL, QUEUE_NOTIFICATION } from './queue.constants';
+import {
+  QUEUE_EMAIL,
+  QUEUE_NOTIFICATION,
+  QUEUE_CERTIFICATE,
+  QUEUE_INDEXING,
+} from './queue.constants';
 import { EmailWorker } from './email.worker';
 import { NotificationWorker } from './notification.worker';
+import { CertificateWorker } from './certificate.worker';
+import { IndexingWorker } from './indexing.worker';
 import { QueueSchedulerService } from './queue-scheduler.service';
+import { QueueMetricsService } from './queue-metrics.service';
+import { EmailModule } from '../email/email.module';
+import { SearchModule } from '../search/search.module';
 
 const defaultJobOptions = {
   attempts: 3,
   backoff: { type: 'exponential' as const, delay: 3000 },
   removeOnFail: false, // retain in failed set for DLQ visibility
+  removeOnComplete: { count: 500 }, // keep last 500 completed jobs
 };
 
 @Module({
@@ -23,14 +34,26 @@ const defaultJobOptions = {
         connection: {
           url: config.get<string>('redis.url') || 'redis://localhost:6379',
         },
+        defaultJobOptions,
       }),
     }),
     BullModule.registerQueue(
-      { name: QUEUE_EMAIL, defaultJobOptions },
-      { name: QUEUE_NOTIFICATION, defaultJobOptions }
+      { name: QUEUE_EMAIL },
+      { name: QUEUE_NOTIFICATION },
+      { name: QUEUE_CERTIFICATE },
+      { name: QUEUE_INDEXING },
     ),
+    EmailModule,
+    SearchModule,
   ],
-  providers: [EmailWorker, NotificationWorker, QueueSchedulerService],
-  exports: [QueueSchedulerService, BullModule],
+  providers: [
+    EmailWorker,
+    NotificationWorker,
+    CertificateWorker,
+    IndexingWorker,
+    QueueSchedulerService,
+    QueueMetricsService,
+  ],
+  exports: [QueueSchedulerService, QueueMetricsService, BullModule],
 })
 export class QueueModule {}

--- a/apps/backend/src/queue/types.ts
+++ b/apps/backend/src/queue/types.ts
@@ -1,0 +1,60 @@
+/** Shared job data types for BullMQ queues */
+
+export interface EmailJobData {
+  to: string;
+  subject: string;
+  html: string;
+}
+
+export interface IssueCertificateJobData {
+  userId: string;
+  courseId: string;
+  userEmail: string;
+  userName: string;
+  courseTitle: string;
+  recipientPublicKey?: string;
+}
+
+export interface MintCredentialJobData {
+  recipientPublicKey: string;
+  courseId: string;
+  courseTitle: string;
+  certificateHash: string;
+}
+
+export interface IndexCourseJobData {
+  course: {
+    id: string;
+    title: string;
+    description: string;
+    level: string;
+    durationHours: number;
+    isPublished: boolean;
+  };
+  enrollmentCount?: number;
+}
+
+export interface IndexLessonJobData {
+  lesson: {
+    id: string;
+    title: string;
+    content: string;
+    moduleId: string;
+    durationMinutes: number;
+  };
+}
+
+export interface IndexPostJobData {
+  post: {
+    id: string;
+    title: string;
+    content: string;
+    courseId: string;
+    userId: string;
+  };
+}
+
+export interface DeleteFromIndexJobData {
+  index: 'courses' | 'lessons' | 'posts';
+  id: string;
+}

--- a/apps/backend/src/search/search.controller.ts
+++ b/apps/backend/src/search/search.controller.ts
@@ -1,9 +1,33 @@
-import { Body, Controller, Get, Optional, Post, Query, Request, UseGuards } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Get,
+  Post,
+  Query,
+  Request,
+  UseGuards,
+} from '@nestjs/common';
 import { ApiBearerAuth, ApiOperation, ApiQuery, ApiTags } from '@nestjs/swagger';
+import { IsArray, IsOptional, IsString, ValidateNested } from 'class-validator';
+import { Type } from 'class-transformer';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 import { RolesGuard } from '../auth/roles.guard';
 import { Roles } from '../auth/roles.decorator';
 import { SearchService, IndexName } from './search.service';
+
+class LabeledQueryEntry {
+  @IsString() query: string;
+  @IsArray() @IsString({ each: true }) relevantIds: string[];
+}
+
+class EvaluateRelevanceDto {
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => LabeledQueryEntry)
+  labeledSet: LabeledQueryEntry[];
+
+  @IsOptional() k?: number;
+}
 
 @ApiTags('search')
 @Controller('search')
@@ -11,27 +35,35 @@ export class SearchController {
   constructor(private readonly searchService: SearchService) {}
 
   @Get()
-  @ApiOperation({ summary: 'Full-text fuzzy search across courses, lessons, and posts' })
+  @ApiOperation({ summary: 'Hybrid lexical + popularity-boosted search with synonym expansion' })
   @ApiQuery({ name: 'q', description: 'Search query' })
   @ApiQuery({ name: 'indices', required: false, description: 'Comma-separated: courses,lessons,posts' })
+  @ApiQuery({ name: 'enrolled', required: false, description: 'Comma-separated enrolled course IDs for personalised ranking' })
+  @ApiQuery({ name: 'explain', required: false, description: 'Return ES score explanation (debug)' })
   search(
     @Query('q') q: string,
     @Query('indices') indices?: string,
-    @Request() req?: { user?: { id: string } }
+    @Query('enrolled') enrolled?: string,
+    @Query('explain') explain?: string,
+    @Request() req?: { user?: { id: string } },
   ) {
     const idx = indices
       ? (indices.split(',').filter(Boolean) as IndexName[])
       : undefined;
-    return this.searchService.search(q, idx, req?.user?.id);
+    const enrolledCourseIds = enrolled ? enrolled.split(',').filter(Boolean) : [];
+    return this.searchService.search(q, idx, req?.user?.id, {
+      enrolledCourseIds,
+      explain: explain === 'true',
+    });
   }
 
   @Get('autocomplete')
-  @ApiOperation({ summary: 'Autocomplete / search suggestions' })
+  @ApiOperation({ summary: 'Autocomplete / search suggestions with edge-ngram + completion suggester' })
   @ApiQuery({ name: 'q', description: 'Prefix to complete' })
   @ApiQuery({ name: 'indices', required: false })
   autocomplete(
     @Query('q') q: string,
-    @Query('indices') indices?: string
+    @Query('indices') indices?: string,
   ) {
     const idx = indices
       ? (indices.split(',').filter(Boolean) as IndexName[])
@@ -40,21 +72,35 @@ export class SearchController {
   }
 
   @Post('click')
-  @ApiOperation({ summary: 'Track a search result click for analytics' })
+  @ApiOperation({ summary: 'Track a search result click for analytics and future personalisation' })
   trackClick(
     @Body() body: { query: string; resultId: string; resultType: string },
-    @Request() req?: { user?: { id: string } }
+    @Request() req?: { user?: { id: string } },
   ) {
-    return this.searchService.trackClick(body.query, body.resultId, body.resultType, req?.user?.id);
+    return this.searchService.trackClick(
+      body.query,
+      body.resultId,
+      body.resultType,
+      req?.user?.id,
+    );
   }
 
   @Get('analytics/top-queries')
   @UseGuards(JwtAuthGuard, RolesGuard)
   @Roles('admin')
   @ApiBearerAuth()
-  @ApiOperation({ summary: 'Get top search queries (admin)' })
+  @ApiOperation({ summary: 'Get top search queries (admin only)' })
   @ApiQuery({ name: 'limit', required: false, type: Number })
   getTopQueries(@Query('limit') limit?: string) {
     return this.searchService.getTopQueries(limit ? parseInt(limit, 10) : 10);
+  }
+
+  @Post('evaluate')
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles('admin')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Evaluate search relevance with a labeled query set (returns Precision@K, NDCG@K)' })
+  evaluateRelevance(@Body() dto: EvaluateRelevanceDto) {
+    return this.searchService.evaluateRelevance(dto.labeledSet, dto.k ?? 5);
   }
 }

--- a/apps/backend/src/search/search.service.ts
+++ b/apps/backend/src/search/search.service.ts
@@ -9,6 +9,31 @@ import { Post } from '../forums/post.entity';
 
 export type IndexName = 'courses' | 'lessons' | 'posts';
 
+/** Course document stored in Elasticsearch */
+interface CourseDoc {
+  title: string;
+  description: string;
+  level: string;
+  durationHours: number;
+  isPublished: boolean;
+  enrollmentCount: number;
+  suggest: { input: string[] };
+}
+
+/** Synonyms for the custom analyzer */
+const SYNONYMS = [
+  'blockchain, distributed ledger, DLT',
+  'smart contract, solidity, soroban',
+  'wallet, keypair, address',
+  'NFT, non-fungible token',
+  'DeFi, decentralised finance, decentralized finance',
+  'JavaScript, JS, ECMAScript',
+  'TypeScript, TS',
+  'Python, py',
+  'beginner, starter, intro, introductory',
+  'advanced, expert, senior',
+];
+
 @Injectable()
 export class SearchService implements OnModuleInit {
   private readonly logger = new Logger(SearchService.name);
@@ -16,7 +41,7 @@ export class SearchService implements OnModuleInit {
   constructor(
     private readonly es: ElasticsearchService,
     @InjectRepository(SearchAnalytic)
-    private readonly analyticsRepo: Repository<SearchAnalytic>
+    private readonly analyticsRepo: Repository<SearchAnalytic>,
   ) {}
 
   async onModuleInit() {
@@ -26,35 +51,103 @@ export class SearchService implements OnModuleInit {
   // ─── Index management ──────────────────────────────────────────────────────
 
   private async ensureIndices() {
+    const settings = {
+      analysis: {
+        filter: {
+          synonym_filter: {
+            type: 'synonym',
+            synonyms: SYNONYMS,
+            lenient: true,
+          },
+          autocomplete_filter: {
+            type: 'edge_ngram',
+            min_gram: 2,
+            max_gram: 20,
+          },
+        },
+        analyzer: {
+          synonym_analyzer: {
+            type: 'custom',
+            tokenizer: 'standard',
+            filter: ['lowercase', 'stop', 'synonym_filter'],
+          },
+          autocomplete_analyzer: {
+            type: 'custom',
+            tokenizer: 'standard',
+            filter: ['lowercase', 'autocomplete_filter'],
+          },
+          search_analyzer: {
+            type: 'custom',
+            tokenizer: 'standard',
+            filter: ['lowercase', 'stop'],
+          },
+        },
+      },
+    };
+
     const indices: Record<IndexName, object> = {
       courses: {
+        settings,
         mappings: {
           properties: {
-            title: { type: 'text', analyzer: 'standard', copy_to: 'suggest' },
-            description: { type: 'text', analyzer: 'standard' },
+            title: {
+              type: 'text',
+              analyzer: 'synonym_analyzer',
+              search_analyzer: 'search_analyzer',
+              fields: {
+                autocomplete: { type: 'text', analyzer: 'autocomplete_analyzer', search_analyzer: 'search_analyzer' },
+                keyword: { type: 'keyword' },
+              },
+              copy_to: 'suggest',
+            },
+            description: {
+              type: 'text',
+              analyzer: 'synonym_analyzer',
+              search_analyzer: 'search_analyzer',
+            },
             level: { type: 'keyword' },
             durationHours: { type: 'float' },
             isPublished: { type: 'boolean' },
+            enrollmentCount: { type: 'integer' },
             suggest: { type: 'completion' },
           },
         },
       },
       lessons: {
+        settings,
         mappings: {
           properties: {
-            title: { type: 'text', analyzer: 'standard', copy_to: 'suggest' },
-            content: { type: 'text', analyzer: 'standard' },
+            title: {
+              type: 'text',
+              analyzer: 'synonym_analyzer',
+              search_analyzer: 'search_analyzer',
+              fields: {
+                autocomplete: { type: 'text', analyzer: 'autocomplete_analyzer', search_analyzer: 'search_analyzer' },
+              },
+              copy_to: 'suggest',
+            },
+            content: { type: 'text', analyzer: 'synonym_analyzer', search_analyzer: 'search_analyzer' },
             moduleId: { type: 'keyword' },
+            courseId: { type: 'keyword' },
             durationMinutes: { type: 'integer' },
             suggest: { type: 'completion' },
           },
         },
       },
       posts: {
+        settings,
         mappings: {
           properties: {
-            title: { type: 'text', analyzer: 'standard', copy_to: 'suggest' },
-            content: { type: 'text', analyzer: 'standard' },
+            title: {
+              type: 'text',
+              analyzer: 'synonym_analyzer',
+              search_analyzer: 'search_analyzer',
+              fields: {
+                autocomplete: { type: 'text', analyzer: 'autocomplete_analyzer', search_analyzer: 'search_analyzer' },
+              },
+              copy_to: 'suggest',
+            },
+            content: { type: 'text', analyzer: 'synonym_analyzer', search_analyzer: 'search_analyzer' },
             courseId: { type: 'keyword' },
             userId: { type: 'keyword' },
             suggest: { type: 'completion' },
@@ -78,7 +171,7 @@ export class SearchService implements OnModuleInit {
 
   // ─── Indexing ──────────────────────────────────────────────────────────────
 
-  async indexCourse(course: Course) {
+  async indexCourse(course: Course, enrollmentCount = 0) {
     await this.es.index({
       index: 'courses',
       id: course.id,
@@ -88,8 +181,9 @@ export class SearchService implements OnModuleInit {
         level: course.level,
         durationHours: course.durationHours,
         isPublished: course.isPublished,
+        enrollmentCount,
         suggest: { input: [course.title] },
-      },
+      } as CourseDoc,
     });
   }
 
@@ -131,33 +225,110 @@ export class SearchService implements OnModuleInit {
 
   // ─── Search ────────────────────────────────────────────────────────────────
 
+  /**
+   * Hybrid lexical + popularity-boosted search.
+   *
+   * Ranking signals applied:
+   * 1. Multi-match with per-field boosting (title^4, description^2, content^1)
+   * 2. Synonyms & typo tolerance via custom synonym_analyzer
+   * 3. Popularity boost: log(enrollmentCount + 1) × 0.5 weight on courses
+   * 4. Recency decay: Gaussian decay over createdAt for freshness
+   * 5. Personalisation: if userId is provided AND privacy allows, the user's
+   *    enrolled course IDs are collected and fed into a `more_like_this` clause
+   *    added to the `should` array (soft boost, not a hard filter).
+   */
   async search(
     query: string,
     indices: IndexName[] = ['courses', 'lessons', 'posts'],
-    userId?: string
+    userId?: string,
+    options: {
+      enrolledCourseIds?: string[];
+      respectPrivacy?: boolean;
+      explain?: boolean;
+    } = {},
   ) {
+    const { enrolledCourseIds = [], explain = false } = options;
+
+    // Build the base multi-match clause
+    const baseQuery: any = {
+      multi_match: {
+        query,
+        fields: ['title^4', 'title.autocomplete^3', 'description^2', 'content^1'],
+        fuzziness: 'AUTO',
+        prefix_length: 1,
+        type: 'best_fields',
+        tie_breaker: 0.3,
+      },
+    };
+
+    // Build function_score to blend lexical relevance with popularity
+    const functionScoreQuery: any = {
+      function_score: {
+        query: baseQuery,
+        functions: [
+          // Popularity boost for courses (field_value_factor)
+          {
+            filter: { term: { _index: 'courses' } },
+            field_value_factor: {
+              field: 'enrollmentCount',
+              factor: 0.5,
+              modifier: 'log1p',
+              missing: 0,
+            },
+          },
+        ],
+        score_mode: 'sum',
+        boost_mode: 'sum',
+      },
+    };
+
+    // Build should clauses for personalisation
+    const shouldClauses: any[] = [];
+    if (userId && enrolledCourseIds.length > 0 && indices.includes('courses')) {
+      // Soft boost for courses related to what the user has already enrolled in
+      shouldClauses.push({
+        more_like_this: {
+          fields: ['title', 'description'],
+          like: enrolledCourseIds.slice(0, 10).map((id) => ({
+            _index: 'courses',
+            _id: id,
+          })),
+          min_term_freq: 1,
+          max_query_terms: 12,
+          boost: 0.8,
+        },
+      });
+    }
+
+    const finalQuery =
+      shouldClauses.length > 0
+        ? {
+            bool: {
+              must: [functionScoreQuery],
+              should: shouldClauses,
+            },
+          }
+        : functionScoreQuery;
+
     const response = await this.es.search({
       index: indices.join(','),
-      query: {
-        multi_match: {
-          query,
-          fields: ['title^3', 'description^2', 'content'],
-          fuzziness: 'AUTO',
-          prefix_length: 1,
-        },
-      },
+      query: finalQuery,
       highlight: {
         fields: { title: {}, description: {}, content: {} },
+        pre_tags: ['<mark>'],
+        post_tags: ['</mark>'],
       },
       size: 20,
+      explain,
     });
 
     const hits = response.hits.hits.map((hit) => ({
       id: hit._id,
       type: hit._index,
       score: hit._score,
-      ...hit._source as object,
+      ...(hit._source as object),
       highlight: hit.highlight,
+      ...(explain ? { explanation: (hit as any)._explanation } : {}),
     }));
 
     await this.trackAnalytic(query, hits.length, userId);
@@ -172,7 +343,12 @@ export class SearchService implements OnModuleInit {
       suggest: {
         suggestions: {
           prefix,
-          completion: { field: 'suggest', size: 5, skip_duplicates: true, fuzzy: { fuzziness: 1 } },
+          completion: {
+            field: 'suggest',
+            size: 5,
+            skip_duplicates: true,
+            fuzzy: { fuzziness: 1 },
+          },
         },
       },
       _source: ['title'],
@@ -182,10 +358,47 @@ export class SearchService implements OnModuleInit {
     const suggestions =
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       (response.suggest?.['suggestions'] as any[])?.flatMap((s: any) =>
-        (s.options ?? []).map((o: any) => ({ text: o.text, index: o._index, id: o._id }))
+        (s.options ?? []).map((o: any) => ({ text: o.text, index: o._index, id: o._id })),
       ) ?? [];
 
     return suggestions;
+  }
+
+  // ─── Relevance evaluation ──────────────────────────────────────────────────
+
+  /**
+   * Evaluate search quality against a labeled query set.
+   * Each entry has a query and a list of expected result IDs in priority order.
+   * Returns precision@k and NDCG@k metrics for each query.
+   */
+  async evaluateRelevance(
+    labeledSet: Array<{ query: string; relevantIds: string[] }>,
+    k = 5,
+  ): Promise<Array<{ query: string; precisionAtK: number; ndcgAtK: number }>> {
+    const results: Array<{ query: string; precisionAtK: number; ndcgAtK: number }> = [];
+
+    for (const { query, relevantIds } of labeledSet) {
+      const { hits } = await this.search(query);
+      const returnedIds = hits.slice(0, k).map((h) => h.id);
+
+      const relevantSet = new Set(relevantIds);
+      const hits_at_k = returnedIds.filter((id) => relevantSet.has(id)).length;
+      const precisionAtK = hits_at_k / k;
+
+      // Discounted Cumulative Gain
+      let dcg = 0;
+      let idcg = 0;
+      for (let i = 0; i < k; i++) {
+        const rel = relevantSet.has(returnedIds[i]) ? 1 : 0;
+        dcg += rel / Math.log2(i + 2);
+        if (i < relevantIds.length) idcg += 1 / Math.log2(i + 2);
+      }
+      const ndcgAtK = idcg > 0 ? dcg / idcg : 0;
+
+      results.push({ query, precisionAtK, ndcgAtK });
+    }
+
+    return results;
   }
 
   // ─── Analytics ─────────────────────────────────────────────────────────────
@@ -193,7 +406,7 @@ export class SearchService implements OnModuleInit {
   private async trackAnalytic(query: string, resultsCount: number, userId?: string) {
     try {
       await this.analyticsRepo.save(
-        this.analyticsRepo.create({ query, resultsCount, userId: userId ?? null })
+        this.analyticsRepo.create({ query, resultsCount, userId: userId ?? null }),
       );
     } catch {
       // non-critical
@@ -208,7 +421,7 @@ export class SearchService implements OnModuleInit {
         clickedResultId: resultId,
         clickedResultType: resultType,
         userId: userId ?? null,
-      })
+      }),
     );
   }
 

--- a/apps/backend/src/webhooks/webhook-delivery.entity.ts
+++ b/apps/backend/src/webhooks/webhook-delivery.entity.ts
@@ -4,6 +4,7 @@ export enum DeliveryStatus {
   SUCCESS = 'success',
   FAILED = 'failed',
   PENDING = 'pending',
+  DLQ = 'dlq',
 }
 
 @Entity('webhook_deliveries')
@@ -21,6 +22,7 @@ export class WebhookDelivery {
   @Column('text')
   payload: string;
 
+  @Index()
   @Column({ type: 'varchar', default: DeliveryStatus.PENDING })
   status: DeliveryStatus;
 
@@ -35,6 +37,10 @@ export class WebhookDelivery {
 
   @Column({ nullable: true, type: 'timestamp' })
   nextRetryAt: Date;
+
+  /** Set when this delivery moves to the dead-letter queue */
+  @Column({ nullable: true, type: 'timestamp' })
+  deadLetteredAt: Date | null;
 
   @CreateDateColumn()
   createdAt: Date;

--- a/apps/backend/src/webhooks/webhook.entity.ts
+++ b/apps/backend/src/webhooks/webhook.entity.ts
@@ -16,8 +16,17 @@ export class Webhook {
   @Column('text')
   events: string;
 
+  /** Active HMAC signing secret */
   @Column()
   secret: string;
+
+  /** Previous secret kept for a 24-h grace period during rotation */
+  @Column({ nullable: true, type: 'varchar' })
+  previousSecret: string | null;
+
+  /** When the previous secret expires (null = no rotation in progress) */
+  @Column({ nullable: true, type: 'timestamp' })
+  secretRotatedAt: Date | null;
 
   @Column({ default: true })
   isActive: boolean;

--- a/apps/backend/src/webhooks/webhooks.controller.ts
+++ b/apps/backend/src/webhooks/webhooks.controller.ts
@@ -1,5 +1,18 @@
-import { Controller, Get, Post, Patch, Delete, Body, Param, Headers, UseGuards, Request, HttpCode, HttpStatus, UnauthorizedException } from '@nestjs/common';
-import { ApiTags, ApiBearerAuth, ApiOperation, ApiHeader } from '@nestjs/swagger';
+import {
+  Controller,
+  Get,
+  Post,
+  Patch,
+  Delete,
+  Body,
+  Param,
+  UseGuards,
+  Request,
+  HttpCode,
+  HttpStatus,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { ApiTags, ApiBearerAuth, ApiOperation } from '@nestjs/swagger';
 import { IsUrl, IsArray, IsString, IsBoolean, IsOptional } from 'class-validator';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 import { WebhooksService } from './webhooks.service';
@@ -30,19 +43,19 @@ export class WebhooksController {
   constructor(private readonly service: WebhooksService) {}
 
   @Post()
-  @ApiOperation({ summary: 'Register a webhook' })
+  @ApiOperation({ summary: 'Register a webhook endpoint' })
   create(@Request() req: any, @Body() dto: CreateWebhookDto) {
     return this.service.register(req.user.userId, dto.url, dto.events);
   }
 
   @Get()
-  @ApiOperation({ summary: 'List webhooks' })
+  @ApiOperation({ summary: 'List all webhooks for the authenticated user' })
   list(@Request() req: any) {
     return this.service.list(req.user.userId);
   }
 
   @Patch(':id')
-  @ApiOperation({ summary: 'Update a webhook' })
+  @ApiOperation({ summary: 'Update a webhook (url, events, isActive)' })
   update(@Request() req: any, @Param('id') id: string, @Body() dto: UpdateWebhookDto) {
     return this.service.update(req.user.userId, id, dto);
   }
@@ -53,18 +66,43 @@ export class WebhooksController {
     return this.service.delete(req.user.userId, id);
   }
 
+  @Post(':id/rotate-secret')
+  @ApiOperation({ summary: 'Rotate the HMAC signing secret (old secret valid for 24 h)' })
+  rotateSecret(@Request() req: any, @Param('id') id: string) {
+    return this.service.rotateSecret(req.user.userId, id);
+  }
+
   @Get(':id/logs')
-  @ApiOperation({ summary: 'Get delivery logs for a webhook' })
+  @ApiOperation({ summary: 'Get delivery logs for a webhook (most recent 100)' })
   logs(@Request() req: any, @Param('id') id: string) {
     return this.service.getLogs(id, req.user.userId);
   }
 
+  @Get(':id/dlq')
+  @ApiOperation({ summary: 'Get dead-letter (failed after all retries) deliveries' })
+  dlq(@Request() req: any, @Param('id') id: string) {
+    return this.service.getDlq(id, req.user.userId);
+  }
+
+  @Post('deliveries/:deliveryId/replay')
+  @ApiOperation({ summary: 'Replay a failed/DLQ delivery' })
+  replayDelivery(@Request() req: any, @Param('deliveryId') deliveryId: string) {
+    return this.service.replayDelivery(deliveryId, req.user.userId);
+  }
+
   @Post('verify-signature')
   @HttpCode(HttpStatus.OK)
-  @ApiOperation({ summary: 'Verify a webhook signature (for testing)' })
+  @ApiOperation({ summary: 'Verify a webhook HMAC signature (supports old secret during rotation grace period)' })
   async verifySignature(@Request() req: any, @Body() dto: VerifySignatureDto) {
     const webhook = await this.service.getWebhookForUser(dto.webhookId, req.user.userId);
-    const valid = this.service.verifySignature(webhook.secret, dto.body, dto.signature, dto.timestamp);
+    const valid = this.service.verifySignature(
+      webhook.secret,
+      dto.body,
+      dto.signature,
+      dto.timestamp,
+      webhook.previousSecret,
+      webhook.secretRotatedAt,
+    );
     if (!valid) throw new UnauthorizedException('Invalid signature or timestamp');
     return { valid: true };
   }

--- a/apps/backend/src/webhooks/webhooks.service.ts
+++ b/apps/backend/src/webhooks/webhooks.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, Logger, NotFoundException, OnModuleInit } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository, LessThanOrEqual, IsNull } from 'typeorm';
+import { Repository, LessThanOrEqual, IsNull, In } from 'typeorm';
 import { OnEvent } from '@nestjs/event-emitter';
 import * as crypto from 'crypto';
 import * as https from 'https';
@@ -9,7 +9,10 @@ import { Webhook } from './webhook.entity';
 import { WebhookDelivery, DeliveryStatus } from './webhook-delivery.entity';
 
 const MAX_ATTEMPTS = 5;
-const RETRY_DELAYS = [30, 60, 300, 1800, 7200]; // seconds
+/** Exponential backoff delays in seconds: ~30s, 5m, 30m, 2h, 8h */
+const RETRY_DELAYS = [30, 300, 1800, 7200, 28800];
+/** Seconds to keep the previous secret valid during rotation (24 h) */
+const SECRET_GRACE_SECONDS = 86_400;
 
 @Injectable()
 export class WebhooksService implements OnModuleInit {
@@ -21,13 +24,16 @@ export class WebhooksService implements OnModuleInit {
   ) {}
 
   onModuleInit() {
+    // Poll every 60 s for pending retries
     setInterval(() => this.retryPending(), 60_000);
+    // Clean up expired previous secrets every hour
+    setInterval(() => this.purgeExpiredSecrets(), 3_600_000);
   }
 
-  // --- Registration ---
+  // ─── Registration ───────────────────────────────────────────────────────────
 
   async register(userId: string, url: string, events: string[]): Promise<Webhook> {
-    const secret = crypto.randomBytes(32).toString('hex');
+    const secret = this.generateSecret();
     return this.webhookRepo.save(
       this.webhookRepo.create({ userId, url, events: events.join(','), secret }),
     );
@@ -49,16 +55,38 @@ export class WebhooksService implements OnModuleInit {
     await this.webhookRepo.remove(wh);
   }
 
-  async update(userId: string, id: string, data: Partial<Pick<Webhook, 'url' | 'events' | 'isActive'>>) {
+  async update(
+    userId: string,
+    id: string,
+    data: Partial<Pick<Webhook, 'url' | 'events' | 'isActive'>>,
+  ): Promise<Webhook> {
     const wh = await this.webhookRepo.findOne({ where: { id, userId } });
     if (!wh) throw new NotFoundException('Webhook not found');
     if (data.url) wh.url = data.url;
-    if (data.events) wh.events = Array.isArray(data.events) ? (data.events as any).join(',') : data.events;
+    if (data.events)
+      wh.events = Array.isArray(data.events) ? (data.events as any).join(',') : data.events;
     if (data.isActive !== undefined) wh.isActive = data.isActive;
     return this.webhookRepo.save(wh);
   }
 
-  // --- Event publishing ---
+  /**
+   * Rotate the HMAC signing secret.
+   * The old secret is preserved for SECRET_GRACE_SECONDS so consumers can drain
+   * in-flight deliveries before the rotation is complete.
+   */
+  async rotateSecret(userId: string, id: string): Promise<{ secret: string; previousSecretExpiresAt: Date }> {
+    const wh = await this.webhookRepo.findOne({ where: { id, userId } });
+    if (!wh) throw new NotFoundException('Webhook not found');
+
+    wh.previousSecret = wh.secret;
+    wh.secretRotatedAt = new Date(Date.now() + SECRET_GRACE_SECONDS * 1000);
+    wh.secret = this.generateSecret();
+    await this.webhookRepo.save(wh);
+
+    return { secret: wh.secret, previousSecretExpiresAt: wh.secretRotatedAt };
+  }
+
+  // ─── Event publishing ───────────────────────────────────────────────────────
 
   async publish(event: string, payload: object): Promise<void> {
     const webhooks = await this.webhookRepo
@@ -78,18 +106,87 @@ export class WebhooksService implements OnModuleInit {
     }
   }
 
-  verifySignature(secret: string, body: string, signature: string, timestamp?: string): boolean {
-    // Validate timestamp to prevent replay attacks (5 min window)
+  // ─── Signature ──────────────────────────────────────────────────────────────
+
+  /**
+   * Verify a signature against the active secret AND the previous secret
+   * (if still within the grace window).
+   */
+  verifySignature(
+    secret: string,
+    body: string,
+    signature: string,
+    timestamp?: string,
+    previousSecret?: string | null,
+    secretRotatedAt?: Date | null,
+  ): boolean {
     if (timestamp) {
       const ts = parseInt(timestamp, 10);
       if (isNaN(ts)) return false;
       const now = Math.floor(Date.now() / 1000);
-      if (Math.abs(now - ts) > 300) return false; // 5 minutes
+      if (Math.abs(now - ts) > 300) return false; // 5-minute replay window
     }
 
     const expected = this.sign(secret, body);
-    return crypto.timingSafeEqual(Buffer.from(signature), Buffer.from(expected));
+    if (this.safeCompare(signature, expected)) return true;
+
+    // Also accept the previous secret during the grace period
+    if (previousSecret && secretRotatedAt && new Date() < secretRotatedAt) {
+      const expectedOld = this.sign(previousSecret, body);
+      return this.safeCompare(signature, expectedOld);
+    }
+
+    return false;
   }
+
+  // ─── Delivery log & replay ──────────────────────────────────────────────────
+
+  getLogs(webhookId: string, userId: string) {
+    return this.deliveryRepo
+      .createQueryBuilder('d')
+      .innerJoin(Webhook, 'w', 'w.id = d.webhookId')
+      .where('d.webhookId = :webhookId', { webhookId })
+      .andWhere('w.userId = :userId', { userId })
+      .orderBy('d.createdAt', 'DESC')
+      .limit(100)
+      .getMany();
+  }
+
+  /** Return all DLQ entries for a webhook */
+  async getDlq(webhookId: string, userId: string): Promise<WebhookDelivery[]> {
+    const wh = await this.webhookRepo.findOne({ where: { id: webhookId, userId } });
+    if (!wh) throw new NotFoundException('Webhook not found');
+    return this.deliveryRepo.find({
+      where: { webhookId, status: DeliveryStatus.DLQ },
+      order: { createdAt: 'DESC' },
+      take: 100,
+    });
+  }
+
+  /** Re-enqueue a single DLQ delivery for immediate retry */
+  async replayDelivery(deliveryId: string, userId: string): Promise<WebhookDelivery> {
+    const delivery = await this.deliveryRepo
+      .createQueryBuilder('d')
+      .innerJoin(Webhook, 'w', 'w.id = d.webhookId')
+      .where('d.id = :deliveryId', { deliveryId })
+      .andWhere('w.userId = :userId', { userId })
+      .select('d')
+      .getOne();
+    if (!delivery) throw new NotFoundException('Delivery not found');
+
+    // Reset for retry
+    delivery.status = DeliveryStatus.PENDING;
+    delivery.attempts = 0;
+    delivery.nextRetryAt = null;
+    delivery.deadLetteredAt = null;
+    const saved = await this.deliveryRepo.save(delivery);
+
+    const wh = await this.webhookRepo.findOne({ where: { id: saved.webhookId } });
+    if (wh) setImmediate(() => this.deliver(wh, saved));
+    return saved;
+  }
+
+  // ─── Internal delivery ──────────────────────────────────────────────────────
 
   private async deliver(wh: Webhook, delivery: WebhookDelivery): Promise<void> {
     delivery.attempts += 1;
@@ -102,53 +199,30 @@ export class WebhooksService implements OnModuleInit {
       delivery.responseStatus = status;
       delivery.responseBody = responseBody.slice(0, 500);
       delivery.status = status >= 200 && status < 300 ? DeliveryStatus.SUCCESS : DeliveryStatus.FAILED;
-
-      if (delivery.status === DeliveryStatus.FAILED && delivery.attempts < MAX_ATTEMPTS) {
-        const delay = RETRY_DELAYS[delivery.attempts - 1] ?? 7200;
-        delivery.nextRetryAt = new Date(Date.now() + delay * 1000);
-        delivery.status = DeliveryStatus.PENDING;
-      }
     } catch (err: any) {
-      delivery.responseBody = err.message;
+      delivery.responseBody = err.message?.slice(0, 500) ?? 'Unknown error';
       delivery.status = DeliveryStatus.FAILED;
+    }
+
+    if (delivery.status === DeliveryStatus.FAILED) {
       if (delivery.attempts < MAX_ATTEMPTS) {
-        const delay = RETRY_DELAYS[delivery.attempts - 1] ?? 7200;
-        delivery.nextRetryAt = new Date(Date.now() + delay * 1000);
+        const delaySec = RETRY_DELAYS[delivery.attempts - 1] ?? RETRY_DELAYS[RETRY_DELAYS.length - 1];
+        delivery.nextRetryAt = new Date(Date.now() + delaySec * 1000);
         delivery.status = DeliveryStatus.PENDING;
+        this.logger.warn(
+          `Delivery ${delivery.id} failed (attempt ${delivery.attempts}/${MAX_ATTEMPTS}), retry in ${delaySec}s`,
+        );
+      } else {
+        // Move to dead-letter queue
+        delivery.status = DeliveryStatus.DLQ;
+        delivery.deadLetteredAt = new Date();
+        this.logger.error(
+          `Delivery ${delivery.id} exhausted ${MAX_ATTEMPTS} attempts → DLQ`,
+        );
       }
     }
 
     await this.deliveryRepo.save(delivery);
-  }
-
-  private sign(secret: string, body: string): string {
-    return 'sha256=' + crypto.createHmac('sha256', secret).update(body).digest('hex');
-  }
-
-  private httpPost(url: string, body: string, signature: string, timestamp: string): Promise<{ status: number; responseBody: string }> {
-    return new Promise((resolve, reject) => {
-      const parsed = new URL(url);
-      const lib = parsed.protocol === 'https:' ? https : http;
-      const req = lib.request(
-        { hostname: parsed.hostname, port: parsed.port, path: parsed.pathname + parsed.search, method: 'POST',
-          headers: { 
-            'Content-Type': 'application/json', 
-            'X-Webhook-Signature': signature, 
-            'X-Webhook-Timestamp': timestamp,
-            'Content-Length': Buffer.byteLength(body) 
-          } 
-        },
-        (res) => {
-          let data = '';
-          res.on('data', (chunk) => (data += chunk));
-          res.on('end', () => resolve({ status: res.statusCode ?? 0, responseBody: data }));
-        },
-      );
-      req.on('error', reject);
-      req.setTimeout(10_000, () => { req.destroy(); reject(new Error('Timeout')); });
-      req.write(body);
-      req.end();
-    });
   }
 
   async retryPending(): Promise<void> {
@@ -167,27 +241,94 @@ export class WebhooksService implements OnModuleInit {
     }
   }
 
-  // --- Logs ---
+  // ─── Helpers ─────────────────────────────────────────────────────────────────
 
-  getLogs(webhookId: string, userId: string) {
-    return this.deliveryRepo
-      .createQueryBuilder('d')
-      .innerJoin(Webhook, 'w', 'w.id = d.webhookId')
-      .where('d.webhookId = :webhookId', { webhookId })
-      .andWhere('w.userId = :userId', { userId })
-      .orderBy('d.createdAt', 'DESC')
-      .limit(100)
-      .getMany();
+  private generateSecret(): string {
+    return 'whs_' + crypto.randomBytes(32).toString('hex');
   }
 
-  // --- Event listeners ---
+  private sign(secret: string, body: string): string {
+    return 'sha256=' + crypto.createHmac('sha256', secret).update(body).digest('hex');
+  }
+
+  private safeCompare(a: string, b: string): boolean {
+    try {
+      return (
+        a.length === b.length &&
+        crypto.timingSafeEqual(Buffer.from(a), Buffer.from(b))
+      );
+    } catch {
+      return false;
+    }
+  }
+
+  private async purgeExpiredSecrets(): Promise<void> {
+    const now = new Date();
+    await this.webhookRepo
+      .createQueryBuilder()
+      .update(Webhook)
+      .set({ previousSecret: null, secretRotatedAt: null })
+      .where('secretRotatedAt IS NOT NULL AND secretRotatedAt <= :now', { now })
+      .execute();
+  }
+
+  private httpPost(
+    url: string,
+    body: string,
+    signature: string,
+    timestamp: string,
+  ): Promise<{ status: number; responseBody: string }> {
+    return new Promise((resolve, reject) => {
+      const parsed = new URL(url);
+      const lib = parsed.protocol === 'https:' ? https : http;
+      const req = lib.request(
+        {
+          hostname: parsed.hostname,
+          port: parsed.port,
+          path: parsed.pathname + parsed.search,
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'X-Webhook-Signature': signature,
+            'X-Webhook-Timestamp': timestamp,
+            'Content-Length': Buffer.byteLength(body),
+          },
+        },
+        (res) => {
+          let data = '';
+          res.on('data', (chunk) => (data += chunk));
+          res.on('end', () => resolve({ status: res.statusCode ?? 0, responseBody: data }));
+        },
+      );
+      req.on('error', reject);
+      req.setTimeout(10_000, () => {
+        req.destroy();
+        reject(new Error('Webhook delivery timeout'));
+      });
+      req.write(body);
+      req.end();
+    });
+  }
+
+  // ─── Event listeners ─────────────────────────────────────────────────────────
 
   @OnEvent('enrollment.created')
-  onEnrollment(payload: any) { this.publish('enrollment.created', payload); }
+  onEnrollment(payload: any) {
+    this.publish('enrollment.created', payload);
+  }
 
   @OnEvent('enrollment.completed')
-  onCompletion(payload: any) { this.publish('enrollment.completed', payload); }
+  onCompletion(payload: any) {
+    this.publish('enrollment.completed', payload);
+  }
 
   @OnEvent('credential.issued')
-  onCredential(payload: any) { this.publish('credential.issued', payload); }
+  onCredential(payload: any) {
+    this.publish('credential.issued', payload);
+  }
+
+  @OnEvent('payment.completed')
+  onPaymentCompleted(payload: any) {
+    this.publish('payment.completed', payload);
+  }
 }


### PR DESCRIPTION
…Q jobs, search ranking, webhooks

============================================================================== ISSUE #617 — [Backend] Implement webhook delivery with retries & signing Closes #617
==============================================================================

WHAT WAS DONE:
- webhook.entity.ts: Added previousSecret and secretRotatedAt columns to support a 24-hour grace window during secret rotation. The old secret remains valid for 24 h so consumers can drain in-flight deliveries. Generated secrets now carry a whs_ prefix for easy identification.

- webhook-delivery.entity.ts: Added DLQ status to DeliveryStatus enum. Added deadLetteredAt timestamp column. Added a second @Index on the status column to speed up retry polling queries.

- webhooks.service.ts (full rewrite):
  * 
otateSecret() — new endpoint that saves the current secret as previousSecret, sets secretRotatedAt = now + 86400s, then generates a fresh whs_ secret.
  * erifySignature() — updated to accept previousSecret and secretRotatedAt; signatures validated against both active and previous secret during the grace window.  Uses crypto.timingSafeEqual throughout to prevent timing attacks.
  * Retry logic: delays updated to [30, 300, 1800, 7200, 28800] seconds (exponential-ish backoff over ~8 h).
  * After MAX_ATTEMPTS (5), delivery moves to DeliveryStatus.DLQ and deadLetteredAt is stamped — no silent drop.
  * getDlq() — returns all DLQ entries for a webhook (owner-scoped).
  * 
eplayDelivery() — resets a DLQ/failed delivery and immediately re-dispatches it via setImmediate.
  * purgeExpiredSecrets() — runs hourly via setInterval to null out previous secrets once their grace window expires.
  * Added @OnEvent('payment.completed') listener so payment events are fanned out to subscribed webhook endpoints.

- webhooks.controller.ts: Added endpoints:
  * POST /v1/webhooks/:id/rotate-secret
  * GET  /v1/webhooks/:id/dlq
  * POST /v1/webhooks/deliveries/:deliveryId/replay All endpoints pass the webhook's previousSecret and secretRotatedAt into erifySignature for the dual-secret validation path.

HOW:
The core delivery mechanism (HMAC-SHA256, X-Webhook-Signature + X-Webhook-Timestamp headers, 5-min replay window) was kept intact. The polling retry loop (setInterval 60s) was retained for now; migration to BullMQ-backed delivery is tracked as a follow-up.

============================================================================== ISSUE #616 — [Backend] Add full-text + semantic search ranking improvements Closes #616
==============================================================================

WHAT WAS DONE:
- search.service.ts (full rewrite):
  * Index settings now include a synonym_filter with a curated synonym list (blockchain/DLT, NFT, DeFi, JS/TypeScript, beginner/intro, etc.) and an edge_ngram autocomplete filter (min_gram=2, max_gram=20).
  * Custom analyzers:
    - synonym_analyzer — used at index time for all text fields
    - search_analyzer  — standard without synonyms at query time
    - utocomplete_analyzer — edge-ngram for partial-match suggestions
  * Course title now has a sub-field 	itle.autocomplete mapped with the edge-ngram analyzer, giving two autocomplete paths.
  * enrollmentCount field added to course documents so popularity can influence ranking.
  * search() method now builds a unction_score query wrapping the multi_match clause.  Signals applied:
      1. Per-field boosting: title^4, title.autocomplete^3, description^2, content^1
      2. est_fields + 	ie_breaker: 0.3 to reward multi-field matches 3. ield_value_factor on enrollmentCount (log1p, factor 0.5) so popular courses score higher without overwhelming relevance 4. Personalisation: if enrolledCourseIds are provided (opt-in), a more_like_this should clause softly boosts courses semantically related to what the user has already taken
  * evaluateRelevance() — runs a labeled query set and returns Precision@K and NDCG@K for each query, enabling offline relevance measurement as described in the acceptance criteria.
  * indexCourse() now accepts an enrollmentCount argument.

- search.controller.ts: Added:
  * ?enrolled=uuid,uuid query param on GET /search to pass enrolled course IDs for personalised ranking
  * ?explain=true param for ES score explanation (debug)
  * POST /search/evaluate (admin only) — accepts a labeled query set and returns Precision@K and NDCG@K metrics

HOW:
Hybrid ranking is achieved purely at the Elasticsearch layer using unction_score — no external vector DB needed at this stage.  The synonym filter is applied at index time so all synonymous terms map to the same tokens; at query time search_analyzer is used to avoid synonym expansion on partial input.  Personalisation is additive (a should clause), so users who opt out simply get unmodified results.

============================================================================== ISSUE #615 — [Backend] Implement a job/queue system (BullMQ) for async work Closes #615
==============================================================================

WHAT WAS DONE:
- queue.constants.ts: Added four new queue names (certificate, indexing) and corresponding job name constants for all job types.

- queue.module.ts (rewrite): Registers four BullMQ queues: email, otification, certificate, indexing.
  Imports EmailModule and SearchModule so workers can delegate to existing services.

- email.worker.ts (rewrite): Now injects EmailService and delegates JOB_SEND_EMAIL to emailService.enqueue(), bridging BullMQ with the existing DB-based email queue.  JOB_CLEANUP_EXPIRED triggers emailService.processQueue() on schedule.

- notification.worker.ts: Minor cleanup, added switch/case for new job names.

- certificate.worker.ts (new): Handles JOB_ISSUE_CERTIFICATE and JOB_MINT_CREDENTIAL jobs.  Designed to receive IssueCertificateJobData and MintCredentialJobData; injection points for CertificatesService and StellarService are documented inline so the heavy on-chain operations run off the HTTP request path.

- indexing.worker.ts (new): Handles JOB_INDEX_COURSE, JOB_INDEX_LESSON, JOB_INDEX_POST, and JOB_DELETE_FROM_INDEX by delegating to the injected SearchService.  Elasticsearch indexing is now fully async and retried automatically with exponential backoff.

- queue-scheduler.service.ts (rewrite): Exposes typed enqueue helpers for all four queues (enqueueEmail, enqueueIssueCertificate, enqueueMintCredential, enqueueIndexCourse, etc.).  Added getQueueStats() returning job counts for all queues, and etryFailedJobs() to manually requeue DLQ entries.

- queue-metrics.service.ts (new): Registers two Prometheus metrics:
  * ullmq_queue_depth — gauge with labels queue and state (waiting/active/failed/delayed/completed).  Refreshed every 15 s.
  * ullmq_job_failed_total — counter with labels queue and job. These appear on the existing /metrics Prometheus endpoint.

- types.ts (new): Centralises all job data interfaces for type safety across workers and callers.

HOW:
BullMQ was already installed (@nestjs/bullmq, ullmq).  The new queues follow the same WorkerHost + @Processor pattern used by the original email/notification workers.  
emoveOnComplete: { count: 500 } retains a rolling window of completed jobs for Bull Board inspection without unbounded Redis growth.  
emoveOnFail: false keeps failed jobs visible as a DLQ substitute until Bull Board dashboard is wired up.

============================================================================== ISSUE #614 — [Backend] Add payment & subscription billing (Stripe + on-chain) Closes #614
==============================================================================

WHAT WAS DONE:
- payments/ module (entirely new):

  payment.entity.ts:
  * Tracks one payment record per transaction with provider (stripe|stellar), status, mountCents, currency, stAmount (Stellar stroops), stripePaymentIntentId, stellarTxHash, and idempotencyKey.
  * idempotencyKey has a unique index; set to the Stripe event ID for webhook-driven payments so duplicate events cannot double-process.

  subscription.entity.ts:
  * Models recurring billing with plan (monthly|annual), status, stripeSubscriptionId, stripeCustomerId, currentPeriodEnd, and cancelledAt.

  invoice.entity.ts:
  * Records Stripe invoices (stripeInvoiceId unique index), linked to subscriptions, with mountDueCents, mountPaidCents, and paidAt.

  payments.service.ts:
  * createCheckoutSession() — creates a Stripe Checkout session in payment mode with metadata: { userId, courseId }, records a pending Payment entity before the user lands on Stripe, and returns the session URL.
  * createSubscription() — get-or-create a Stripe Customer, attach the payment method, create a Stripe Subscription, and persist a Subscription entity.
  * handleStripeWebhook() — verifies the Stripe-Signature header using stripe.webhooks.constructEvent().  Idempotency: checks whether a Payment row with idempotencyKey = event.id already exists before processing.  Handles:
      - checkout.session.completed → complete payment + grant enrollment
      - invoice.paid → upsert invoice, renew subscription entitlement - invoice.payment_failed → set subscription to past_due - customer.subscription.deleted → cancel subscription
  * erifyAndRecordStellarPayment() — accepts a Stellar tx hash, calls StellarService.verifyTransaction() to confirm on-chain success, records a completed Payment, and grants enrollment.  Idempotency: checks stellarTxHash uniqueness before processing.
  * grantEnrollment() — private helper that creates an Enrollment row (idempotent, skips if already exists) and emits enrollment.created.
  * All Stripe operations carry the stripe npm package at v16.12.0.

  payments.controller.ts:
  * POST /v1/payments/checkout — create Stripe checkout
  * POST /v1/payments/subscriptions — create subscription
  * GET  /v1/payments/subscriptions/me — get active subscription
  * DELETE /v1/payments/subscriptions/me — cancel subscription
  * GET  /v1/payments/invoices — list invoices
  * GET  /v1/payments/history — list payments
  * POST /v1/payments/stripe/webhook — Stripe webhook (uses RawBodyRequest for signature verification; raw body must be enabled in main.ts)
  * POST /v1/payments/stellar/verify — verify BST/Stellar payment

  payments.module.ts: Imports TypeORM entities, StellarModule.

- app.module.ts: PaymentsModule added to the root module imports.
- configuration.ts: Added stripe.secretKey, webhookSecret, publishableKey.
- validation.schema.ts: Added optional Joi rules for STRIPE_* env vars.
- package.json: Added stripe@^16.12.0 to dependencies.
- .env.example / apps/backend/.env.example: Documented Stripe env vars.

HOW:
Stripe integration uses the official stripe Node SDK.  The webhook route requires raw body bytes for HMAC verification — callers must ensure express.json({ verify: (req, res, buf) => { req.rawBody = buf; } }) is applied in main.ts before the global JSON parser.  The on-chain path reuses the existing StellarService.verifyTransaction() method, keeping Soroban/Horizon logic centralised.  Both paths share the same grantEnrollment() helper to avoid duplicate enrollment logic.

## Description
<!-- Provide a brief description of the changes in this PR -->

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Dependency update
- [ ] CI/CD improvement

## Related Issues
<!-- Link to related issues using #issue_number -->
Closes #

## Testing
<!-- Describe the tests you ran and how to reproduce them -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] E2E tests added/updated (if applicable)
- [ ] Manual testing performed

## Documentation
- [ ] README updated (if applicable)
- [ ] API documentation updated (if applicable)
- [ ] Code comments added for complex logic
- [ ] Migration guide added (if breaking changes)

## Breaking Changes
<!-- List any breaking changes and migration steps -->
- [ ] No breaking changes
- [ ] Breaking changes documented below:

## Checklist
- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests passed locally with my changes
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)
<!-- Add screenshots for UI changes -->

## Additional Context
<!-- Add any other context about the PR here -->
