### PR TITLE
refactor(frontend): standardize error boundary usage across route components

### DIFF
--- a/apps/frontend/src/app/[locale]/error.tsx
+++ b/apps/frontend/src/app/[locale]/error.tsx
@@ -2,9 +2,9 @@
 
 import { RouteError } from '@/components/ui/RouteError';
 
-export default function CoursesError(props: {
+export default function LocaleError(props: {
   error: Error & { digest?: string };
   reset: () => void;
 }) {
-  return <RouteError boundary="courses" {...props} />;
+  return <RouteError boundary="locale" {...props} />;
 }

--- a/apps/frontend/src/app/admin/error.tsx
+++ b/apps/frontend/src/app/admin/error.tsx
@@ -2,9 +2,9 @@
 
 import { RouteError } from '@/components/ui/RouteError';
 
-export default function CoursesError(props: {
+export default function AdminError(props: {
   error: Error & { digest?: string };
   reset: () => void;
 }) {
-  return <RouteError boundary="courses" {...props} />;
+  return <RouteError boundary="admin" {...props} />;
 }

--- a/apps/frontend/src/app/dashboard/error.tsx
+++ b/apps/frontend/src/app/dashboard/error.tsx
@@ -1,70 +1,10 @@
 'use client';
 
-import { useCallback, useEffect, useState } from 'react';
-import * as Sentry from '@sentry/nextjs';
-import { Button } from '@/components/ui/Button';
-import {
-  categorizeError,
-  getErrorDescription,
-  getErrorTitle,
-} from '@/lib/error-utils';
+import { RouteError } from '@/components/ui/RouteError';
 
-export default function DashboardError({
-  error,
-  reset,
-}: {
+export default function DashboardError(props: {
   error: Error & { digest?: string };
   reset: () => void;
 }) {
-  const [isRetrying, setIsRetrying] = useState(false);
-  const category = categorizeError(error);
-
-  useEffect(() => {
-    Sentry.captureException(error, {
-      tags: { errorBoundary: 'dashboard', category },
-    });
-  }, [error, category]);
-
-  const handleRetry = useCallback(async () => {
-    setIsRetrying(true);
-    try {
-      reset();
-    } finally {
-      setIsRetrying(false);
-    }
-  }, [reset]);
-
-  const reportIssue = useCallback(() => {
-    const subject = encodeURIComponent('Dashboard Error Report from Brain Storm App');
-    const body = encodeURIComponent(
-      `Error: ${error?.message || 'Unknown error'}\n\nStack:\n${error?.stack || 'N/A'}`
-    );
-    window.location.href = `mailto:support@brainstorm.com?subject=${subject}&body=${body}`;
-  }, [error]);
-
-  return (
-    <div className="min-h-screen flex flex-col items-center justify-center p-8 text-center">
-      <div className="text-6xl mb-6" aria-hidden="true">
-        {category === 'network' ? '🌐' : '⚠️'}
-      </div>
-      <h1 className="text-2xl font-bold mb-2">{getErrorTitle(category)}</h1>
-      <p className="text-gray-500 mb-6 max-w-md">{getErrorDescription(category)}</p>
-      {error?.message && (
-        <p className="text-xs text-gray-400 bg-gray-100 dark:bg-gray-800 rounded px-3 py-2 mb-6 max-w-md break-all font-mono">
-          {error.message}
-        </p>
-      )}
-      <div className="flex gap-3 flex-wrap justify-center">
-        <Button onClick={handleRetry} disabled={isRetrying}>
-          {isRetrying ? 'Retrying…' : 'Try Again'}
-        </Button>
-        <Button variant="outline" onClick={() => window.history.back()}>
-          Go Back
-        </Button>
-        <Button variant="outline" onClick={reportIssue}>
-          Report Issue
-        </Button>
-      </div>
-    </div>
-  );
+  return <RouteError boundary="dashboard" {...props} />;
 }

--- a/apps/frontend/src/app/error.tsx
+++ b/apps/frontend/src/app/error.tsx
@@ -1,81 +1,10 @@
 'use client';
 
-import { useCallback, useEffect, useState } from 'react';
-import * as Sentry from '@sentry/nextjs';
-import { Button } from '@/components/ui/Button';
-import {
-  categorizeError,
-  getErrorDescription,
-  getErrorTitle,
-} from '@/lib/error-utils';
+import { RouteError } from '@/components/ui/RouteError';
 
-export default function GlobalError({
-  error,
-  reset,
-}: {
+export default function GlobalError(props: {
   error: Error & { digest?: string };
   reset: () => void;
 }) {
-  const [isRetrying, setIsRetrying] = useState(false);
-  const category = categorizeError(error);
-
-  useEffect(() => {
-    Sentry.captureException(error, {
-      tags: { errorBoundary: 'global', category, digest: error.digest },
-      extra: { href: typeof window !== 'undefined' ? window.location.href : '' },
-    });
-  }, [error, category]);
-
-  const handleRetry = useCallback(async () => {
-    setIsRetrying(true);
-    try {
-      reset();
-    } finally {
-      setIsRetrying(false);
-    }
-  }, [reset]);
-
-  const handleRefresh = useCallback(() => {
-    window.location.reload();
-  }, []);
-
-  const reportIssue = useCallback(() => {
-    const subject = encodeURIComponent('Error Report from Brain Storm App');
-    const body = encodeURIComponent(
-      `Error: ${error?.message || 'Unknown error'}\n\nStack:\n${error?.stack || 'N/A'}\n\nURL: ${typeof window !== 'undefined' ? window.location.href : 'N/A'}\n\nPlease describe what you were doing:`
-    );
-    window.location.href = `mailto:support@brainstorm.com?subject=${subject}&body=${body}`;
-  }, [error]);
-
-  return (
-    <main className="min-h-screen flex flex-col items-center justify-center p-8 text-center">
-      <div className="text-6xl mb-6" aria-hidden="true">
-        {category === 'chunk-load' ? '🔄' : category === 'network' ? '🌐' : '⚠️'}
-      </div>
-      <h1 className="text-2xl font-bold mb-2">{getErrorTitle(category)}</h1>
-      <p className="text-gray-500 mb-6 max-w-md">{getErrorDescription(category)}</p>
-      {error?.message && (
-        <p className="text-xs text-gray-400 bg-gray-100 dark:bg-gray-800 rounded px-3 py-2 mb-6 max-w-md break-all font-mono">
-          {error.message}
-        </p>
-      )}
-      <div className="flex gap-3 flex-wrap justify-center">
-        {category === 'chunk-load' ? (
-          <Button onClick={handleRefresh} disabled={isRetrying}>
-            {isRetrying ? 'Refreshing…' : 'Refresh Page'}
-          </Button>
-        ) : (
-          <Button onClick={handleRetry} disabled={isRetrying}>
-            {isRetrying ? 'Retrying…' : 'Try Again'}
-          </Button>
-        )}
-        <Button variant="outline" onClick={() => (window.location.href = '/')}>
-          Go Home
-        </Button>
-        <Button variant="outline" onClick={reportIssue}>
-          Report Issue
-        </Button>
-      </div>
-    </main>
-  );
+  return <RouteError boundary="global" root {...props} />;
 }

--- a/apps/frontend/src/components/ui/RouteError.tsx
+++ b/apps/frontend/src/components/ui/RouteError.tsx
@@ -1,0 +1,97 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import * as Sentry from '@sentry/nextjs';
+import { Button } from './Button';
+import {
+  categorizeError,
+  getErrorDescription,
+  getErrorTitle,
+} from '@/lib/error-utils';
+
+export interface RouteErrorProps {
+  error: Error & { digest?: string };
+  reset: () => void;
+  /** Route segment name used for the Sentry `errorBoundary` tag and report subject. */
+  boundary: string;
+  /** The root boundary renders <main> and offers "Go Home" instead of "Go Back". */
+  root?: boolean;
+}
+
+/**
+ * Shared UI for Next.js route-level error.tsx boundaries. Every route
+ * segment's error.tsx should delegate here instead of re-implementing
+ * Sentry reporting, retry handling and the fallback layout.
+ */
+export function RouteError({ error, reset, boundary, root = false }: RouteErrorProps) {
+  const [isRetrying, setIsRetrying] = useState(false);
+  const category = categorizeError(error);
+
+  useEffect(() => {
+    Sentry.captureException(error, {
+      tags: { errorBoundary: boundary, category, digest: error.digest },
+      extra: { href: typeof window !== 'undefined' ? window.location.href : '' },
+    });
+  }, [error, category, boundary]);
+
+  const handleRetry = useCallback(async () => {
+    setIsRetrying(true);
+    try {
+      reset();
+    } finally {
+      setIsRetrying(false);
+    }
+  }, [reset]);
+
+  const handleRefresh = useCallback(() => {
+    window.location.reload();
+  }, []);
+
+  const reportIssue = useCallback(() => {
+    const subject = encodeURIComponent(`Error Report from Brain Storm App (${boundary})`);
+    const body = encodeURIComponent(
+      `Error: ${error?.message || 'Unknown error'}\n\nStack:\n${error?.stack || 'N/A'}\n\nURL: ${typeof window !== 'undefined' ? window.location.href : 'N/A'}`
+    );
+    window.location.href = `mailto:support@brainstorm.com?subject=${subject}&body=${body}`;
+  }, [error, boundary]);
+
+  const Wrapper = root ? 'main' : 'div';
+
+  return (
+    <Wrapper className="min-h-screen flex flex-col items-center justify-center p-8 text-center">
+      <div className="text-6xl mb-6" aria-hidden="true">
+        {category === 'chunk-load' ? '🔄' : category === 'network' ? '🌐' : '⚠️'}
+      </div>
+      <h1 className="text-2xl font-bold mb-2">{getErrorTitle(category)}</h1>
+      <p className="text-gray-500 mb-6 max-w-md">{getErrorDescription(category)}</p>
+      {error?.message && (
+        <p className="text-xs text-gray-400 bg-gray-100 dark:bg-gray-800 rounded px-3 py-2 mb-6 max-w-md break-all font-mono">
+          {error.message}
+        </p>
+      )}
+      <div className="flex gap-3 flex-wrap justify-center">
+        {category === 'chunk-load' ? (
+          <Button onClick={handleRefresh} disabled={isRetrying}>
+            {isRetrying ? 'Refreshing…' : 'Refresh Page'}
+          </Button>
+        ) : (
+          <Button onClick={handleRetry} disabled={isRetrying}>
+            {isRetrying ? 'Retrying…' : 'Try Again'}
+          </Button>
+        )}
+        {root ? (
+          <Button variant="outline" onClick={() => (window.location.href = '/')}>
+            Go Home
+          </Button>
+        ) : (
+          <Button variant="outline" onClick={() => window.history.back()}>
+            Go Back
+          </Button>
+        )}
+        <Button variant="outline" onClick={reportIssue}>
+          Report Issue
+        </Button>
+      </div>
+    </Wrapper>
+  );
+}


### PR DESCRIPTION
## Summary

Standardizes route-level error handling in `apps/frontend`, as requested in #776.

The three existing `error.tsx` files (`app/error.tsx`, `app/courses/error.tsx`, `app/dashboard/error.tsx`) were near-identical copy-paste: each re-implemented Sentry capture, retry state, mailto issue reporting and the fallback layout, with small inconsistencies (only the root boundary tagged `digest`/URL, only the root handled the chunk-load category). Meanwhile the `[locale]` and `admin` segments had no boundary at all.

## Changes

- Added `src/components/ui/RouteError.tsx` — a single shared client component that owns:
  - Sentry capture tagged with `errorBoundary: <segment>`, error category and digest (now consistent everywhere)
  - chunk-load / network / unknown category handling with the matching primary action (Refresh vs Try Again)
  - "Go Home" (root) vs "Go Back" secondary action, plus "Report Issue" mailto with the segment in the subject
- Rewrote the three existing `error.tsx` files as thin wrappers delegating to `RouteError`
- Added previously missing boundaries: `src/app/[locale]/error.tsx` and `src/app/admin/error.tsx`

The component-level `ErrorBoundary`/`ErrorFallback` in `src/components/ui/ErrorBoundary.tsx` is unchanged — it serves in-page boundaries, while `RouteError` now standardizes the Next.js route-segment ones.

Closes #776

🤖 Generated with [Claude Code](https://claude.com/claude-code)