### PR TITLE
docs: contract boundary ADRs, dev setup gaps, API reference, contract interfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,6 +289,14 @@ GitHub Actions workflows in `.github/workflows/` run on every push and PR:
 
 ---
 
+## Documentation
+
+- **[docs/README.md](./docs/README.md)** — full documentation index
+- **[docs/development-setup.md](./docs/development-setup.md)** — complete local setup guide covering `contracts/`, `apps/backend`, `apps/frontend`, and every `packages/*` directory (workspace linking, build order, troubleshooting)
+- **[docs/adr/README.md](./docs/adr/README.md)** — Architecture Decision Records, including why `contracts/` is split into 19 separate crates instead of a monolith
+- **[docs/contract-interfaces.md](./docs/contract-interfaces.md)** — public interface reference for every Soroban contract, cross-contract call conventions, and worked examples
+- **[docs/api/README.md](./docs/api/README.md)** — REST API route reference and how to regenerate the OpenAPI spec
+
 ## Contributing
 
 1. Fork the repository

--- a/contracts/shared/src/lib.rs
+++ b/contracts/shared/src/lib.rs
@@ -1,4 +1,9 @@
 #![no_std]
+//! Shared RBAC contract and common Soroban patterns (pause, reentrancy guard, multisig, timelocked upgrade).
+//!
+//! Full interface reference: [docs/contract-interfaces.md § Shared / RBAC Contract](../../../docs/contract-interfaces.md#shared--rbac-contract).
+//! Cross-contract call conventions used across `contracts/`: [docs/contract-interfaces.md § Cross-Contract Call Conventions](../../../docs/contract-interfaces.md#cross-contract-call-conventions).
+//! Rationale for this crate's existence and how it relates to other contracts: [ADR-007](../../../docs/adr/ADR-007-shared-crate-for-common-code.md).
 use soroban_sdk::{contract, contractimpl, contracttype, symbol_short, Address, BytesN, Env, Symbol};
 
 pub mod pausable;

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,57 @@
+# Brain-Storm Documentation
+
+Entry point for `docs/`. Start here, then follow the links below by topic.
+
+## Getting Started
+
+- **[development-setup.md](./development-setup.md)** — set up `contracts/`, `apps/backend`, `apps/frontend`, and `packages/*` locally, from a clean checkout to a running stack. Covers workspace linking/build order for every `packages/*` directory.
+- [developer-onboarding.md](./developer-onboarding.md) — broader onboarding: project structure, dev workflow, debugging tips, FAQ.
+- [contributor-onboarding.md](./contributor-onboarding.md) — contribution process and PR checklist.
+- [troubleshooting-guide.md](./troubleshooting-guide.md) — general troubleshooting beyond local setup.
+
+## Architecture & Decisions
+
+- [architecture.md](./architecture.md) — system architecture overview and data-flow diagram.
+- **[adr/](./adr/README.md)** — Architecture Decision Records. Includes why the platform is split into 19 Soroban contracts instead of a monolith ([ADR-006](./adr/ADR-006-contract-per-domain-architecture.md)–[ADR-009](./adr/ADR-009-credential-nft-decomposition.md)), tech stack choices (Stellar/Soroban, NestJS, Next.js), and token economics.
+- [code-organization-guide.md](./code-organization-guide.md) / [code-organization-migration-guide.md](./code-organization-migration-guide.md) — codebase layout conventions.
+- [mobile-architecture.md](./mobile-architecture.md) — `packages/mobile` / `packages/mobile-app` architecture.
+
+## Smart Contracts (`contracts/`)
+
+- **[contract-interfaces.md](./contract-interfaces.md)** — full public interface reference for all 19 contract crates (functions, auth, events), cross-contract call conventions, and worked call-chain examples.
+- [contracts.md](./contracts.md) — contract addresses, CLI usage, and TypeScript/JavaScript integration examples.
+- [smart-contract-interaction-guide.md](./smart-contract-interaction-guide.md) / [smart-contract-upgrade-guide.md](./smart-contract-upgrade-guide.md) — invoking and upgrading deployed contracts.
+- [contract-upgrades.md](./contract-upgrades.md) — the timelocked upgrade mechanism.
+- [CONTRACT_SECURITY.md](./CONTRACT_SECURITY.md) — contract-specific security considerations.
+- [contract-fuzzing-guide.md](./contract-fuzzing-guide.md) / [contract-integration-testing.md](./contract-integration-testing.md) — contract testing strategy, including `contracts/integration`.
+- [wasm-release.md](./wasm-release.md) — WASM build/release process.
+
+## Backend API (`apps/backend`)
+
+- **[api/README.md](./api/README.md)** — generated reference of every active REST route (method, path, auth) and how to regenerate the full OpenAPI spec.
+- [api/DEPLOYMENT.md](./api/DEPLOYMENT.md) — publishing the OpenAPI spec / Swagger UI to GitHub Pages.
+- [api-versioning.md](./api-versioning.md) / [api-rate-limiting.md](./api-rate-limiting.md) / [api-gateway.md](./api-gateway.md) / [api-integration-examples.md](./api-integration-examples.md) / [api-documentation-automation.md](./api-documentation-automation.md) — API platform concerns.
+- [database-schema.md](./database-schema.md) / [migrations.md](./migrations.md) / [DATABASE_MIGRATIONS.md](./DATABASE_MIGRATIONS.md) / [database-migrations-cicd.md](./database-migrations-cicd.md) — data layer.
+- [error-handling.md](./error-handling.md) / [validation-guide.md](./validation-guide.md) / [input-sanitization.md](./input-sanitization.md) — backend conventions.
+- [stellar-auth.md](./stellar-auth.md) / [stellar-integration.md](./stellar-integration.md) — how the backend talks to Stellar/Soroban.
+- [webhook-signatures.md](./webhook-signatures.md) / [notifications-guide.md](./notifications-guide.md) — async/event delivery.
+
+## Security & Compliance
+
+[security.md](./security.md) · [security-guidelines.md](./security-guidelines.md) · [security-best-practices.md](./security-best-practices.md) · [security-audit.md](./security-audit.md) · [SECURITY_TESTING.md](./SECURITY_TESTING.md) · [CONTRACT_SECURITY.md](./CONTRACT_SECURITY.md) · [COMPLIANCE.md](./COMPLIANCE.md) · [compliance-checking.md](./compliance-checking.md) · [data-privacy-gdpr.md](./data-privacy-gdpr.md) · [kyc-verification.md](./kyc-verification.md) · [secret-management.md](./secret-management.md) · [secret-rotation.md](./secret-rotation.md) · [cors-policy.md](./cors-policy.md) · [csp-implementation.md](./csp-implementation.md)
+
+## Operations & Infrastructure
+
+[deployment-guide.md](./deployment-guide.md) · [PRODUCTION_DEPLOYMENT.md](./PRODUCTION_DEPLOYMENT.md) · [deployment-runbook.md](./deployment-runbook.md) · [staging.md](./staging.md) · [preview-environments.md](./preview-environments.md) · [environment-provisioning.md](./environment-provisioning.md) · [environment-variables.md](./environment-variables.md) · [docker-guide.md](./docker-guide.md) · [monitoring.md](./monitoring.md) · [monitoring-observability.md](./monitoring-observability.md) · [oncall-escalation.md](./oncall-escalation.md) · [incident-runbook.md](./incident-runbook.md) · [disaster-recovery.md](./disaster-recovery.md) · [catastrophic-recovery.md](./catastrophic-recovery.md) · [backup-restore.md](./backup-restore.md) · [backup-verification.md](./backup-verification.md) · [infrastructure-validation.md](./infrastructure-validation.md) · [cost-optimization-implementation.md](./cost-optimization-implementation.md) · [aws-oidc.md](./aws-oidc.md) · [aws-oidc-workflow-changes.md](./aws-oidc-workflow-changes.md) · [cdn setup](./CDN_SETUP.md)
+
+## Testing & Quality
+
+[testing-strategy.md](./testing-strategy.md) · [contract-fuzzing-guide.md](./contract-fuzzing-guide.md) · [contract-integration-testing.md](./contract-integration-testing.md) · [mutation-testing.md](./mutation-testing.md) · [pact-testing.md](./pact-testing.md) · [test-data-management.md](./test-data-management.md) · [load-testing.md](./load-testing.md) · [load-testing-guide.md](./load-testing-guide.md) · [load-testing-automation.md](./load-testing-automation.md) · [performance-testing-guide.md](./performance-testing-guide.md) · [performance-optimization.md](./performance-optimization.md) · [performance-optimization-caching.md](./performance-optimization-caching.md) · [accessibility.md](./accessibility.md) · [accessibility-testing.md](./accessibility-testing.md) · [accessibility-testing-guide.md](./accessibility-testing-guide.md) · [automated-accessibility-testing.md](./automated-accessibility-testing.md) · [visual-regression-testing.md](./visual-regression-testing.md) · [visual-regression-testing-guide.md](./visual-regression-testing-guide.md) · [visual-testing-guidelines.md](./visual-testing-guidelines.md)
+
+## Miscellaneous
+
+[analytics-guide.md](./analytics-guide.md) · [ANALYTICS.md](./ANALYTICS.md) · [community-moderation.md](./community-moderation.md) · [notifications-guide.md](./notifications-guide.md) · [i18n-guide.md](./i18n-guide.md) · [shared-types.md](./shared-types.md) · [dependency-injection-guide.md](./dependency-injection-guide.md) · [dependency-injection-best-practices.md](./dependency-injection-best-practices.md) · [utilities-guide.md](./utilities-guide.md) · [user-rate-limiting.md](./user-rate-limiting.md) · [ASSET_SUPPORT.md](./ASSET_SUPPORT.md) · [scripts.md](./scripts.md)
+
+---
+
+New to the repo? Read [development-setup.md](./development-setup.md) first, then [architecture.md](./architecture.md), then [adr/README.md](./adr/README.md) for the reasoning behind the current structure.

--- a/docs/adr/ADR-006-contract-per-domain-architecture.md
+++ b/docs/adr/ADR-006-contract-per-domain-architecture.md
@@ -1,0 +1,133 @@
+# ADR-006: Contract-Per-Domain Architecture (vs. a Monolithic Contract)
+
+**Status:** Accepted
+
+**Date:** 2026-07-25
+
+**Author(s):** Brain-Storm maintainers
+
+---
+
+## Context
+
+`contracts/` holds 18 crates registered in the Cargo workspace (`Cargo.toml`) plus a 19th (`contracts/royalty_distribution`) that has its own manifest but is **not currently listed** in the workspace `members` array — a discrepancy noted here rather than silently "fixed," since correcting it is a build-config change outside the scope of this documentation effort:
+
+`analytics`, `badges`, `buyback`, `certificate`, `credential_metadata`, `dispute`, `governance`, `grants`, `liquidity_pool`, `market`, `nft`, `registry`, `reputation`, `royalty_distribution`, `scholarship_fund`, `shared`, `token`, `token_restrictions` — plus `integration`, which is a test-only crate (see [ADR-008](./ADR-008-registry-integration-separation.md)) rather than a deployable contract.
+
+None of these crates declare a compile-time path dependency on any other **production** contract crate (verified by grepping every `contracts/*/Cargo.toml` for `path = `). The only crate with cross-contract path dependencies is `contracts/integration`, and those are `[dev-dependencies]` used purely for test harness deployment. This means the 18 deployable contracts are, by construction, independently compiled, independently sized, and independently upgradable WASM modules — there is no shared runtime or shared address space between them.
+
+New contributors and auditors have had to reverse-engineer why the platform is split this way instead of, say, one large "Platform" contract with internal modules. This ADR records that rationale.
+
+## Decision
+
+We deploy one Soroban contract per business domain (token economics, credentials, marketplace, governance, etc.) rather than a single monolithic contract, and we accept that most cross-domain composition happens **off-chain**, orchestrated by `apps/backend`, rather than through on-chain cross-contract calls.
+
+### Verified on-chain call graph
+
+Grepping every contract for `invoke_contract` and the `#[contractclient]` macro (the two ways a Soroban contract calls another contract) turns up exactly **three** on-chain edges across all 18 production contracts:
+
+| Caller | Callee | Mechanism | Call | Why |
+|---|---|---|---|---|
+| `credential_metadata::issue_with_nft` | `nft::mint_course_nft` | Locally-declared `#[contractclient]` stub (`contracts/credential_metadata/src/linkage.rs`) — **not** a crate dependency on `brain-storm-nft` | Mint a linked NFT atomically when a credential is issued | Issuing the credential record and minting its NFT must succeed or fail together (issue #635); a stub avoids coupling the two crates at compile time |
+| `governance` | `token::balance` | `env.invoke_contract` (dynamic, untyped) | Read a voter's BST balance to weight a vote | Voting power is derived from live token balance, not a duplicated ledger inside governance |
+| `grants` | `token::transfer` | `env.invoke_contract` (dynamic, untyped) | Disburse milestone funds to a grant applicant | Fund release must move real BST, which only the token contract can authorize |
+
+```mermaid
+graph LR
+    subgraph "On-chain cross-contract calls (verified)"
+        CM[credential_metadata] -->|mint_course_nft<br/>local client stub| NFT[nft]
+        GOV[governance] -->|invoke_contract: balance| TOK[token]
+        GRANTS[grants] -->|invoke_contract: transfer| TOK
+    end
+
+    subgraph "Independent — invoked separately by apps/backend, no on-chain edges"
+        CERT[certificate]
+        MARKET[market]
+        ANALYTICS[analytics]
+        REG[registry]
+        REP[reputation]
+        BADGES[badges]
+        DISPUTE[dispute]
+        SCHOL[scholarship_fund]
+        BUYBACK[buyback]
+        ROYALTY[royalty_distribution]
+        RESTRICT[token_restrictions]
+        LP[liquidity_pool]
+        SHARED[shared — deployed standalone,<br/>RBAC/pause/reentrancy/upgrade]
+    end
+
+    BACKEND[apps/backend orchestrator] -.->|separate txs, off-chain composition| CERT
+    BACKEND -.-> MARKET
+    BACKEND -.-> ANALYTICS
+    BACKEND -.-> REG
+    BACKEND -.-> REP
+    BACKEND -.-> BADGES
+    BACKEND -.-> DISPUTE
+    BACKEND -.-> SCHOL
+    BACKEND -.-> BUYBACK
+    BACKEND -.-> ROYALTY
+    BACKEND -.-> RESTRICT
+    BACKEND -.-> LP
+    BACKEND -.-> SHARED
+    BACKEND -.-> CM
+    BACKEND -.-> GOV
+    BACKEND -.-> GRANTS
+    BACKEND -.-> TOK
+    BACKEND -.-> NFT
+```
+
+Everything outside those three edges — e.g. a marketplace purchase that touches `market` (escrow) and separately `nft` (ownership transfer) and separately `royalty_distribution` (creator payout) — is composed by `apps/backend` issuing separate Stellar transactions, not by one contract calling another. See [docs/contract-interfaces.md § Cross-Contract Call Conventions](../contract-interfaces.md#cross-contract-call-conventions) for how the backend sequences those flows and what happens on partial failure.
+
+## Rationale
+
+**Why not one monolithic contract?**
+- **WASM size and gas.** Soroban meters and caps contract code size and per-invocation CPU/memory instructions. A single contract holding token economics, marketplace escrow, governance voting, dispute resolution, and 15 other domains would be large, slow to instantiate, and would make every invocation pay the cost of code it doesn't use.
+- **Blast radius of upgrades.** Each contract upgrades independently via `shared::schedule_upgrade` / `execute_upgrade` (timelocked) or, for `governance`-gated contracts, `propose_upgrade` → `vote_upgrade` → `approve_upgrade` → `execute_upgrade`. A bug fix to the dispute-resolution logic should not require re-auditing and re-deploying the token contract.
+- **Audit surface.** Security review of a 300–600 line single-domain contract (the actual size range of `contracts/*/src/lib.rs` in this codebase) is tractable; reviewing a merged multi-thousand-line contract is not, and a vulnerability in one domain (e.g. `liquidity_pool` swap math) can't corrupt storage in an unrelated domain (e.g. `certificate` records) because they are different contract instances with separate storage.
+- **Independent admin keys.** Each contract has its own `Admin` storage entry and its own `require_auth()` gate, so compromising one contract's admin key does not automatically compromise every domain.
+
+**Why accept off-chain composition instead of building more on-chain call chains like the three that exist?**
+- Each additional on-chain cross-contract call adds gas cost and a hard compile-time or dynamic-invocation dependency between two independently-upgradable contracts (if contract A hardcodes contract B's address and interface, upgrading B's interface can break A). The three edges that exist were added because atomicity was a hard requirement (credential+NFT must not exist in a partial state; a vote must read *current* balance; a fund release must actually move tokens or not happen at all). Everywhere else, `apps/backend` already has to persist off-chain state (PostgreSQL rows for users, courses, enrollments) alongside on-chain effects, so it was already the natural place to sequence multi-contract flows and handle partial-failure/retry logic.
+
+**Alternatives considered**
+1. **Single monolithic "Platform" contract.** Rejected — WASM size/gas limits, audit surface, and upgrade blast radius as above.
+2. **A handful of larger contracts grouped by rough theme (e.g. one "Credentials" contract covering certificate + credential_metadata + nft + badges).** Rejected for the credential domain specifically — see [ADR-009](./ADR-009-credential-nft-decomposition.md) for why those three stayed separate.
+3. **More on-chain cross-contract calls to reduce backend orchestration.** Rejected as a default — reserved for cases (like the three above) where atomicity is a correctness requirement, not a convenience.
+
+## Consequences
+
+### Positive
+- Each contract can be independently upgraded, paused, and audited.
+- A bug or exploit in one domain's storage cannot directly corrupt another domain's storage.
+- New domains (e.g. `dispute`, added later per its own `#659` issue reference) can be added as new crates without touching existing contracts.
+
+### Negative
+- Multi-contract business flows (e.g. an NFT marketplace purchase touching `market`, `nft`, and `royalty_distribution`) are **not atomic on-chain** — `apps/backend` must sequence separate transactions and handle partial failure (e.g. escrow funded but royalty distribution transaction fails) with its own retry/reconciliation logic. This is not currently documented in one place; contributors should read the worked examples in [docs/contract-interfaces.md](../contract-interfaces.md) before adding a new multi-contract flow.
+- `contracts/royalty_distribution` exists as a crate but is absent from the root `Cargo.toml` workspace `members` list, so `cargo build`/`cargo test` at the workspace root silently skips it. Anyone touching that contract must build it explicitly: `cargo build --manifest-path contracts/royalty_distribution/Cargo.toml --target wasm32-unknown-unknown`.
+
+### Neutral
+- Contracts do not share compiled code. Common patterns (pause, reentrancy guard, admin check) are either copied per-contract or, for RBAC specifically, available from the separately-deployed `shared` contract — see [ADR-007](./ADR-007-shared-crate-for-common-code.md).
+
+## Implementation Notes
+
+- When adding a new contract, default to a new crate under `contracts/<name>/` with its own `Cargo.toml`, and add it to the root workspace `members` list (unlike `royalty_distribution`, which was missed).
+- Only add an on-chain cross-contract call (`invoke_contract` or a local `#[contractclient]` stub, per [ADR-008](./ADR-008-registry-integration-separation.md)'s pattern) when atomicity across two contracts is a correctness requirement — not for convenience. Prefer backend orchestration otherwise.
+- Never add a compile-time path dependency from one production contract onto another; that pattern is reserved for the `contracts/integration` test-only crate.
+
+## References
+
+- [Root `Cargo.toml`](../../Cargo.toml)
+- [contracts/credential_metadata/src/linkage.rs](../../contracts/credential_metadata/src/linkage.rs)
+- [contracts/governance/src/lib.rs](../../contracts/governance/src/lib.rs)
+- [contracts/grants/src/lib.rs](../../contracts/grants/src/lib.rs)
+- [docs/contract-interfaces.md](../contract-interfaces.md)
+- [ADR-007: Shared Crate for Common Code](./ADR-007-shared-crate-for-common-code.md)
+- [ADR-008: Registry vs. Integration Crate Separation](./ADR-008-registry-integration-separation.md)
+- [ADR-009: Credential/NFT Contract Decomposition](./ADR-009-credential-nft-decomposition.md)
+- [Issue #762](https://github.com/BrainTease/Brain-Storm/issues/762)
+
+## Revision History
+
+| Date | Author | Change |
+|------|--------|--------|
+| 2026-07-25 | Brain-Storm maintainers | Initial proposal, derived from git history and static analysis of `contracts/*/src` for issue #762 |

--- a/docs/adr/ADR-007-shared-crate-for-common-code.md
+++ b/docs/adr/ADR-007-shared-crate-for-common-code.md
@@ -1,0 +1,79 @@
+# ADR-007: `contracts/shared` for Common Contract Code
+
+**Status:** Accepted
+
+**Date:** 2026-07-25
+
+**Author(s):** Brain-Storm maintainers
+
+---
+
+## Context
+
+`contracts/shared` (crate name `brain-storm-shared`) is unusual among the 18 production contracts: it is both a library of reusable Soroban patterns (`pausable.rs`, `reentrancy.rs`, `multisig.rs`, `upgrade.rs`, `validation.rs`, `errors.rs`) **and** a deployable contract in its own right (`#[contract] pub struct SharedContract` in `contracts/shared/src/lib.rs`), exposing RBAC (`assign_role`/`has_role`/`has_permission`), a generic authorized cross-contract call registry (`authorize_caller`/`call_contract`/`relay_event`), and pause/reentrancy/upgrade primitives as callable functions.
+
+Contributors have had to guess whether new contracts are expected to depend on `brain-storm-shared` for these patterns. Static analysis of every `contracts/*/Cargo.toml` shows the answer, as of this writing, is **no**: the only crate with a path dependency on `brain-storm-shared` is `contracts/integration`, and it's a `[dev-dependencies]` entry used purely to deploy the shared contract inside integration tests. Every production contract that needs a pause flag or an admin check (e.g. `market::pause`/`unpause`/`is_paused`, `registry::pause`/`unpause`) reimplements it locally rather than calling out to the deployed `shared` contract or depending on `brain-storm-shared` as a library.
+
+This ADR records why the crate exists, what it is for, and — since ADRs must not contradict current code — the honest state of how (and how much) it's actually reused today.
+
+## Decision
+
+We keep `contracts/shared` as a single crate serving two purposes:
+
+1. **A vetted pattern library.** `pausable.rs`, `reentrancy.rs`, `multisig.rs`, `upgrade.rs`, and `validation.rs` are the canonical, tested (`tests.rs`, `upgrade_tests.rs`) implementations of pause-with-auto-unpause, a reentrancy lock, an N-of-M multisig proposal flow, a timelocked WASM upgrade flow, and basic input validation (positive amounts, percentage bounds, future timestamps). Contract authors copy these patterns rather than re-deriving them from scratch.
+2. **A deployed RBAC contract.** `SharedContract` is deployed on-chain and provides `Role`/`Permission`-based access control (`Admin`/`Instructor`/`Student` roles) plus a generic `authorize_caller`/`call_contract` registry that lets one contract be recorded as an authorized caller of another. It is the contract deployed alongside `analytics` and `token` in the `contracts/integration` end-to-end test scenario.
+
+What we do **not** currently do is make every other production contract take a compile-time dependency on `brain-storm-shared`, or call the deployed `SharedContract` on-chain for their own pause/admin checks. `market`, `registry`, and every other contract that needs a pause flag or an admin gate implement it inline with `env.storage().instance()` and `admin.require_auth()` directly.
+
+## Rationale
+
+**Why not duplicate the code with no shared crate at all?**
+Soroban contracts are independently compiled WASM binaries with no shared runtime — there's no way for two deployed contracts to literally share code the way two services can share a library at runtime. Without a shared *source* crate, the reentrancy guard, the pause auto-unpause math, the multisig threshold/expiry logic, and the timelocked upgrade flow would each be re-derived per contract, multiplying the number of places a subtle bug (e.g. an off-by-one in `expires_ledger` comparison) could hide. Keeping one audited implementation in `contracts/shared/src/*.rs` — even if contract authors copy rather than import it — means code review and security audits (see `docs/CONTRACT_SECURITY.md`) have one canonical implementation to check each contract's inline copy against.
+
+**Why is it also a deployed contract, not just a library?**
+RBAC (`Role`/`Permission`) and the authorized-caller registry are naturally *shared state* — "is address X an Instructor" is a fact that should have one on-chain answer, not 18 separate copies that could drift. Deploying `SharedContract` gives a single, queryable source of truth for roles, independent of which other contract is asking. The pause/reentrancy/upgrade *logic*, by contrast, is inherently per-contract state (each contract has its own `Paused` flag for its own storage), so those parts are consumed as copied source rather than through a deployed call.
+
+**Why hasn't compile-time reuse (a real `brain-storm-shared` dependency) happened yet?**
+Adding `brain-storm-shared` as a path dependency to, say, `market`'s `Cargo.toml` is straightforward in principle, but doing so was evidently deprioritized in favor of shipping each domain contract's own feature set (`market`'s pause support landed under issue `#663`, `registry`'s under the same batch per its git history — both implemented inline rather than by adding the dependency). This is a real gap, not a deliberate design choice, and is called out as a **negative consequence** below rather than as intended architecture.
+
+**Alternatives considered**
+1. **No shared crate; every contract reimplements everything from scratch with no shared reference.** Rejected — no canonical pattern to audit against; higher risk of divergent, subtly-inconsistent pause/reentrancy semantics across 18 contracts.
+2. **Make `brain-storm-shared` a real compile-time dependency of every contract, calling `SharedContract::has_permission` etc. instead of local checks.** Not adopted (yet) — every check would become a cross-contract call (gas cost, and a hard runtime dependency on `shared`'s address and interface staying stable across upgrades). This remains a reasonable future direction; see Implementation Notes.
+3. **Fold `shared`'s RBAC into `governance`**, since governance already gates upgrades. Rejected — RBAC (who is a Student/Instructor) is a much higher-frequency, lower-stakes read than governance proposals, and coupling the two would mean every role check goes through the governance contract's storage.
+
+## Consequences
+
+### Positive
+- One audited reference implementation exists for pause, reentrancy, multisig, and timelocked-upgrade patterns.
+- RBAC has a single on-chain source of truth via the deployed `SharedContract`, usable by off-chain systems (`apps/backend`) without querying 18 separate contracts.
+- New contracts can bootstrap pause/upgrade support by copying a known-good pattern instead of writing one from scratch.
+
+### Negative
+- **No production contract currently depends on `brain-storm-shared` at compile time or calls the deployed `SharedContract` on-chain.** Each contract's pause/admin logic is an independent copy, so a fix to `contracts/shared/src/pausable.rs` does **not** automatically propagate to `market`'s or `registry`'s inline copies — each must be patched separately. Contributors fixing a bug in one contract's pause logic should check whether the same bug exists in every other contract's local copy.
+- The deployed `SharedContract`'s `authorize_caller`/`call_contract`/`relay_event` cross-contract-call registry is unused by any of the 18 production contracts today (only exercised in `contracts/integration` tests) — it is speculative infrastructure, not a wired-up convention.
+
+### Neutral
+- Adding a real compile-time dependency on `brain-storm-shared` to a production contract is safe to do incrementally, contract by contract — it does not require a workspace-wide migration.
+
+## Implementation Notes
+
+- If you fix a bug in `contracts/shared/src/*.rs`, grep other contracts for the equivalent inline logic (`grep -rn "Paused" contracts/*/src/lib.rs`) and check whether they need the same fix.
+- When starting a **new** contract that needs pause/reentrancy/multisig/upgrade support, prefer adding `brain-storm-shared` as a real path dependency over copy-pasting, to start closing the gap described above.
+- Do not build new features on `SharedContract::authorize_caller`/`call_contract` without first confirming with a maintainer that this registry is meant to become load-bearing — as of this ADR it is unused by any production contract.
+
+## References
+
+- [contracts/shared/src/lib.rs](../../contracts/shared/src/lib.rs)
+- [contracts/shared/src/pausable.rs](../../contracts/shared/src/pausable.rs)
+- [contracts/shared/src/multisig.rs](../../contracts/shared/src/multisig.rs)
+- [contracts/shared/src/upgrade.rs](../../contracts/shared/src/upgrade.rs)
+- [contracts/integration/tests/integration.rs](../../contracts/integration/tests/integration.rs)
+- [docs/contract-interfaces.md § Shared / RBAC Contract](../contract-interfaces.md#shared--rbac-contract)
+- [ADR-006: Contract-Per-Domain Architecture](./ADR-006-contract-per-domain-architecture.md)
+- [Issue #762](https://github.com/BrainTease/Brain-Storm/issues/762)
+
+## Revision History
+
+| Date | Author | Change |
+|------|--------|--------|
+| 2026-07-25 | Brain-Storm maintainers | Initial proposal, derived from dependency analysis of `contracts/*/Cargo.toml` for issue #762 |

--- a/docs/adr/ADR-008-registry-integration-separation.md
+++ b/docs/adr/ADR-008-registry-integration-separation.md
@@ -1,0 +1,67 @@
+# ADR-008: `registry` and `integration` Are Different Kinds of Crates
+
+**Status:** Accepted
+
+**Date:** 2026-07-25
+
+**Author(s):** Brain-Storm maintainers
+
+---
+
+## Context
+
+Two crate names in `contracts/` are easy to conflate: `registry` and `integration`. Both sound like they could be about "wiring contracts together," but they solve unrelated problems:
+
+- `contracts/registry` (crate name `registry`) is a **production Soroban contract** (`#[contract] pub struct RegistryContract`) that tracks per-user verification levels, certified skills (with expiry), specialisations, curator permissions, and a paginated global user directory (`register_user`, `list_users`, `list_users_by_level`, `total_users`). It has its own `src/lib.rs`, is a workspace member, and compiles to WASM for deployment.
+- `contracts/integration` (crate name `brain-storm-integration`) has **no `src/lib.rs` and no `#[contract]` struct at all** — only a `Cargo.toml` and `tests/integration.rs`. It is a `[dev-dependencies]`-only crate that path-depends on `brain-storm-analytics`, `brain-storm-token`, and `brain-storm-shared` (per its `Cargo.toml`) purely to deploy those three contracts inside a single Soroban test `Env` and script an end-to-end register → progress → reward flow, asserting on emitted events and final state (see `contracts/integration/README.md`).
+
+New contributors reasonably ask why "integration" isn't just test code living inside `registry`, or why registry-style directory/lookup functionality isn't itself called "integration." This ADR records the distinction.
+
+## Decision
+
+Keep `registry` as an ordinary production contract crate, and keep `integration` as a **workspace-only test harness crate that is never compiled to WASM or deployed**. The two names refer to unrelated concepts (a user directory/verification contract vs. a cross-contract test harness) and should not be merged or renamed to imply a relationship.
+
+## Rationale
+
+**Why can't multi-contract integration tests live inside one of the contracts they test (e.g. inside `analytics` or `token`)?**
+A contract crate that path-depends on sibling contract crates (even as `[dev-dependencies]`) to deploy them inside its own tests would need those siblings to depend back on it for symmetry, or would asymmetrically entangle one "primary" contract with testing responsibility for flows that aren't really about that contract. `contracts/integration/Cargo.toml` shows the actual pattern used instead: a crate with **no production code of its own**, whose only job is to `[dev-dependencies]`-depend on `brain-storm-analytics`, `brain-storm-token`, and `brain-storm-shared` and drive them together via `env.register_contract` + generated `*Client` types in `testutils` mode. This keeps every production contract's `Cargo.toml` free of any dependency on its siblings (see [ADR-006](./ADR-006-contract-per-domain-architecture.md)), while still allowing realistic, multi-contract, single-ledger test scenarios to exist somewhere in the workspace.
+
+**Why is this useful given each contract already has its own `tests.rs`?**
+Per-contract `#[cfg(test)] mod tests` (present in `analytics`, `token`, `nft`, `market`, `registry`, `royalty_distribution`, and others) verifies a single contract's logic in isolation. It cannot verify what happens when, e.g., a student's on-chain progress record in `analytics` is used to justify an admin minting BST via `token` in the same session — that requires deploying both contracts into one `Env` and asserting on the combined outcome, which is exactly what `contracts/integration/tests/integration.rs` does. The `.github/workflows/contract-integration.yml` CI job (per `contracts/integration/README.md`) additionally spins up a real local Stellar sandbox and deploys the WASM artifacts, closer to a production deployment than the in-process `testutils::Address` scenario.
+
+**Why is `registry`'s user-directory/verification-level functionality not itself the "integration" layer?**
+`registry` answers questions about a *single* domain — "what is this user's verification level / certified skills / specialisations" — backed by its own storage. It doesn't call, and isn't called by, any other contract on-chain (confirmed: no `invoke_contract` or `#[contractclient]` usage in `contracts/registry/src/lib.rs`). Its "batch" operations (`batch_register_users`, `batch_set_verification_levels`) reduce the number of *transactions* a caller needs, but do not integrate with other contracts. Naming or treating it as an integration layer would misrepresent what it does.
+
+**Alternatives considered**
+1. **Delete `contracts/integration` and rely solely on per-contract unit tests.** Rejected — multi-contract interaction bugs (e.g. an event topic mismatch between what `analytics` emits and what a listener expects) are exactly the class of bug unit tests in a single contract can't catch.
+2. **Move `tests/integration.rs` into the root `Cargo.toml`'s workspace-level `[dev-dependencies]` without a dedicated crate.** Rejected — Cargo workspaces don't have a "workspace-level test" concept; a crate is the natural unit, and keeping it as its own crate lets it appear as its own CI job (`contract-integration.yml`) with its own sandbox lifecycle.
+3. **Rename `registry` to something like `directory` to reduce naming confusion with `integration`.** Not adopted — out of scope for a documentation-only change, and the current name is otherwise accurate (it's the registry of users/skills/verification, in the same sense as a service registry). Noted here as a possible future cleanup if the naming confusion recurs.
+
+## Consequences
+
+### Positive
+- Production contracts never take on cross-sibling dependencies for the sake of testing.
+- `contracts/integration` can freely add path dependencies on any contract crate it needs to test together, without those contracts knowing or caring.
+- CI can treat `contract-integration.yml` as a distinct, sandboxed job from the fast per-crate `cargo test` runs.
+
+### Negative
+- `contracts/integration` currently only exercises `analytics` + `token` + `shared` (3 of 18 production contracts). The three *actual* on-chain cross-contract call edges documented in [ADR-006](./ADR-006-contract-per-domain-architecture.md#verified-on-chain-call-graph) — `credential_metadata → nft`, `governance → token`, `grants → token` — are **not** covered by this harness today. This is a real test-coverage gap, not a design flaw in the separation itself; a natural follow-up is extending `contracts/integration`'s `[dev-dependencies]` to cover those three pairs.
+- Because `contracts/integration` has no `src/lib.rs`, `cargo doc` produces no crate documentation for it; its only documentation is `contracts/integration/README.md`.
+
+### Neutral
+- `registry` and `integration` will keep sitting next to each other alphabetically in `contracts/` and in workspace listings; the naming similarity is coincidental, not a sign of a relationship.
+
+## References
+
+- [contracts/registry/src/lib.rs](../../contracts/registry/src/lib.rs)
+- [contracts/integration/Cargo.toml](../../contracts/integration/Cargo.toml)
+- [contracts/integration/README.md](../../contracts/integration/README.md)
+- [contracts/integration/tests/integration.rs](../../contracts/integration/tests/integration.rs)
+- [ADR-006: Contract-Per-Domain Architecture](./ADR-006-contract-per-domain-architecture.md)
+- [Issue #762](https://github.com/BrainTease/Brain-Storm/issues/762)
+
+## Revision History
+
+| Date | Author | Change |
+|------|--------|--------|
+| 2026-07-25 | Brain-Storm maintainers | Initial proposal for issue #762 |

--- a/docs/adr/ADR-009-credential-nft-decomposition.md
+++ b/docs/adr/ADR-009-credential-nft-decomposition.md
@@ -1,0 +1,71 @@
+# ADR-009: Separate `certificate`, `credential_metadata`, and `nft` Contracts
+
+**Status:** Accepted
+
+**Date:** 2026-07-25
+
+**Author(s):** Brain-Storm maintainers
+
+---
+
+## Context
+
+Three contracts under `contracts/` all relate to "what a student has": `certificate`, `credential_metadata`, and `nft`. This is the most frequently asked "why are these separate?" question new contributors raise about the contract boundaries. Reading each contract's actual interface (function signatures verified directly against `contracts/*/src/lib.rs`) shows they are not redundant — they implement three functionally distinct primitives:
+
+| Contract | What it is | Key functions |
+|---|---|---|
+| `certificate` | A **soulbound-by-default** proof-of-completion token. Transfer is disabled unless an admin explicitly opts a specific certificate into transferability. | `mint_certificate`, `revoke_certificate`, `is_revoked`, `enable_transfer`, `transfer`, `is_transferable`, `is_valid` |
+| `credential_metadata` | A **metadata and lifecycle layer**: course name, completion date, grade, IPFS content hash, expiry/renewal, and a content-hash verification function — independent of whether the credential is represented as a certificate or an NFT. | `store_metadata`, `update_metadata`, `is_expired`, `can_renew`, `renew_credential`, `store_metadata_hash`, `verify_metadata_hash`, `get_metadata_history` |
+| `nft` | A **generic, tradeable course token** with marketplace primitives: listing, buying, delisting, access grants, and royalty info — not credential-specific. | `mint_course_nft`, `transfer_nft`, `list_nft`, `buy_nft`, `delist_nft`, `grant_access`, `revoke_access`, `has_access`, `get_royalty_info` |
+
+`credential_metadata` optionally composes with `nft` through exactly one on-chain call: `issue_with_nft` mints a `credential_metadata` record and, in the same invocation, calls `nft::mint_course_nft` via a locally-declared client stub (`contracts/credential_metadata/src/linkage.rs`), storing a bidirectional `credential_id ↔ nft_id` link. `credential_metadata` also exposes a plain `store_metadata` path that does **not** touch `nft` at all. `certificate` has no on-chain relationship to either of the other two — it is entirely self-contained.
+
+## Decision
+
+Keep `certificate`, `credential_metadata`, and `nft` as three separate contracts, each with a distinct, narrow responsibility, composed optionally (not by default) rather than merged into one "Credentials" contract.
+
+## Rationale
+
+**Why not merge `certificate` and `credential_metadata`?**
+`certificate` is intentionally minimal: mint, revoke, optionally-enable-transfer, done. It is the contract whose integrity matters most — a "proof of completion" record — so its attack surface is kept as small as possible. `credential_metadata`'s expiry/renewal/history features (`renew_credential`, `get_metadata_history`, content-hash verification) are considerably more complex and were added later (its `issue_with_nft` path is tagged issue `#635` in code comments). Bundling that complexity into `certificate` would mean every future metadata feature risks an upgrade or bug surface on the soulbound proof-of-completion contract itself. Keeping them separate means `certificate` can stay small, stable, and rarely need to change, while `credential_metadata` absorbs metadata-related feature growth.
+
+**Why not merge `credential_metadata` and `nft`?**
+They serve different consumers. `nft` is a general-purpose tradeable asset primitive — its marketplace functions (`list_nft`/`buy_nft`/`delist_nft`) and access-grant functions (`grant_access`/`revoke_access`/`has_access`) have nothing to do with credentials specifically; an NFT minted via `mint_course_nft` could represent a purchasable course seat as easily as a credential. `credential_metadata` needs to be usable **without** an NFT at all (`store_metadata` vs. `issue_with_nft`) — not every credential needs to be a tradeable, marketplace-listable asset, and forcing one onto the other would mean an admin issuing a plain internal credential record pays the gas and complexity cost of NFT semantics whether or not the credential is meant to be sellable.
+
+**Why not merge all three into one "Credentials" contract?**
+Mixing soulbound-integrity semantics (`certificate`), lifecycle/expiry semantics (`credential_metadata`), and tradeable-marketplace semantics (`nft`) in one contract means a bug in marketplace listing logic sits in the same audit scope, and shares the same upgrade path, as the code that decides whether a certificate is revoked. The current split lets each concern be reasoned about, and upgraded, independently — consistent with the general contract-per-domain rationale in [ADR-006](./ADR-006-contract-per-domain-architecture.md).
+
+**Alternatives considered**
+1. **One `Credential` contract with certificate + metadata + optional-NFT flag.** Rejected as above — conflates soulbound-integrity, lifecycle, and marketplace concerns in one audit/upgrade scope.
+2. **Fold `credential_metadata`'s expiry/renewal into `certificate` directly, keep `nft` separate.** Rejected — `certificate`'s `is_valid`/`is_revoked` model and `credential_metadata`'s `is_expired`/`can_renew`/`renew_credential` model are different lifecycle state machines; forcing them into one contract's storage schema would require reconciling two different "is this still good?" definitions.
+3. **Make the `credential_metadata → nft` link mandatory (every credential always mints an NFT).** Rejected — `store_metadata` (no NFT) is a real, used code path; not every credential needs marketplace tradeability, and mandatory NFT minting would add cost and complexity to the common case.
+
+## Consequences
+
+### Positive
+- Each contract stays small and independently auditable (`certificate`: 17 functions; `credential_metadata`: 17 functions; `nft`: 16 functions — none of them large by Soroban contract standards).
+- `nft` can be reused as a general marketplace primitive by other flows (e.g. `market`'s escrow) without dragging in credential-specific expiry logic.
+- The one on-chain link (`issue_with_nft`) is atomic — per `linkage.rs`'s doc comment, "If either operation fails the whole call is rolled back" — so there's no partial state where a credential exists without its NFT or vice versa, for the flows that opt into linkage.
+
+### Negative
+- There is no single canonical "give me everything about this credential" query. A full picture requires reading `certificate` (if the credential was also issued as a soulbound cert), `credential_metadata` (course name/grade/expiry), and — only if `issue_with_nft` was used — `nft` (ownership/marketplace state) via `get_credential_link`. `apps/backend` is responsible for joining these views; see the worked example in [docs/contract-interfaces.md](../contract-interfaces.md#worked-example-2-credential-issuance-with-linked-nft-635).
+- Contributors adding a new credential-related feature must decide up front which of the three contracts it belongs in; this ADR is the reference for that decision, but there's no automated check preventing e.g. expiry logic from accidentally being added to `certificate` instead of `credential_metadata`.
+
+### Neutral
+- `certificate` remains entirely unaware of `nft` and `credential_metadata` — it has zero on-chain or off-chain-required relationship to either, and can be used standalone.
+
+## References
+
+- [contracts/certificate/src/lib.rs](../../contracts/certificate/src/lib.rs)
+- [contracts/credential_metadata/src/lib.rs](../../contracts/credential_metadata/src/lib.rs)
+- [contracts/credential_metadata/src/linkage.rs](../../contracts/credential_metadata/src/linkage.rs)
+- [contracts/nft/src/lib.rs](../../contracts/nft/src/lib.rs)
+- [docs/contract-interfaces.md](../contract-interfaces.md)
+- [ADR-006: Contract-Per-Domain Architecture](./ADR-006-contract-per-domain-architecture.md)
+- [Issue #762](https://github.com/BrainTease/Brain-Storm/issues/762)
+
+## Revision History
+
+| Date | Author | Change |
+|------|--------|--------|
+| 2026-07-25 | Brain-Storm maintainers | Initial proposal for issue #762 |

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -26,13 +26,21 @@ We use the [MADR (Markdown Any Decision Records)](https://adr.github.io/madr/) t
 | [ADR-003](./ADR-003-nextjs-app-router.md) | Use Next.js App Router | Accepted |
 | [ADR-004](./ADR-004-soroban-persistent-storage-credentials.md) | Use Soroban Persistent Storage for Credentials | Accepted |
 | [ADR-005](./ADR-005-token-economics.md) | Brain-Storm Token (BST) Economics | Accepted |
+| [ADR-006](./ADR-006-contract-per-domain-architecture.md) | Contract-Per-Domain Architecture (vs. a Monolithic Contract) | Accepted |
+| [ADR-007](./ADR-007-shared-crate-for-common-code.md) | `contracts/shared` for Common Contract Code | Accepted |
+| [ADR-008](./ADR-008-registry-integration-separation.md) | `registry` and `integration` Are Different Kinds of Crates | Accepted |
+| [ADR-009](./ADR-009-credential-nft-decomposition.md) | Separate `certificate`, `credential_metadata`, and `nft` Contracts | Accepted |
+
+## Contract Module Boundaries
+
+ADR-006 through ADR-009 document why `contracts/` is split into 19 separate Soroban crates instead of one monolith, including the verified on-chain cross-contract call graph. Start with [ADR-006](./ADR-006-contract-per-domain-architecture.md) for the overall rationale and call graph, then the others for specific boundary decisions. See also [docs/contract-interfaces.md](../contract-interfaces.md) for the full public interface of every contract and the cross-contract call conventions used across the codebase.
 
 ## Creating New ADRs
 
 When making significant architectural decisions:
 
 1. Copy the template from `ADR-TEMPLATE.md`
-2. Number sequentially (ADR-006, ADR-007, etc.)
+2. Number sequentially (ADR-010, ADR-011, etc.)
 3. Use descriptive kebab-case filenames
 4. Fill in all sections with context and reasoning
 5. Update this README index

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -1,0 +1,738 @@
+# Backend API Reference
+
+Auto-generated reference of every active REST route exposed by `apps/backend` (NestJS). Generated for [issue #764](https://github.com/BrainTease/Brain-Storm/issues/764).
+
+This is a **generated index**, not the source of truth for request/response bodies. `apps/backend` already uses `@nestjs/swagger` decorators throughout its controllers and DTOs to produce a full OpenAPI 3.0 spec at runtime — that spec, not this file, has the authoritative request/response JSON schemas and error response shapes for every route. This file exists to answer "what routes exist and what do they need for auth," at a glance, without running the backend.
+
+## How this was generated
+
+The table below was produced by mechanically parsing every `*.controller.ts` file under `apps/backend/src` for `@Controller(...)`, `@Get/@Post/@Put/@Patch/@Delete(...)`, `@UseGuards(...)`, `@Public()`, and `@Roles(...)` decorators — not hand-transcribed — so it can be regenerated and diffed against the router whenever controllers change. As of this writing it covers **314 routes across 57 controllers in 43 domains**, matching `find apps/backend/src -iname '*.controller.ts' | wc -l` (57) at the time of writing. No `@deprecated`/`@ApiExcludeEndpoint` markers were found in any controller, so every route listed here is active.
+
+To regenerate this table yourself (no NestJS build or database required):
+
+```bash
+python3 scripts/list-api-routes.py
+```
+
+This prints the same markdown grouped by domain to stdout (route count/domain count/controller count to stderr) — diff it against the table below to check for drift. Pass `--json` for the raw structured data if you're scripting against it.
+
+## Regenerating the Full OpenAPI Spec
+
+The commands below produce the full request/response JSON schemas and error codes for every route.
+
+`apps/backend` already exports a complete OpenAPI 3.0 document from its Swagger decorators. This is the CI-independent, documented way to regenerate it locally, per the `Makefile`:
+
+```bash
+make export-openapi
+```
+
+which runs:
+
+```bash
+npm run build --workspace=apps/backend
+cd apps/backend && EXPORT_OPENAPI=true node dist/main --export-openapi
+mkdir -p docs/api/dist
+cp apps/backend/openapi.json docs/api/dist/openapi.json
+cp docs/api/swagger-ui.html docs/api/dist/index.html
+```
+
+This requires the backend to be able to bootstrap (a reachable PostgreSQL instance per your `.env` — see [docs/development-setup.md](../development-setup.md)), since `main.ts` boots the full Nest application before serializing its route/DTO metadata to `openapi.json`. Open `docs/api/dist/index.html` in a browser to view it via Swagger UI, or run the backend normally and visit `http://localhost:3000/api/docs`.
+
+See also [docs/api/DEPLOYMENT.md](./DEPLOYMENT.md) for publishing the generated spec to GitHub Pages.
+
+## Route index
+
+Grouped by top-level domain (the first path segment under `apps/backend/src/`). "Auth" reflects the effective guards active on each route (class-level guards merged with method-level overrides); `—` means no guard decorator was found (verify against the controller before assuming a route is unauthenticated — some domains gate access inside the handler body rather than via a guard decorator).
+
+
+### access-control (7 routes)
+
+**`AccessControlController`** — `apps/backend/src/access-control/access-control.controller.ts`
+
+| Method | Path | Auth | Handler |
+|---|---|---|---|
+| POST | `/v1/access-control/grant` | JWT | `grantAccess` |
+| POST | `/v1/access-control/check` | JWT | `checkAccess` |
+| DELETE | `/v1/access-control/:courseId/users/:userId` | JWT | `revokeAccess` |
+| POST | `/v1/access-control/:courseId/users/:userId/subscription` | JWT | `updateSubscription` |
+| GET | `/v1/access-control/:courseId/logs` | JWT | `getAccessLogs` |
+| GET | `/v1/access-control/:courseId/users/:userId` | JWT | `getAccessControl` |
+| GET | `/v1/access-control/:courseId/users` | JWT | `getCourseAccessList` |
+
+### admin (7 routes)
+
+**`AdminController`** — `apps/backend/src/admin/admin.controller.ts`
+
+| Method | Path | Auth | Handler |
+|---|---|---|---|
+| PATCH | `/v1/admin/users/:id/ban` | JWT + Roles | `banUser` |
+| PATCH | `/v1/admin/users/:id/suspend` | JWT + Roles (roles: 'admin') | `suspendUser` |
+| PATCH | `/v1/admin/users/:id/role` | JWT + Roles (roles: 'admin') | `changeRole` |
+| POST | `/v1/admin/disputes` | JWT + Roles (roles: 'admin') | `createDispute` |
+| GET | `/v1/admin/disputes` | JWT + Roles (roles: 'admin', 'student', 'instructor') | `listDisputes` |
+| GET | `/v1/admin/disputes/:id` | JWT + Roles (roles: 'admin') | `getDispute` |
+| PATCH | `/v1/admin/disputes/:id/resolve` | JWT + Roles (roles: 'admin') | `resolveDispute` |
+
+### analytics (12 routes)
+
+**`AdminAnalyticsController`** — `apps/backend/src/analytics/admin-analytics.controller.ts`
+
+| Method | Path | Auth | Handler |
+|---|---|---|---|
+| GET | `/v1/admin/analytics/dashboard` | JWT + Roles (roles: 'admin') | `` |
+| GET | `/v1/admin/analytics/export` | JWT + Roles | `` |
+
+**`AnalyticsController`** — `apps/backend/src/analytics/analytics.controller.ts`
+
+| Method | Path | Auth | Handler |
+|---|---|---|---|
+| GET | `/v1/courses/:id/analytics` | JWT | `getAnalytics` |
+| POST | `/v1/courses/:id/analytics/refresh` | JWT | `refresh` |
+
+**`InstructorAnalyticsController`** — `apps/backend/src/analytics/instructor-analytics.controller.ts`
+
+| Method | Path | Auth | Handler |
+|---|---|---|---|
+| GET | `/v1/analytics/instructor` | JWT | `getAnalytics` |
+| GET | `/v1/analytics/instructor/export/csv` | JWT | `exportToCSV` |
+
+**`PlatformAnalyticsController`** — `apps/backend/src/analytics/platform-analytics.controller.ts`
+
+| Method | Path | Auth | Handler |
+|---|---|---|---|
+| POST | `/v1/analytics/events` | — | `trackEvent` |
+| GET | `/v1/analytics/dashboard` | — | `getDashboard` |
+| GET | `/v1/analytics/events` | — | `` |
+| GET | `/v1/analytics/events/export` | — | `exportEvents` |
+
+**`ProtocolMetricsController`** — `apps/backend/src/analytics/protocol-metrics.controller.ts`
+
+| Method | Path | Auth | Handler |
+|---|---|---|---|
+| GET | `/v1/protocol-metrics/summary` | — | `summary` |
+| GET | `/v1/protocol-metrics/time-series` | — | `` |
+
+### api-usage (5 routes)
+
+**`ApiUsageController`** — `apps/backend/src/api-usage/api-usage.controller.ts`
+
+| Method | Path | Auth | Handler |
+|---|---|---|---|
+| GET | `/api-usage/dashboard` | JWT + Roles (roles: 'admin') | `` |
+| GET | `/api-usage/by-endpoint` | JWT + Roles | `` |
+| GET | `/api-usage/by-user` | JWT + Roles | `` |
+| GET | `/api-usage/by-time` | JWT + Roles | `` |
+| GET | `/api-usage/alerts` | JWT + Roles | `checkAlerts` |
+
+### audit (4 routes)
+
+**`AuditController`** — `apps/backend/src/audit/audit.controller.ts`
+
+| Method | Path | Auth | Handler |
+|---|---|---|---|
+| GET | `/audit` | JWT + Roles | `` |
+| GET | `/audit/export` | JWT + Roles (roles: 'admin') | `` |
+| GET | `/audit/verify` | JWT + Roles (roles: 'admin') | `` |
+| GET | `/audit/me` | JWT + Roles (roles: 'admin') | `getMyLogs` |
+
+### auth (18 routes)
+
+**`AuthController`** — `apps/backend/src/auth/auth.controller.ts`
+
+| Method | Path | Auth | Handler |
+|---|---|---|---|
+| GET | `/auth/stellar` | — | `` |
+| POST | `/auth/stellar` | — | `` |
+| POST | `/auth/register` | — | `` |
+| POST | `/auth/login` | — | `` |
+| POST | `/auth/refresh` | — | `` |
+| POST | `/auth/logout` | — | `` |
+| GET | `/auth/verify` | — | `` |
+| POST | `/auth/resend-verification` | — | `` |
+| POST | `/auth/forgot-password` | — | `` |
+| POST | `/auth/reset-password` | — | `` |
+| POST | `/auth/mfa/enable` | — | `enableMfa` |
+| POST | `/auth/mfa/verify` | JWT | `verifyMfa` |
+| POST | `/auth/mfa/disable` | JWT | `disableMfa` |
+| POST | `/auth/mfa/backup-codes/regenerate` | JWT | `regenerateBackupCodes` |
+| POST | `/auth/admin/api-keys` | JWT | `generateApiKey` |
+| POST | `/auth/admin/api-keys/revoke` | JWT + Roles (roles: 'admin') | `revokeApiKey` |
+| POST | `/auth/stellar-challenge` | JWT + Roles (roles: 'admin') | `` |
+| POST | `/auth/stellar-verify` | JWT | `` |
+
+### batch (7 routes)
+
+**`BatchController`** — `apps/backend/src/batch/batch.controller.ts`
+
+| Method | Path | Auth | Handler |
+|---|---|---|---|
+| POST | `/batch/users` | JWT + Roles (roles: 'admin') | `` |
+| POST | `/batch/courses` | JWT + Roles | `` |
+| POST | `/batch/certificates` | JWT + Roles | `` |
+| POST | `/batch/emails` | JWT + Roles | `` |
+| POST | `/batch/export` | JWT + Roles | `` |
+| GET | `/batch/jobs` | JWT + Roles | `listJobs` |
+| GET | `/batch/jobs/:jobId` | JWT + Roles | `getJobStatus` |
+
+### bookings (8 routes)
+
+**`BookingsController`** — `apps/backend/src/bookings/bookings.controller.ts`
+
+| Method | Path | Auth | Handler |
+|---|---|---|---|
+| POST | `/v1/bookings/availability` | JWT | `setAvailability` |
+| GET | `/v1/bookings/availability/:workerId` | JWT | `getAvailability` |
+| POST | `/v1/bookings` | JWT | `` |
+| GET | `/v1/bookings` | JWT | `getMyBookings` |
+| GET | `/v1/bookings/:id` | JWT | `getBooking` |
+| PATCH | `/v1/bookings/:id/accept` | JWT | `acceptBooking` |
+| PATCH | `/v1/bookings/:id/reject` | JWT | `rejectBooking` |
+| DELETE | `/v1/bookings/:id` | JWT | `` |
+
+### cache (3 routes)
+
+**`CacheManagementController`** — `apps/backend/src/cache/cache-management.controller.ts`
+
+| Method | Path | Auth | Handler |
+|---|---|---|---|
+| GET | `/cache/stats` | JWT + Roles (roles: 'admin') | `stats` |
+| POST | `/cache/clear` | JWT + Roles | `clear` |
+| POST | `/cache/warm` | JWT + Roles | `warm` |
+
+### cdn (6 routes)
+
+**`CdnController`** — `apps/backend/src/cdn/cdn.controller.ts`
+
+| Method | Path | Auth | Handler |
+|---|---|---|---|
+| POST | `/v1/cdn/upload` | JWT | `uploadAsset` |
+| GET | `/v1/cdn/:assetId/signed-url` | JWT | `getSignedUrl` |
+| POST | `/v1/cdn/:assetId/transcode` | JWT | `markTranscoded` |
+| POST | `/v1/cdn/:assetId/invalidate` | JWT | `invalidateCache` |
+| GET | `/v1/cdn/:assetId` | JWT | `getAsset` |
+| GET | `/v1/cdn/lesson/:lessonId` | JWT | `getLessonAssets` |
+
+### certificates (6 routes)
+
+**`CertificatesController`** — `apps/backend/src/certificates/certificates.controller.ts`
+
+| Method | Path | Auth | Handler |
+|---|---|---|---|
+| POST | `/v1/certificates` | JWT | `` |
+| POST | `/v1/certificates/verify` | RolesGuard | `` |
+| GET | `/v1/certificates/user/:userId` | JWT | `getUserCertificates` |
+| GET | `/v1/certificates/verify/:hash` | JWT | `verifyCertificate` |
+| GET | `/v1/certificates/:id/pdf` | JWT | `` |
+| GET | `/v1/certificates/:id` | JWT | `` |
+
+### cohorts (13 routes)
+
+**`CohortsController`** — `apps/backend/src/cohorts/cohorts.controller.ts`
+
+| Method | Path | Auth | Handler |
+|---|---|---|---|
+| POST | `/v1/cohorts` | JWT | `createCohort` |
+| GET | `/v1/cohorts/:id` | JWT | `getCohort` |
+| POST | `/v1/cohorts/:cohortId/members` | JWT | `addMember` |
+| DELETE | `/v1/cohorts/:cohortId/members/:userId` | JWT | `removeMember` |
+| POST | `/v1/cohorts/:cohortId/progress` | JWT | `updateProgress` |
+| GET | `/v1/cohorts/:cohortId/progress` | JWT | `getCohortProgress` |
+| GET | `/v1/cohorts/course/:courseId` | JWT | `getCohortsByCourse` |
+
+**`SessionsController`** — `apps/backend/src/cohorts/sessions.controller.ts`
+
+| Method | Path | Auth | Handler |
+|---|---|---|---|
+| POST | `/v1/cohorts/:cohortId/sessions` | JWT | `createSession` |
+| GET | `/v1/cohorts/:cohortId/sessions` | JWT | `getSessionsByCohort` |
+| GET | `/v1/cohorts/:cohortId/sessions/:sessionId` | JWT | `getSession` |
+| GET | `/v1/cohorts/:cohortId/sessions/:sessionId/attendance` | JWT | `getAttendance` |
+| POST | `/v1/cohorts/:cohortId/sessions/:sessionId/attendance` | JWT | `recordAttendance` |
+| GET | `/v1/cohorts/:cohortId/sessions/:sessionId/invite` | JWT | `getCalendarInvite` |
+
+### coupons (7 routes)
+
+**`CouponsController`** — `apps/backend/src/coupons/coupons.controller.ts`
+
+| Method | Path | Auth | Handler |
+|---|---|---|---|
+| POST | `/v1/coupons` | — | `create` |
+| POST | `/v1/coupons/bulk` | JWT + Roles (roles: 'admin') | `generateBulk` |
+| POST | `/v1/coupons/validate` | JWT + Roles (roles: 'admin') | `validate` |
+| GET | `/v1/coupons` | — | `findAll` |
+| GET | `/v1/coupons/:id` | JWT + Roles (roles: 'admin') | `findById` |
+| PATCH | `/v1/coupons/:id` | JWT + Roles (roles: 'admin') | `update` |
+| DELETE | `/v1/coupons/:id` | JWT + Roles (roles: 'admin') | `delete` |
+
+### courses (27 routes)
+
+**`CourseVersioningController`** — `apps/backend/src/courses/course-versioning.controller.ts`
+
+| Method | Path | Auth | Handler |
+|---|---|---|---|
+| POST | `/courses/:courseId/versions` | JWT + Roles | `createVersion` |
+| GET | `/courses/:courseId/versions` | JWT + Roles (roles: 'admin', 'instructor') | `listVersions` |
+| GET | `/courses/:courseId/versions/diff` | JWT + Roles (roles: 'admin', 'instructor') | `` |
+| GET | `/courses/:courseId/versions/:versionId` | JWT + Roles (roles: 'admin', 'instructor') | `getVersion` |
+| POST | `/courses/:courseId/versions/:versionId/rollback` | JWT + Roles (roles: 'admin', 'instructor') | `rollback` |
+
+**`CoursesController`** — `apps/backend/src/courses/courses.controller.ts`
+
+| Method | Path | Auth | Handler |
+|---|---|---|---|
+| GET | `/courses` | — | `` |
+| GET | `/courses/:id` | — | `` |
+| POST | `/courses` | — | `` |
+| PATCH | `/courses/:id` | JWT + Roles (roles: 'admin', 'instructor') | `` |
+| DELETE | `/courses/:id` | JWT + Roles (roles: 'admin', 'instructor') | `` |
+| POST | `/courses/:id/schedule` | JWT + Roles (roles: 'admin', 'instructor') | `` |
+| POST | `/courses/:id/publish` | JWT + Roles (roles: 'admin', 'instructor') | `` |
+
+**`ModulesController`** — `apps/backend/src/courses/modules.controller.ts`
+
+| Method | Path | Auth | Handler |
+|---|---|---|---|
+| GET | `/courses/:courseId/modules` | — | `` |
+| POST | `/courses/:courseId/modules` | JWT + Roles (roles: 'instructor', 'admin') | `` |
+| PATCH | `/modules/:id` | JWT + Roles (roles: 'instructor', 'admin') | `` |
+| DELETE | `/modules/:id` | JWT + Roles (roles: 'instructor', 'admin') | `` |
+| GET | `/modules/:moduleId/lessons` | — | `` |
+| POST | `/modules/:moduleId/lessons` | JWT + Roles (roles: 'instructor', 'admin') | `` |
+| PATCH | `/lessons/:id` | JWT + Roles (roles: 'instructor', 'admin') | `` |
+| DELETE | `/lessons/:id` | JWT + Roles (roles: 'instructor', 'admin') | `` |
+
+**`PrerequisitesController`** — `apps/backend/src/courses/prerequisites.controller.ts`
+
+| Method | Path | Auth | Handler |
+|---|---|---|---|
+| GET | `/courses/:courseId/prerequisites` | JWT + Roles | `getPrerequisites` |
+| GET | `/courses/:courseId/prerequisites/chain` | JWT + Roles (roles: 'admin', 'instructor', 'student') | `getChain` |
+| POST | `/courses/:courseId/prerequisites` | JWT + Roles (roles: 'admin', 'instructor', 'student') | `addPrerequisite` |
+| DELETE | `/courses/:courseId/prerequisites/:prerequisiteId` | JWT + Roles (roles: 'admin', 'instructor') | `removePrerequisite` |
+| POST | `/courses/:courseId/prerequisites/validate/:userId` | JWT + Roles (roles: 'admin', 'instructor') | `validatePrerequisites` |
+
+**`ReviewsController`** — `apps/backend/src/courses/reviews.controller.ts`
+
+| Method | Path | Auth | Handler |
+|---|---|---|---|
+| POST | `/courses/:id/reviews` | — | `` |
+| GET | `/courses/:id/reviews` | JWT | `` |
+
+### credentials (8 routes)
+
+**`CredentialsController`** — `apps/backend/src/credentials/credentials.controller.ts`
+
+| Method | Path | Auth | Handler |
+|---|---|---|---|
+| GET | `/credentials/:id/pdf` | JWT | `` |
+| GET | `/credentials/:userId` | JWT | `` |
+| GET | `/credentials/verify/:txHash` | JWT | `` |
+| POST | `/credentials/issue` | JWT | `` |
+
+**`PublicCredentialVerificationController`** — `apps/backend/src/credentials/public-credential-verification.controller.ts`
+
+| Method | Path | Auth | Handler |
+|---|---|---|---|
+| GET | `/public/credentials/:id/verify` | — | `` |
+| GET | `/public/credentials/hash/:txHash/verify` | — | `` |
+| GET | `/public/credentials/:id/widget` | — | `` |
+| GET | `/public/credentials/:id/badge` | — | `` |
+
+### email (3 routes)
+
+**`EmailController`** — `apps/backend/src/email/email.controller.ts`
+
+| Method | Path | Auth | Handler |
+|---|---|---|---|
+| GET | `/v1/email/unsubscribe` | — | `unsubscribe` |
+| GET | `/v1/email/preferences` | JWT | `getPreferences` |
+| PATCH | `/v1/email/preferences` | JWT | `updatePreferences` |
+
+### enrollments (7 routes)
+
+**`EnrollmentsController`** — `apps/backend/src/enrollments/enrollments.controller.ts`
+
+| Method | Path | Auth | Handler |
+|---|---|---|---|
+| POST | `/v1/enrollments` | JWT | `` |
+| GET | `/v1/enrollments` | JWT | `` |
+| GET | `/v1/enrollments/:id` | JWT | `` |
+| DELETE | `/v1/enrollments/:id` | JWT | `` |
+| POST | `/v1/enrollments/courses/:id/enroll` | JWT | `` |
+| DELETE | `/v1/enrollments/courses/:id/enroll` | JWT | `` |
+| GET | `/v1/enrollments/users/:id/enrollments` | JWT | `` |
+
+### feature-flags (5 routes)
+
+**`FeatureFlagsController`** — `apps/backend/src/feature-flags/feature-flags.controller.ts`
+
+| Method | Path | Auth | Handler |
+|---|---|---|---|
+| GET | `/feature-flags/evaluate/:key` | — | `` |
+| POST | `/feature-flags/evaluate` | JWT | `evaluateBatch` |
+| GET | `/feature-flags` | JWT | `findAll` |
+| POST | `/feature-flags` | JWT | `upsert` |
+| DELETE | `/feature-flags/:key` | JWT | `remove` |
+
+### forums (3 routes)
+
+**`ForumsController`** — `apps/backend/src/forums/forums.controller.ts`
+
+| Method | Path | Auth | Handler |
+|---|---|---|---|
+| GET | `/courses/:id/posts` | — | `findByCourse` |
+| POST | `/courses/:id/posts` | — | `` |
+| POST | `/posts/:id/replies` | JWT | `` |
+
+### gateway (2 routes)
+
+**`GatewayController`** — `apps/backend/src/gateway/gateway.controller.ts`
+
+| Method | Path | Auth | Handler |
+|---|---|---|---|
+| GET | `/v1/gateway/health` | — | `health` |
+| GET | `/v1/gateway/routes` | — | `` |
+
+### gdpr (2 routes)
+
+**`PrivacyController`** — `apps/backend/src/gdpr/privacy.controller.ts`
+
+| Method | Path | Auth | Handler |
+|---|---|---|---|
+| GET | `/v1/privacy/export` | JWT | `` |
+| DELETE | `/v1/privacy/account` | JWT | `` |
+
+### health (3 routes)
+
+**`HealthController`** — `apps/backend/src/health/health.controller.ts`
+
+| Method | Path | Auth | Handler |
+|---|---|---|---|
+| GET | `/health/liveness` | — | `` |
+| GET | `/health/readiness` | — | `` |
+| GET | `/health` | — | `` |
+
+### import-export (5 routes)
+
+**`ImportExportController`** — `apps/backend/src/import-export/import-export.controller.ts`
+
+| Method | Path | Auth | Handler |
+|---|---|---|---|
+| GET | `/courses/:id/export` | JWT + Roles (roles: 'instructor', 'admin') | `exportCourse` |
+| POST | `/courses/import/json` | JWT + Roles | `` |
+| POST | `/courses/import/scorm` | JWT + Roles | `` |
+| POST | `/courses/import/bulk` | JWT + Roles | `` |
+| GET | `/courses/import/jobs/:jobId` | JWT + Roles | `getJobStatus` |
+
+### jobs (11 routes)
+
+**`JobsController`** — `apps/backend/src/jobs/jobs.controller.ts`
+
+| Method | Path | Auth | Handler |
+|---|---|---|---|
+| GET | `/jobs` | — | `findAll` |
+| GET | `/jobs/recommendations` | JWT | `getRecommendations` |
+| GET | `/jobs/:id` | — | `findOne` |
+| POST | `/jobs` | JWT | `create` |
+| PATCH | `/jobs/:id` | JWT | `update` |
+| DELETE | `/jobs/:id` | JWT | `remove` |
+| POST | `/jobs/:id/apply` | JWT | `apply` |
+| GET | `/jobs/:id/applications` | JWT | `getApplications` |
+| GET | `/jobs/applications/mine` | JWT | `myApplications` |
+| PATCH | `/jobs/applications/:appId/status` | JWT | `updateStatus` |
+| PATCH | `/jobs/applications/:appId/withdraw` | JWT | `withdraw` |
+
+### kyc (5 routes)
+
+**`KycController`** — `apps/backend/src/kyc/kyc.controller.ts`
+
+| Method | Path | Auth | Handler |
+|---|---|---|---|
+| GET | `/kyc/status/:stellarPublicKey` | — | `getStatus` |
+| PUT | `/kyc/customer` | — | `upsertCustomer` |
+| POST | `/kyc/customer/document` | — | `` |
+| GET | `/kyc/report` | — | `getComplianceReport` |
+| POST | `/kyc/webhook` | — | `webhook` |
+
+### leaderboard (6 routes)
+
+**`LeaderboardController`** — `apps/backend/src/leaderboard/leaderboard.controller.ts`
+
+| Method | Path | Auth | Handler |
+|---|---|---|---|
+| GET | `/leaderboard` | — | `getLeaderboard` |
+
+**`RedisLeaderboardController`** — `apps/backend/src/leaderboard/redis-leaderboard.controller.ts`
+
+| Method | Path | Auth | Handler |
+|---|---|---|---|
+| GET | `/v1/leaderboard/global` | — | `` |
+| GET | `/v1/leaderboard/course/:courseId` | — | `` |
+| GET | `/v1/leaderboard/cohort/:cohortId` | — | `` |
+| GET | `/v1/leaderboard/me` | — | `` |
+| GET | `/v1/leaderboard/top` | JWT | `` |
+
+### media (6 routes)
+
+**`MediaController`** — `apps/backend/src/media/media.controller.ts`
+
+| Method | Path | Auth | Handler |
+|---|---|---|---|
+| POST | `/media/upload` | JWT | `` |
+| GET | `/media/mine` | JWT | `mine` |
+| GET | `/media/:id/url` | JWT | `getUrl` |
+| GET | `/media/:id/url/:suffix` | JWT | `getDerivativeUrl` |
+| DELETE | `/media/:id` | JWT | `delete` |
+| DELETE | `/media/:id/purge` | JWT | `purge` |
+
+### moderation (6 routes)
+
+**`ModerationController`** — `apps/backend/src/moderation/moderation.controller.ts`
+
+| Method | Path | Auth | Handler |
+|---|---|---|---|
+| POST | `/moderation/flag` | JWT | `flag` |
+| GET | `/moderation/queue` | JWT | `` |
+| PATCH | `/moderation/:id/review` | RolesGuard | `` |
+| POST | `/moderation/:id/appeal` | RolesGuard | `appeal` |
+| PATCH | `/moderation/:id/appeal/resolve` | JWT | `` |
+| GET | `/moderation/:id/logs` | RolesGuard | `` |
+
+### notifications (10 routes)
+
+**`NotificationPreferencesController`** — `apps/backend/src/notifications/notification-preferences.controller.ts`
+
+| Method | Path | Auth | Handler |
+|---|---|---|---|
+| GET | `/notifications/preferences` | JWT | `get` |
+| PUT | `/notifications/preferences` | JWT | `upsert` |
+
+**`NotificationsController`** — `apps/backend/src/notifications/notifications.controller.ts`
+
+| Method | Path | Auth | Handler |
+|---|---|---|---|
+| GET | `/notifications` | JWT | `findAll` |
+| PATCH | `/notifications/:id/read` | JWT | `` |
+| PATCH | `/notifications/read-all` | JWT | `markAllAsRead` |
+| GET | `/notifications/preferences` | JWT | `getPreferences` |
+| PATCH | `/notifications/preferences` | JWT | `` |
+| POST | `/notifications/schedule` | JWT | `scheduleNotification` |
+| DELETE | `/notifications/schedule/:id` | JWT | `` |
+| POST | `/notifications/register-device` | JWT | `` |
+
+### organizations (10 routes)
+
+**`OrganizationsController`** — `apps/backend/src/organizations/organizations.controller.ts`
+
+| Method | Path | Auth | Handler |
+|---|---|---|---|
+| POST | `/v1/organizations` | JWT | `createOrganization` |
+| GET | `/v1/organizations` | JWT | `getMyOrganizations` |
+| GET | `/v1/organizations/:orgId` | JWT | `getOrganization` |
+| GET | `/v1/organizations/:orgId/members` | JWT | `getMembers` |
+| POST | `/v1/organizations/:orgId/invite` | JWT | `inviteMember` |
+| POST | `/v1/organizations/invite/:token/accept` | JWT | `acceptInvite` |
+| PUT | `/v1/organizations/:orgId/members/:memberId/role` | JWT | `changeRole` |
+| DELETE | `/v1/organizations/:orgId/members/:memberId` | JWT | `removeMember` |
+| GET | `/v1/organizations/:orgId/billing` | JWT | `getBillingProfile` |
+| PUT | `/v1/organizations/:orgId/billing/budget` | JWT | `updateBudget` |
+
+### payments (8 routes)
+
+**`PaymentsController`** — `apps/backend/src/payments/payments.controller.ts`
+
+| Method | Path | Auth | Handler |
+|---|---|---|---|
+| POST | `/v1/payments/checkout` | — | `` |
+| POST | `/v1/payments/subscriptions` | JWT | `` |
+| GET | `/v1/payments/subscriptions/me` | JWT | `` |
+| DELETE | `/v1/payments/subscriptions/me` | JWT | `` |
+| GET | `/v1/payments/invoices` | JWT | `` |
+| GET | `/v1/payments/history` | JWT | `` |
+| POST | `/v1/payments/stripe/webhook` | JWT | `stripeWebhook` |
+| POST | `/v1/payments/stellar/verify` | — | `` |
+
+### payouts (5 routes)
+
+**`PayoutsController`** — `apps/backend/src/payouts/payouts.controller.ts`
+
+| Method | Path | Auth | Handler |
+|---|---|---|---|
+| POST | `/v1/payouts/calculate` | — | `calculatePayouts` |
+| POST | `/v1/payouts/:payoutId/process` | JWT + Roles (roles: 'admin') | `processPayout` |
+| GET | `/v1/payouts/instructor/:instructorId` | JWT + Roles (roles: 'admin') | `getInstructorPayouts` |
+| GET | `/v1/payouts/instructor/:instructorId/stats` | JWT | `getPayoutStats` |
+| GET | `/v1/payouts/instructor/:instructorId/history` | JWT | `getPayoutHistory` |
+
+### progress (5 routes)
+
+**`ProgressController`** — `apps/backend/src/progress/progress.controller.ts`
+
+| Method | Path | Auth | Handler |
+|---|---|---|---|
+| POST | `/v1/progress` | JWT | `` |
+| GET | `/v1/progress/:courseId` | JWT | `` |
+| GET | `/v1/progress/user/:userId` | JWT | `` |
+| POST | `/v1/progress/progress` | JWT | `` |
+| GET | `/v1/progress/users/:id/progress` | JWT | `` |
+
+### quizzes (8 routes)
+
+**`QuizzesController`** — `apps/backend/src/quizzes/quizzes.controller.ts`
+
+| Method | Path | Auth | Handler |
+|---|---|---|---|
+| GET | `/v1/quizzes/:id` | JWT | `` |
+| POST | `/v1/quizzes/:quizId/submit` | JWT | `` |
+| GET | `/v1/quizzes/:quizId/results` | JWT | `` |
+| POST | `/v1/quizzes/:lessonId` | JWT | `createQuiz` |
+| POST | `/v1/quizzes/:quizId/questions` | JWT | `addQuestion` |
+| POST | `/v1/quizzes/questions/:questionId/answers` | JWT | `addAnswer` |
+| POST | `/v1/quizzes/:attemptId/grade` | JWT | `gradeEssay` |
+| GET | `/v1/quizzes/:quizId/attempts` | JWT | `getAttempts` |
+
+### rate-limit (5 routes)
+
+**`RateLimitController`** — `apps/backend/src/rate-limit/rate-limit.controller.ts`
+
+| Method | Path | Auth | Handler |
+|---|---|---|---|
+| GET | `/rate-limit/status` | JWT | `getMyStatus` |
+| GET | `/rate-limit/config` | JWT | `` |
+| DELETE | `/rate-limit/users/:userId/reset` | RolesGuard | `` |
+| POST | `/rate-limit/allowlist/:userId` | RolesGuard | `` |
+| DELETE | `/rate-limit/allowlist/:userId` | RolesGuard | `` |
+
+### recommendations (5 routes)
+
+**`RecommendationSignalsController`** — `apps/backend/src/recommendations/recommendation-signals.controller.ts`
+
+| Method | Path | Auth | Handler |
+|---|---|---|---|
+| POST | `/v1/recommendations/signals` | JWT | `` |
+| GET | `/v1/recommendations/signal-recommendations` | JWT | `` |
+| DELETE | `/v1/recommendations/signals` | JWT | `deleteMySignals` |
+| GET | `/v1/recommendations/evaluate` | JWT | `` |
+
+**`RecommendationsController`** — `apps/backend/src/recommendations/recommendations.controller.ts`
+
+| Method | Path | Auth | Handler |
+|---|---|---|---|
+| GET | `/v1/recommendations` | JWT | `getRecommendations` |
+
+### reminders (5 routes)
+
+**`RemindersController`** — `apps/backend/src/reminders/reminders.controller.ts`
+
+| Method | Path | Auth | Handler |
+|---|---|---|---|
+| POST | `/v1/reminders/send-inactive` | — | `sendInactiveReminders` |
+| POST | `/v1/reminders/:userId/:courseId` | JWT + Roles (roles: 'admin') | `createReminder` |
+| PATCH | `/v1/reminders/:userId/:courseId/disable` | JWT | `disableReminder` |
+| PATCH | `/v1/reminders/:userId/:courseId/enable` | JWT | `enableReminder` |
+| GET | `/v1/reminders/stats` | JWT | `getReminderStats` |
+
+### search (5 routes)
+
+**`SearchController`** — `apps/backend/src/search/search.controller.ts`
+
+| Method | Path | Auth | Handler |
+|---|---|---|---|
+| GET | `/search` | — | `` |
+| GET | `/search/autocomplete` | — | `` |
+| POST | `/search/click` | — | `trackClick` |
+| GET | `/search/analytics/top-queries` | — | `` |
+| POST | `/search/evaluate` | JWT + Roles (roles: 'admin') | `` |
+
+### secrets (7 routes)
+
+**`SecretRotationController`** — `apps/backend/src/secrets/secret-rotation.controller.ts`
+
+| Method | Path | Auth | Handler |
+|---|---|---|---|
+| POST | `/secrets/api-keys/:id/rotate` | JWT | `rotateApiKey` |
+| GET | `/secrets/rotation-history` | JWT | `` |
+| GET | `/secrets/access-logs` | RolesGuard | `` |
+| GET | `/secrets/aws/list` | RolesGuard | `` |
+| GET | `/secrets/aws/:name/describe` | RolesGuard | `` |
+| POST | `/secrets/aws/:name/backup` | RolesGuard | `` |
+| POST | `/secrets/aws/:name/emergency-access` | RolesGuard | `` |
+
+### stellar (7 routes)
+
+**`StellarController`** — `apps/backend/src/stellar/stellar.controller.ts`
+
+| Method | Path | Auth | Handler |
+|---|---|---|---|
+| GET | `/stellar/network-status` | — | `getNetworkStatus` |
+| GET | `/stellar/balance/:publicKey` | — | `getBalance` |
+| POST | `/stellar/fund-testnet` | — | `` |
+| POST | `/stellar/mint` | — | `` |
+| GET | `/stellar/transactions/verify/:txHash` | JWT + Roles (roles: 'admin') | `` |
+| GET | `/stellar/transactions` | JWT | `` |
+| POST | `/stellar/issue` | JWT + Roles (roles: 'admin') | `` |
+
+### surveys (6 routes)
+
+**`SurveysController`** — `apps/backend/src/surveys/surveys.controller.ts`
+
+| Method | Path | Auth | Handler |
+|---|---|---|---|
+| POST | `/v1/surveys` | JWT | `createSurvey` |
+| POST | `/v1/surveys/:surveyId/questions` | RolesGuard | `addQuestion` |
+| POST | `/v1/surveys/:surveyId/responses` | RolesGuard | `submitResponse` |
+| GET | `/v1/surveys/course/:courseId` | JWT | `getSurveysByCourse` |
+| GET | `/v1/surveys/:surveyId/responses` | JWT | `getResponses` |
+| GET | `/v1/surveys/:surveyId/analytics` | RolesGuard | `getAnalytics` |
+
+### users (17 routes)
+
+**`GdprController`** — `apps/backend/src/users/gdpr.controller.ts`
+
+| Method | Path | Auth | Handler |
+|---|---|---|---|
+| GET | `/gdpr/export` | JWT | `export` |
+| DELETE | `/gdpr/delete` | JWT | `delete` |
+| POST | `/gdpr/recover/:id` | JWT | `recover` |
+| POST | `/gdpr/purge` | JWT | `purge` |
+
+**`UsersController`** — `apps/backend/src/users/users.controller.ts`
+
+| Method | Path | Auth | Handler |
+|---|---|---|---|
+| GET | `/v1/users/me` | JWT | `` |
+| GET | `/v1/users/:id` | JWT | `` |
+| PATCH | `/v1/users/:id` | JWT | `` |
+| POST | `/v1/users/avatar` | JWT | `` |
+| GET | `/v1/users` | JWT | `` |
+| GET | `/v1/users/:id/token-balance` | RolesGuard | `` |
+| GET | `/v1/users/:id/referrals` | JWT | `getReferrals` |
+| GET | `/v1/users` | JWT + Roles | `` |
+| POST | `/v1/users/import/csv` | JWT | `` |
+| GET | `/v1/users/import-jobs/:jobId` | JWT | `getUserImportJob` |
+| PATCH | `/v1/users/:id/role` | JWT | `` |
+| PATCH | `/v1/users/:id/ban` | JWT | `` |
+| DELETE | `/v1/users/:id` | JWT | `` |
+
+### webhooks (9 routes)
+
+**`WebhooksController`** — `apps/backend/src/webhooks/webhooks.controller.ts`
+
+| Method | Path | Auth | Handler |
+|---|---|---|---|
+| POST | `/v1/webhooks` | JWT | `create` |
+| GET | `/v1/webhooks` | JWT | `list` |
+| PATCH | `/v1/webhooks/:id` | JWT | `update` |
+| DELETE | `/v1/webhooks/:id` | JWT | `remove` |
+| POST | `/v1/webhooks/:id/rotate-secret` | JWT | `rotateSecret` |
+| GET | `/v1/webhooks/:id/logs` | JWT | `logs` |
+| GET | `/v1/webhooks/:id/dlq` | JWT | `dlq` |
+| POST | `/v1/webhooks/deliveries/:deliveryId/replay` | JWT | `replayDelivery` |
+| POST | `/v1/webhooks/verify-signature` | JWT | `verifySignature` |
+
+
+## See also
+
+- [docs/api/DEPLOYMENT.md](./DEPLOYMENT.md) — publishing the generated OpenAPI spec to GitHub Pages
+- [docs/api/swagger-ui.html](./swagger-ui.html) — static Swagger UI shell used for the published spec
+- [docs/development-setup.md](../development-setup.md) — running the backend locally so `/api/docs` is reachable

--- a/docs/contract-interfaces.md
+++ b/docs/contract-interfaces.md
@@ -13,9 +13,23 @@ Complete interface documentation for all Soroban smart contracts on the Stellar 
 7. [Reputation Contract](#reputation-contract)
 8. [Scholarship Fund Contract](#scholarship-fund-contract)
 9. [Liquidity Pool Contract](#liquidity-pool-contract)
-10. [Shared / RBAC Contract](#shared--rbac-contract)
-11. [Security Considerations](#security-considerations)
-12. [Upgrade Guide](#upgrade-guide)
+10. [NFT Contract](#nft-contract)
+11. [Market Contract](#market-contract)
+12. [Credential Metadata Contract](#credential-metadata-contract)
+13. [Registry Contract](#registry-contract)
+14. [Dispute Contract](#dispute-contract)
+15. [Grants Contract](#grants-contract)
+16. [Royalty Distribution Contract](#royalty-distribution-contract)
+17. [Buyback Contract](#buyback-contract)
+18. [Token Restrictions Contract](#token-restrictions-contract)
+19. [Shared / RBAC Contract](#shared--rbac-contract)
+20. [`contracts/integration` — Not a Contract](#contractsintegration--not-a-contract)
+21. [Cross-Contract Call Conventions](#cross-contract-call-conventions)
+22. [Worked Examples](#worked-examples)
+23. [Security Considerations](#security-considerations)
+24. [Upgrade Guide](#upgrade-guide)
+
+> This reference covers all 19 crates under `contracts/`. For *why* the platform is split into this many contracts instead of fewer, see [docs/adr/ADR-006](./adr/ADR-006-contract-per-domain-architecture.md) through [ADR-009](./adr/ADR-009-credential-nft-decomposition.md).
 
 ---
 
@@ -290,9 +304,360 @@ AMM-style BST/XLM liquidity pool with LP mining rewards.
 
 ---
 
+## NFT Contract
+
+Generic, tradeable course NFT with marketplace listing and per-holder access grants. Unlike the soulbound `certificate`/`badges` contracts, ownership is transferable by default and the contract includes its own escrow-free marketplace (`list_nft`/`buy_nft`/`delist_nft`).
+
+### Functions
+
+| Function | Auth | Description |
+|---|---|---|
+| `initialize(admin)` | none | One-time setup |
+| `get_admin()` | — | Read admin |
+| `mint_course_nft(admin, owner, course_id, course_name, instructor, purchase_price, royalty_basis)` | admin | Mint an NFT; returns `nft_id`. Called directly, or cross-contract by `credential_metadata::issue_with_nft` |
+| `transfer_nft(from, to, nft_id)` | from | Transfer ownership |
+| `grant_access(nft_owner, nft_id, holder)` | nft_owner | Grant a non-owner address access to gated content tied to the NFT |
+| `revoke_access(nft_owner, nft_id, holder)` | nft_owner | Revoke a previously-granted access |
+| `has_access(nft_id, holder)` | — | Check access |
+| `get_nft_metadata(nft_id)` | — | Read metadata |
+| `get_nft_owner(nft_id)` | — | Read current owner |
+| `get_owner_nfts(owner)` | — | All NFT IDs owned by an address |
+| `get_royalty_info(nft_id)` | — | `(instructor, royalty_basis)` for a given NFT |
+| `burn_nft(owner, nft_id)` | owner | Destroy an NFT |
+| `list_nft(seller, nft_id, price)` | seller | List an owned NFT for sale |
+| `delist_nft(seller, nft_id)` | seller | Cancel a listing |
+| `buy_nft(buyer, nft_id)` | buyer | Purchase a listed NFT; transfers ownership and payment |
+| `get_listing(nft_id)` | — | Read listing details |
+
+### Events
+
+Topic symbols emitted (grep-verified against `contracts/nft/src/lib.rs`): `minted`, `xfer`, `acc_grt`, `acc_rvk`, `burned`, `listed`, `delisted`, `sold`, all under the `nft` prefix.
+
+### Notes
+
+`nft` performs no on-chain cross-contract calls of its own — it is called *into* by `credential_metadata` (see [Cross-Contract Call Conventions](#cross-contract-call-conventions)) and separately, as an independent contract, by `apps/backend` for plain marketplace flows. See [ADR-009](./adr/ADR-009-credential-nft-decomposition.md) for why this is a separate contract from `certificate` and `credential_metadata`.
+
+---
+
+## Market Contract
+
+Escrow, tips, protocol fees, and multi-sig escrow for marketplace-style payments. Does not hold NFTs or credentials itself — `apps/backend` composes `market` with `nft` for a full purchase flow (see [Worked Example 1](#worked-example-1-marketplace-purchase-market--nft--royalty_distribution)).
+
+### Functions
+
+| Function | Auth | Description |
+|---|---|---|
+| `initialize(admin)` | none | One-time setup |
+| `get_admin()` | — | Read admin |
+| `pause(admin)` / `unpause(admin)` / `is_paused()` | admin | Emergency stop for all mutating operations (#663) |
+| `set_fee_bps(admin, fee_bps)` / `get_fee_bps()` | admin | Configure protocol fee, in basis points |
+| `set_treasury(admin, treasury)` / `get_treasury_balance()` | admin | Configure the fee-collection treasury address |
+| `fund_escrow(payer, payee, amount)` | payer | Fund a simple escrow; returns `escrow_id`. Blocked when paused |
+| `settle_escrow(caller, escrow_id)` | payer or admin | Apply fee to treasury, pay net to payee. Blocked when paused |
+| `refund_escrow(admin, escrow_id)` | admin | Refund escrow to payer. Blocked when paused |
+| `get_escrow(escrow_id)` | — | Read escrow state |
+| `tip(tipper, amount)` | tipper | Send a tip; fee → treasury, net amount returned to caller. Blocked when paused |
+| `batch_settle_escrows(caller, escrow_ids)` | admin or payer of each | Settle multiple escrows in one transaction (#662). Blocked when paused |
+| `batch_refund_escrows(admin, escrow_ids)` | admin | Refund multiple escrows in one transaction (#662). Blocked when paused |
+| `ms_fund_escrow(payer, payee, amount, signers, threshold, timeout_ledgers)` | payer | Fund a multi-signature escrow (#658) requiring `threshold`-of-`signers` approval |
+| `ms_approve_escrow(escrow_id, signer)` | signer | Approve a multi-sig escrow |
+| `ms_timeout_escrow(escrow_id)` | — | Mark expired if the approval threshold wasn't met in time; caller/backend then triggers the refund fallback |
+| `ms_get_escrow(escrow_id)` | — | Read multi-sig escrow state |
+
+### Events
+
+Topic symbols emitted: `paused`, `unpaused`, `es_fund`, `es_settl`, `es_refnd`, `tip`, all under the `market` prefix.
+
+### Notes
+
+`market` performs no on-chain cross-contract calls — it moves value entirely within its own escrow storage. Payment amounts are caller-supplied `i128` values; `market` does not itself invoke `token::transfer`. Composing an actual token/XLM payment with escrow funding/settlement is the caller's (i.e. `apps/backend`'s) responsibility. See [Cross-Contract Call Conventions](#cross-contract-call-conventions).
+
+---
+
+## Credential Metadata Contract
+
+Off-chain-content metadata and lifecycle (expiry/renewal/content-hash verification) for a credential, optionally linked atomically to an `nft` at issuance time. See [ADR-009](./adr/ADR-009-credential-nft-decomposition.md) for why this is separate from `certificate` and `nft`.
+
+### Functions
+
+| Function | Auth | Description |
+|---|---|---|
+| `initialize(admin)` | none | One-time setup, no NFT linkage support |
+| `initialize_with_nft(admin, nft_contract)` | admin | One-time setup, registers the `nft` contract address for linkage (#635) |
+| `issue_with_nft(admin, credential_id, course_name, completion_date, expiry_timestamp, grade, ipfs_hash, owner, course_id, instructor, royalty_basis)` | admin | Store metadata **and** atomically cross-call `nft::mint_course_nft`; rolls back entirely on either failure. Returns the minted `nft_id` |
+| `get_credential_link(credential_id)` | — | Read the `CredentialNftLink` for a credential, if any |
+| `get_nft_credential_id(nft_id)` | — | Reverse lookup: NFT → credential |
+| `credential_is_linked(credential_id)` | — | Check whether a credential has a linked NFT |
+| `store_metadata(admin, credential_id, course_name, completion_date, expiry_timestamp, grade, ipfs_hash)` | admin | Store metadata **without** minting an NFT |
+| `update_metadata(admin, credential_id, course_name, grade)` | admin | Update mutable fields of an existing record |
+| `get_metadata(credential_id)` | — | Read the full metadata record |
+| `is_expired(credential_id)` / `is_valid(credential_id)` / `can_renew(credential_id)` | — | Lifecycle state checks |
+| `renew_credential(admin, credential_id, new_expiry_timestamp)` | admin | Extend expiry |
+| `emit_expiry_event(credential_id)` | — | Emit an expiry event for off-chain indexers |
+| `store_metadata_hash(admin, credential_id, hash)` | admin | Store a content hash (e.g. of the full credential document) for later verification |
+| `verify_metadata_hash(credential_id, hash)` | — | Compare a supplied hash against the stored one |
+| `get_metadata_history(credential_id, index)` / `get_history_count(credential_id)` | — | Paginated update history |
+
+### Events
+
+Topic symbols emitted: `cred` (linkage), `store`, `update`, `renew`, `expire`.
+
+### Notes
+
+`issue_with_nft` is one of only three verified on-chain cross-contract calls in the entire contract suite — see [Worked Example 2](#worked-example-2-credential-issuance-with-linked-nft-635) and [ADR-006](./adr/ADR-006-contract-per-domain-architecture.md#verified-on-chain-call-graph).
+
+---
+
+## Registry Contract
+
+Verification levels, certified skills (with expiry), specialisations, curator permissions, and a paginated global user directory (#656).
+
+### Functions
+
+| Function | Auth | Description |
+|---|---|---|
+| `initialize(admin)` | none | One-time setup |
+| `get_admin()` | — | Read admin |
+| `pause(admin)` / `unpause(admin)` / `is_paused()` | admin | Emergency stop |
+| `add_curator(admin, curator)` / `remove_curator(admin, curator)` / `is_curator(addr)` | admin | Manage the curator set — curators can set verification levels/skills/specialisations alongside admin |
+| `set_verification_level(setter, user, level)` / `get_verification_level(user)` | admin or curator | Set/read a user's verification level. Blocked when paused |
+| `add_certified_skill(setter, user, skill, expiry_ts)` / `remove_certified_skill(setter, user, skill)` | admin or curator | Manage certified skills. Blocked when paused |
+| `get_certified_skills(user)` | — | Returns only non-expired skills |
+| `has_certified_skill(user, skill)` | — | Boolean check |
+| `set_specialisations(setter, user, specs)` / `get_specialisations(user)` | admin or curator | Manage specialisations. Blocked when paused |
+| `batch_register_users(users)` | each user | Register multiple users in one transaction. Blocked when paused |
+| `batch_set_verification_levels(setter, users, level)` | admin or curator | Bulk-set verification levels. Blocked when paused |
+| `register_user(user)` | user | Idempotently register a user in the global directory |
+| `list_users(offset, limit)` / `list_users_by_level(min_level, offset, limit)` / `total_users()` | — | Paginated directory reads |
+
+### Notes
+
+`registry` performs no on-chain cross-contract calls. It is unrelated to `contracts/integration` despite the similar-sounding names — see [ADR-008](./adr/ADR-008-registry-integration-separation.md).
+
+---
+
+## Dispute Contract
+
+Escrow dispute resolution with an Open → Evidence → Decision → Settled lifecycle (#659).
+
+### Functions
+
+| Function | Auth | Description |
+|---|---|---|
+| `initialize(admin, arbiter)` | admin | One-time setup, sets the arbiter address |
+| `get_arbiter()` / `set_arbiter(admin, arbiter)` | admin (set) | Read/rotate the arbiter |
+| `open_dispute(claimant, respondent, amount)` | claimant | Open a dispute over a given amount; returns `dispute_id` |
+| `submit_evidence(caller, dispute_id, hash)` | claimant or respondent | Submit an evidence hash, moves the dispute to the Evidence phase |
+| `record_decision(arbiter, dispute_id, outcome)` | arbiter | Record the arbiter's ruling, moves to Decision phase |
+| `settle(arbiter, dispute_id)` | arbiter | Enforce the ruling; computes and returns `(claimant_amount, respondent_amount)`, moves to Settled |
+| `get_dispute(dispute_id)` | — | Read dispute state |
+
+### Notes
+
+`dispute` computes payout splits but does not itself move tokens — like `market`, actual fund transfer is the caller's responsibility. It performs no on-chain cross-contract calls.
+
+---
+
+## Grants Contract
+
+Milestone-based grant applications with admin approval and BST fund release.
+
+### Functions
+
+| Function | Auth | Description |
+|---|---|---|
+| `initialize(admin, token_contract)` | admin | One-time setup; records the `token` contract address used for fund release |
+| `get_admin()` | — | Read admin |
+| `apply_for_grant(applicant, title, description, total_amount, milestone_count)` | applicant | Submit an application; returns `grant_id` |
+| `approve_grant(admin, grant_id)` / `reject_grant(admin, grant_id)` | admin | Approve or reject an application |
+| `set_milestone(admin, grant_id, milestone_idx, description, amount)` | admin | Define a milestone's payout amount |
+| `release_milestone_funds(admin, grant_id, milestone_idx)` | admin | Cross-calls `token::transfer` to pay the applicant the milestone amount |
+| `submit_report(applicant, grant_id, content)` | applicant | Submit a progress report |
+| `get_grant(grant_id)` / `get_milestone(grant_id, milestone_idx)` / `get_grant_reports(grant_id)` / `get_applicant_grants(applicant)` | — | Reads |
+
+### Notes
+
+`release_milestone_funds` is one of only three verified on-chain cross-contract calls in the suite (`env.invoke_contract` to `token::transfer`) — see [ADR-006](./adr/ADR-006-contract-per-domain-architecture.md#verified-on-chain-call-graph) and [Cross-Contract Call Conventions](#cross-contract-call-conventions).
+
+---
+
+## Royalty Distribution Contract
+
+Configurable creator/contributor/platform royalty splits per course, with a pull-based withdrawal model.
+
+### Functions
+
+| Function | Auth | Description |
+|---|---|---|
+| `initialize(admin)` | admin | One-time setup |
+| `set_royalty_split(admin, course_id, creator_pct, contributor_pct, platform_pct)` | admin | Define the percentage split for a course (must sum to 100) |
+| `add_royalty_recipient(admin, course_id, recipient)` | admin | Register a recipient address for a course's contributor share |
+| `distribute_royalties(admin, course_id, total_amount)` | admin | Record a distribution event, crediting each recipient's pull-balance according to the split |
+| `withdraw_royalties(recipient)` | recipient | Pull the caller's accrued balance |
+| `get_royalty_balance(recipient)` | — | Read a recipient's withdrawable balance |
+| `get_royalty_split(course_id)` | — | Read a course's configured split |
+| `get_payment_record(payment_id)` / `get_payment_count()` / `get_total_distributed(course_id)` | — | Payment history reads |
+
+### Notes
+
+`royalty_distribution` performs no on-chain cross-contract calls; `distribute_royalties` records amounts in its own storage rather than moving tokens directly — `apps/backend` (or an admin) is responsible for funding the contract's notion of "distributed" amounts and for the actual token movement backing a withdrawal. **Build note:** this crate's `Cargo.toml` exists under `contracts/royalty_distribution/` but, unlike the other 18 contracts, is not currently listed in the root `Cargo.toml` workspace `members` — see [ADR-006](./adr/ADR-006-contract-per-domain-architecture.md#context). Build it explicitly:
+```bash
+cargo build --manifest-path contracts/royalty_distribution/Cargo.toml --target wasm32-unknown-unknown
+```
+
+---
+
+## Buyback Contract
+
+Automated BST buyback-and-burn mechanism, triggered by a configurable price threshold via an oracle and DEX pool reference.
+
+### Functions
+
+| Function | Auth | Description |
+|---|---|---|
+| `initialize(admin, token_contract, oracle_contract, dex_contract, dex_pool_id)` | admin | One-time setup; records the token, oracle, and DEX contract addresses used for buyback decisions |
+| `update_config(admin, enabled, price_threshold, max_buyback_amount, min_reserve_balance, buyback_interval)` | admin | Update any subset of buyback parameters |
+| `get_config()` | — | Read current configuration |
+| `check_and_execute_buyback()` | — | Callable by anyone (e.g. a scheduled off-chain job); executes a buyback only if configured conditions are met |
+| `manual_buyback(admin, max_xlm_amount)` | admin | Force a buyback outside the automated schedule |
+| `add_to_reserve(from, amount)` | from | Fund the reserve used for buybacks |
+| `get_reserve_balance()` / `get_buyback_analytics()` / `get_buyback_history(start_index, limit)` | — | Reads |
+
+### Notes
+
+`buyback` records `oracle_contract` and `dex_contract` addresses at `initialize` time for future price-check/swap integration, but as of this writing `check_and_execute_buyback`/`manual_buyback` do not perform a verified on-chain `invoke_contract` call to those addresses (no `invoke_contract` usage found in `contracts/buyback/src/lib.rs`) — treat the oracle/DEX wiring as configuration state rather than an active on-chain integration until confirmed otherwise by a maintainer familiar with this contract's latest state.
+
+---
+
+## Token Restrictions Contract
+
+Whitelist/blacklist, per-account transfer limits, and an emergency-override switch — a policy layer intended to sit alongside `token`, not inside it.
+
+### Functions
+
+| Function | Auth | Description |
+|---|---|---|
+| `initialize(admin)` | admin | One-time setup |
+| `add_to_whitelist(admin, account)` / `remove_from_whitelist(admin, account)` / `is_whitelisted(account)` | admin | Manage whitelist |
+| `add_to_blacklist(admin, account)` / `remove_from_blacklist(admin, account)` / `is_blacklisted(account)` | admin | Manage blacklist |
+| `set_transfer_limit(admin, account, limit)` / `get_transfer_limit(account)` | admin | Per-account transfer cap |
+| `request_transfer_approval(from, to, amount)` | from | Request approval for a transfer that would otherwise be restricted |
+| `approve_transfer(admin, from, to)` / `is_transfer_approved(from, to)` | admin | Approve/check a pending transfer request |
+| `activate_emergency_override(admin)` / `deactivate_emergency_override(admin)` / `is_emergency_override_active()` | admin | Bypass all restriction checks in an emergency |
+| `can_transfer(from, to)` | — | Composite check: not blacklisted, within limits or approved, or override active |
+| `get_restriction_log(log_id)` / `get_log_count()` | — | Audit log of restriction decisions |
+
+### Notes
+
+`token_restrictions` is a **policy contract, not the token itself** — it does not hold or move BST balances (no `invoke_contract` to `token` was found). `can_transfer` is a read-only advisory check; the caller (`apps/backend` or a future `token` integration) is responsible for consulting it before calling `token::transfer`. As of this writing, `contracts/token/src/lib.rs`'s `transfer` does not itself call `can_transfer` — the two contracts are not yet wired together on-chain.
+
+---
+
 ## Shared / RBAC Contract
 
 Role-based access control library used by other contracts for cross-contract authorization checks.
+
+---
+
+## `contracts/integration` — Not a Contract
+
+`contracts/integration` has no `src/lib.rs` and no `#[contract]` struct — it is a `[dev-dependencies]`-only crate (path-depending on `brain-storm-analytics`, `brain-storm-token`, and `brain-storm-shared`) whose sole purpose is `tests/integration.rs`: deploying those three contracts into one Soroban test `Env` and scripting an end-to-end register → progress → reward flow. It is never compiled to WASM or deployed. See [ADR-008](./adr/ADR-008-registry-integration-separation.md) for the full rationale, and `contracts/integration/README.md` for how to run it locally (`cargo test --test integration -- --test-threads=1` against a local Stellar sandbox).
+
+---
+
+## Cross-Contract Call Conventions
+
+Verified by grepping every `contracts/*/src/*.rs` for `invoke_contract` and `#[contractclient]` (the only two ways a Soroban contract calls another contract in this codebase). There are exactly **three** on-chain cross-contract call edges across all 18 production contracts — everywhere else, multi-contract flows are composed off-chain by `apps/backend` issuing separate transactions. Full rationale: [ADR-006](./adr/ADR-006-contract-per-domain-architecture.md#verified-on-chain-call-graph).
+
+### Auth conventions
+
+- Every state-mutating function takes the acting party's `Address` as an explicit parameter and calls `<address>.require_auth()` as its first statement (e.g. `admin.require_auth()`, `payer.require_auth()`, `nft_owner.require_auth()`). There is no implicit `msg.sender`-style caller identity — the caller is always passed explicitly and Soroban verifies the corresponding signature was authorized for this invocation.
+- Read-only query functions (`get_*`, `is_*`, `has_*`, `list_*`) take no auth and require no `require_auth()` call.
+- Admin-gated functions additionally compare the passed address against a stored `Admin` (or, in `registry`, `Admin`-or-curator-set) value **after** calling `require_auth()`: `require_auth()` proves the caller controls that address; the storage comparison proves that address is *allowed* to perform the action. Both checks are required — `require_auth()` alone does not enforce authorization.
+- `market`, `registry`, and `shared` each implement their own local `pause`/`unpause`/`is_paused` — there is no shared on-chain pause registry. See [ADR-007](./adr/ADR-007-shared-crate-for-common-code.md) for why this pattern is currently copied per-contract rather than centralized.
+
+### Error propagation across contract boundaries
+
+- Contracts in this codebase primarily use `assert!`/`panic!`/`.expect(...)` with a string message rather than the `#[contracterror]` enum pattern (only `contracts/shared/src/errors.rs` defines a `SharedError` enum, and it is not consumed by other contracts' error paths).
+- A panic anywhere inside a Soroban invocation — including inside a cross-contract call made via `invoke_contract` or a `#[contractclient]` stub — aborts and rolls back the **entire** transaction, including any storage writes already made earlier in the same invocation. This is what `credential_metadata::linkage::issue_and_mint_nft`'s doc comment means by "If this panics, the whole invocation rolls back — no partial state": if `nft::mint_course_nft` panics, the `credential_metadata` record it was about to link is never written either.
+- Callers cannot catch or recover from a callee's panic within the same transaction — there is no try/catch equivalent across a Soroban cross-contract call. If a flow needs "best effort, continue on failure" semantics (as opposed to "all or nothing"), it must be implemented as separate transactions orchestrated off-chain by `apps/backend`, not as a single invocation spanning multiple contracts.
+
+### Shared token-interface assumptions
+
+- `governance` and `grants` both call into `token` via **untyped** `env.invoke_contract(&token_contract, &symbol_short!("balance" | "transfer"), args)` rather than a generated typed client. This means neither contract depends on `token`'s crate at compile time, but also means neither gets compile-time verification that `token`'s `balance`/`transfer` signature hasn't changed — a `token` interface change could silently break `governance` or `grants` at runtime. When changing `token::balance` or `token::transfer`'s signature, grep `contracts/governance/src/lib.rs` and `contracts/grants/src/lib.rs` for `invoke_contract` and update the call sites manually.
+- `credential_metadata`'s call into `nft` uses a typed but **locally-declared** `#[contractclient]` stub (`contracts/credential_metadata/src/linkage.rs`'s `nft_contract_client` module) rather than importing the real `brain-storm-nft` crate — the stub's doc comment explains this is deliberate: "we declare a minimal stub here so the credential_metadata crate compiles without depending on the nft crate directly." If `nft::mint_course_nft`'s signature changes, this stub must be updated by hand to match; it will not fail to compile if it drifts, only fail at runtime.
+- No contract in this codebase assumes a SEP-0041-standard `Client` for calling `token` generically — only the exact `balance`/`transfer` function names and argument shapes `governance`/`grants` already use are relied upon.
+
+---
+
+## Worked Examples
+
+### Worked Example 1: Marketplace Purchase (`market` + `nft` + `royalty_distribution`)
+
+There is no single on-chain "buy" call spanning these three contracts — `apps/backend` sequences separate transactions:
+
+```
+Buyer clicks "Buy" on a listed course NFT
+        │
+        ▼
+Backend: POST /v1/market/purchase  (reads nft.get_listing(nft_id) for price)
+        │
+        ├─ Tx 1 — MarketContract.fund_escrow(buyer, seller, price)
+        │           (buyer signs; escrow now holds the funds)
+        │
+        ├─ Tx 2 — MarketContract.settle_escrow(caller, escrow_id)
+        │           (fee → treasury, net → seller's pending balance)
+        │
+        ├─ Tx 3 — NFTContract.buy_nft(buyer, nft_id)
+        │           (ownership transfers to buyer)
+        │
+        └─ Tx 4 — RoyaltyDistributionContract.distribute_royalties(admin, course_id, net_amount)
+                    (credits creator/contributor/platform pull-balances per the configured split)
+        │
+        ▼
+Backend records the purchase (txHashes, nft_id, buyer) in PostgreSQL
+```
+
+Because these are four separate Stellar transactions rather than one atomic Soroban invocation, `apps/backend` — not any contract — is responsible for detecting and reconciling partial failure (e.g. escrow settled but the royalty-distribution transaction fails). This is the direct consequence of the "off-chain composition by default" decision in [ADR-006](./adr/ADR-006-contract-per-domain-architecture.md).
+
+### Worked Example 2: Credential Issuance with Linked NFT (#635)
+
+This is one of the three cases where atomicity is enforced **on-chain**, inside a single Soroban invocation:
+
+```
+Admin issues a credential with NFT linkage
+        │
+        ▼
+Backend: POST /v1/credentials/issue?withNft=true
+        │
+        ▼
+CredentialMetadataContract.issue_with_nft(
+    admin, credential_id, course_name, completion_date,
+    expiry_timestamp, grade, ipfs_hash, owner, course_id,
+    instructor, royalty_basis
+)
+        │
+        ├─ 1. Stores the credential metadata record in credential_metadata's own storage
+        │
+        ├─ 2. Cross-contract call via the local `nft_contract_client::Client` stub:
+        │       NFTContract.mint_course_nft(admin, owner, course_id, course_name,
+        │                                    instructor, purchase_price=0, royalty_basis)
+        │      — if this panics, step 1's write is also rolled back (whole tx aborts)
+        │
+        ├─ 3. Stores the bidirectional CredentialNftLink (credential_id ↔ nft_id)
+        │
+        └─ 4. Emits ("linked", "cred") event with (credential_id, nft_id, owner)
+        │
+        ▼
+Backend records credential_id + nft_id in PostgreSQL (single tx hash)
+        │
+        ▼
+Student dashboard: GET /v1/credentials/:userId
+    ├── CredentialMetadataContract.get_metadata(credential_id)
+    └── CredentialMetadataContract.get_credential_link(credential_id) → NFTContract.get_nft_metadata(nft_id)
+```
+
+Unlike Worked Example 1, this whole sequence from step 1–4 is **one Soroban transaction** — see [Cross-Contract Call Conventions](#cross-contract-call-conventions) for why a panic at step 2 guarantees step 1 never persists.
 
 ---
 

--- a/docs/development-setup.md
+++ b/docs/development-setup.md
@@ -163,6 +163,69 @@ Swagger docs: http://localhost:3000/api/docs
 
 ---
 
+## 7. `packages/*` — Workspace Linking & Build Order
+
+`packages/` holds shared code and testing utilities. Not all six directories under `packages/` are the same kind of thing — verified against each directory's own `package.json` (or lack of one):
+
+| Package | npm workspace member? | What it is | Consumed by |
+|---|---|---|---|
+| `packages/types` | **Yes** (listed in root `package.json` → `workspaces`) | Shared TypeScript types (`@brain-storm/types`) | `apps/frontend`, `apps/backend` (both declare `"@brain-storm/types": "*"`), `packages/mobile-app` |
+| `packages/mobile` | **Yes** | Shared mobile utilities (secure storage, biometrics, network/device helpers) — `@brain-storm/mobile` | `packages/mobile-app` |
+| `packages/sdk` | No | Generated TypeScript client SDK (`@brain-storm/sdk`), built **from** `apps/backend`'s OpenAPI spec, not hand-written | External consumers of the API; not currently imported by `apps/frontend` or `apps/backend` themselves |
+| `packages/mobile-app` | No — **not listed** in root `workspaces`, despite depending on `@brain-storm/mobile` and `@brain-storm/types` | The Expo/React Native mobile app | End users (via Expo) |
+| `packages/api` | N/A — has no `package.json` at all | k6 load-testing scenarios/config for `apps/backend` (`packages/api/load/`) | CI / manual load testing, not linked as a library |
+| `packages/app` | N/A — has no `package.json` at all | Visual regression, accessibility (a11y), and E2E testing assets for `apps/frontend` (`packages/app/visual/`, `packages/app/e2e/`), plus a small shared `transactions.ts` lib under `packages/app/src/` | CI / manual test suites, not linked as a library |
+
+### `packages/types` and `packages/mobile` (real workspace members)
+
+Because these two are declared in the root `package.json`'s `workspaces` array, a single root-level `npm install` symlinks them into `node_modules/@brain-storm/types` and `node_modules/@brain-storm/mobile` automatically — no separate install step is needed, and no build step is required before `npm run dev:backend` / `npm run dev:frontend` for local development (`ts-node`/webpack resolve the workspace source directly). If you only need the compiled output (e.g. for a production build or to `tsc --noEmit` against it in isolation):
+
+```bash
+npm run build --workspace=packages/types
+```
+
+`packages/types` has no dependency on any other workspace package, so it has no required build-before ordering relative to `packages/mobile`. Both are leaf dependencies of `apps/frontend` / `apps/backend` (`types`) and `packages/mobile-app` (`mobile`, `types`) — build/lint the leaf packages first only if you've hit a stale-types error; otherwise the root `npm install` + dev servers handle it.
+
+### `packages/sdk` (generated, not a workspace member)
+
+`packages/sdk` is intentionally **not** wired into the npm workspace graph — it's a build *output*, regenerated from the backend's live OpenAPI spec, not a package other workspaces import at dev time. To regenerate and build it locally:
+
+```bash
+./scripts/generate-sdk.sh          # builds apps/backend, exports openapi.json, copies it into packages/sdk/
+cd packages/sdk && npm install && npm run build
+```
+
+`scripts/generate-sdk.sh` requires `apps/backend` to build and boot successfully (same DB/env requirements as `make export-openapi` — see [docs/api/README.md](./api/README.md#regenerating-the-full-openapi-spec)).
+
+### `packages/mobile-app` (Expo app — known workspace-linking gap)
+
+`packages/mobile-app/package.json` declares `"@brain-storm/mobile": "*"` and `"@brain-storm/types": "*"`, but **`packages/mobile-app` itself is absent from the root `package.json`'s `workspaces` array** (only `packages/types`, `packages/mobile`, `apps/frontend`, and `apps/backend` are listed). Since neither `@brain-storm/mobile` nor `@brain-storm/types` is published to a registry, running `npm install` from inside `packages/mobile-app` on a clean checkout will fail to resolve those two dependencies — there is no root `node_modules/@brain-storm/mobile-app` symlink and no registry fallback.
+
+Until this is fixed upstream, work around it one of two ways:
+
+- **Recommended:** run `npm install` from the **repo root** after temporarily adding `"packages/mobile-app"` to the root `workspaces` array — this lets npm's workspace resolver symlink `@brain-storm/mobile`/`@brain-storm/types` in for you, matching how `packages/types`/`packages/mobile` already work.
+- **Alternative:** from the repo root, `npm link ./packages/mobile ./packages/types` into `packages/mobile-app/node_modules` manually.
+
+Once dependencies resolve, run the app with:
+
+```bash
+cd packages/mobile-app
+npm run start   # or: npm run android / npm run ios / npm run web
+```
+
+### `packages/api` and `packages/app` (test assets, not libraries)
+
+These two do not have a `package.json` and are not consumed via `import`/`require` by any app — they're test suites that target the running apps:
+
+```bash
+# k6 load tests against apps/backend (requires the k6 CLI — see packages/api/load/README.md)
+npm run start:dev --workspace=apps/backend   # in one terminal
+k6 run packages/api/load/scenarios/search-discovery.js   # in another
+
+# Visual regression / accessibility (a11y) tests against apps/frontend
+# (see packages/app/visual/README.md and packages/app/e2e/a11y/README.md)
+```
+
 ## Makefile Shortcuts
 
 ```bash
@@ -226,3 +289,6 @@ This script checks prerequisites, copies `.env`, installs dependencies, builds c
 
 ### `cargo audit` fails in CI
 - Run `cargo update` to refresh `Cargo.lock`, then re-run.
+
+### `npm install` inside `packages/mobile-app` fails to resolve `@brain-storm/mobile` / `@brain-storm/types`
+- Expected — `packages/mobile-app` is not currently listed in the root `package.json`'s `workspaces` array, so npm has no local source for those two packages. See the "`packages/mobile-app` (Expo app — known workspace-linking gap)" section above for the workaround.

--- a/scripts/list-api-routes.py
+++ b/scripts/list-api-routes.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+"""Enumerate every REST route exposed by apps/backend's NestJS controllers.
+
+Regex-parses `*.controller.ts` files for @Controller/@Get|Post|Put|Patch|Delete/
+@UseGuards/@Public/@Roles decorators. Does not require building or running the
+backend (no database needed) — this is the CI-independent way to regenerate
+docs/api/README.md's route index. For full request/response JSON schemas, use
+`make export-openapi` instead (see docs/api/README.md).
+
+Usage:
+    python3 scripts/list-api-routes.py            # markdown table, grouped by domain
+    python3 scripts/list-api-routes.py --json      # raw structured data
+"""
+import re
+import os
+import sys
+import json
+from collections import defaultdict
+
+ROOT = os.path.join(os.path.dirname(__file__), "..", "apps", "backend", "src")
+
+CONTROLLER_RE = re.compile(r"@Controller\(\s*(\[[^\]]*\]|['\"`]([^'\"`]*)['\"`])?\s*\)")
+CLASS_RE = re.compile(r"export class (\w+)")
+GUARD_RE = re.compile(r"@UseGuards\(([^)]*)\)")
+ROUTE_RE = re.compile(r"@(Get|Post|Put|Patch|Delete)\(\s*(['\"`]([^'\"`]*)['\"`])?\s*\)")
+METHOD_NAME_RE = re.compile(r"^\s*(?:async\s+)?(\w+)\s*\(")
+API_TAGS_RE = re.compile(r"@ApiTags\(\s*['\"`]([^'\"`]*)['\"`]")
+PUBLIC_RE = re.compile(r"@Public\(\)")
+ROLES_RE = re.compile(r"@Roles\(([^)]*)\)")
+
+
+def extract(path):
+    src = open(path).read()
+    lines = src.split("\n")
+
+    cm = CONTROLLER_RE.search(src)
+    base = ""
+    if cm and cm.group(2):
+        base = cm.group(2)
+    elif cm and cm.group(1) and cm.group(1).startswith("["):
+        base = cm.group(1)
+
+    tagm = API_TAGS_RE.search(src)
+    tag = tagm.group(1) if tagm else ""
+
+    cls = CLASS_RE.search(src)
+    classname = cls.group(1) if cls else os.path.basename(path)
+
+    class_start_idx = next((i for i, l in enumerate(lines) if "export class" in l), None)
+    class_level_guard = ""
+    if class_start_idx is not None:
+        pre = "\n".join(lines[max(0, class_start_idx - 10):class_start_idx])
+        gm = GUARD_RE.search(pre)
+        if gm:
+            class_level_guard = gm.group(1)
+
+    results = []
+    pending_guard = pending_roles = pending_public = None
+    pending_public = False
+    for i, line in enumerate(lines):
+        gm = GUARD_RE.search(line)
+        if gm:
+            pending_guard = gm.group(1)
+        if PUBLIC_RE.search(line):
+            pending_public = True
+        rm = ROLES_RE.search(line)
+        if rm:
+            pending_roles = rm.group(1)
+        m = ROUTE_RE.search(line)
+        if m:
+            method = m.group(1).upper()
+            sub = m.group(3) or ""
+            name = ""
+            for j in range(i + 1, min(i + 4, len(lines))):
+                nm = METHOD_NAME_RE.match(lines[j])
+                if nm:
+                    name = nm.group(1)
+                    break
+            results.append({
+                "file": os.path.relpath(path, os.path.join(os.path.dirname(__file__), "..")),
+                "class": classname,
+                "tag": tag,
+                "base": base,
+                "sub": sub,
+                "method": method,
+                "handler": name,
+                "guard": pending_guard or class_level_guard,
+                "public": pending_public,
+                "roles": pending_roles,
+            })
+            pending_guard = pending_roles = None
+            pending_public = False
+    return results
+
+
+def full_path(base, sub):
+    parts = [p.strip("'\" ") for p in [base, sub] if p]
+    joined = "/".join(p.strip("/") for p in parts if p.strip("/"))
+    return "/" + joined if joined else "/"
+
+
+def auth_desc(r):
+    if r["public"]:
+        return "Public"
+    g = r["guard"] or ""
+    if "JwtAuthGuard" in g and "RolesGuard" in g:
+        role = f" (roles: {r['roles']})" if r["roles"] else ""
+        return f"JWT + Roles{role}"
+    if "JwtAuthGuard" in g:
+        return "JWT"
+    if g:
+        return g
+    return "—"
+
+
+def main():
+    files = []
+    for dirpath, _, filenames in os.walk(ROOT):
+        for f in filenames:
+            if f.endswith(".controller.ts"):
+                files.append(os.path.join(dirpath, f))
+    files.sort()
+
+    routes = []
+    for path in files:
+        routes.extend(extract(path))
+
+    if "--json" in sys.argv:
+        print(json.dumps(routes, indent=2))
+        return
+
+    domains = defaultdict(list)
+    for r in routes:
+        rel = os.path.relpath(r["file"], os.path.join("apps", "backend", "src"))
+        domains[rel.split(os.sep)[0]].append(r)
+
+    for domain in sorted(domains):
+        drs = domains[domain]
+        print(f"### {domain} ({len(drs)} routes)\n")
+        by_class = defaultdict(list)
+        for r in drs:
+            by_class[r["class"]].append(r)
+        for cls, rs in by_class.items():
+            print(f"**`{cls}`** — `{rs[0]['file']}`\n")
+            print("| Method | Path | Auth | Handler |")
+            print("|---|---|---|---|")
+            for r in rs:
+                print(f"| {r['method']} | `{full_path(r['base'], r['sub'])}` | {auth_desc(r)} | `{r['handler']}` |")
+            print()
+
+    print(f"<!-- {len(routes)} routes across {len(domains)} domains, {len(files)} controller files -->", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Closes #762, closes #763, closes #764, closes #765

- **#762** — Add [ADR-006](docs/adr/ADR-006-contract-per-domain-architecture.md) through [ADR-009](docs/adr/ADR-009-credential-nft-decomposition.md), documenting the contract-per-domain architecture (with a cross-contract call graph verified against `contracts/*/src`), why `contracts/shared` exists and how it's actually used, why `registry` and `integration` are unrelated crates, and why `certificate`/`credential_metadata`/`nft` stayed separate. Indexed from `docs/adr/README.md` and linked from the root `README.md`.
- **#763** — Extend `docs/development-setup.md` with a new section covering workspace linking and build order for every `packages/*` directory (`types`, `mobile`, `sdk`, `mobile-app`, `api`, `app`), including a documented workaround for `packages/mobile-app` not currently being an npm workspace member.
- **#764** — Add `docs/api/README.md`, a route reference covering all 314 active REST routes across 57 controllers, generated (not hand-transcribed) via a new `scripts/list-api-routes.py`, plus regeneration instructions for the full OpenAPI spec via the existing `make export-openapi`.
- **#765** — Fill in `docs/contract-interfaces.md` for the 9 previously undocumented contracts (`nft`, `market`, `dispute`, `registry`, `credential_metadata`, `buyback`, `royalty_distribution`, `token_restrictions`, `grants`), add a "Cross-Contract Call Conventions" section (auth pattern, error propagation/rollback semantics, the untyped-`invoke_contract` vs. local-`#[contractclient]`-stub conventions actually used), and two worked examples derived from real code paths. Linked from `contracts/shared/src/lib.rs`'s crate docs.
- Added `docs/README.md` as the top-level `docs/` entry point, and linked the new docs from the root `README.md`.

All claims about contract boundaries, cross-contract calls, and route counts were derived from static analysis of `contracts/*/src` and `apps/backend/src` (grep/regex extraction, not hand-transcription or assumption) rather than written from memory — including two real gaps found and documented honestly rather than silently fixed: `contracts/royalty_distribution` is missing from the root Cargo workspace `members`, and `packages/mobile-app` is missing from the root npm `workspaces`.

## Test plan

- [x] Verified contract function signatures for all 9 newly-documented contracts by mechanically extracting `pub fn` signatures from `contracts/*/src/lib.rs` (script-based, not manual transcription)
- [x] Verified the 3-edge cross-contract call graph by grepping every `contracts/*/src/*.rs` for `invoke_contract` and `#[contractclient]`
- [x] Verified the 314-route API count against `find apps/backend/src -iname '*.controller.ts' | wc -l` (57 controllers)
- [x] Re-ran `scripts/list-api-routes.py` after committing to confirm it reproduces the table in `docs/api/README.md`
- [x] Checked all internal Markdown anchor links resolve to actual heading slugs (GitHub slugger rules)
- [ ] Review and approval by a maintainer with contract-design context (acceptance criterion for #762)