### PR TITLE
refactor(frontend): extract certificate-viewer logic into a reusable hook

### DIFF
--- a/apps/frontend/src/components/courses/CertificateViewer.tsx
+++ b/apps/frontend/src/components/courses/CertificateViewer.tsx
@@ -1,21 +1,15 @@
 'use client';
 
-import { useState, useRef, type FormEvent } from 'react';
+import { useRef } from 'react';
 import { Modal } from '@/components/ui/Modal';
 import { Button } from '@/components/ui/Button';
 import { Badge } from '@/components/ui/Badge';
+import {
+  useCertificateActions,
+  type Certificate,
+} from '@/hooks/useCertificateActions';
 
-interface Certificate {
-  id: string;
-  courseId: string;
-  courseName: string;
-  studentName: string;
-  issuedAt: string;
-  expiresAt?: string;
-  txHash: string;
-  instructorName?: string;
-  description?: string;
-}
+export type { Certificate };
 
 interface CertificateViewerProps {
   certificate: Certificate;
@@ -24,96 +18,25 @@ interface CertificateViewerProps {
 }
 
 export function CertificateViewer({ certificate, isOpen, onClose }: CertificateViewerProps) {
-  const [downloading, setDownloading] = useState(false);
-  const [copyFeedback, setCopyFeedback] = useState(false);
-  const [emailOpen, setEmailOpen] = useState(false);
-  const [emailAddress, setEmailAddress] = useState('');
-  const [emailSending, setEmailSending] = useState(false);
-  const [emailFeedback, setEmailFeedback] = useState<string | null>(null);
   const certRef = useRef<HTMLDivElement>(null);
-
-  const certUrl =
-    typeof window !== 'undefined'
-      ? `${window.location.origin}/credentials/${certificate.id}`
-      : '';
-
-  const isExpired =
-    certificate.expiresAt ? new Date(certificate.expiresAt) < new Date() : false;
-
-  /* ── Download PDF ── */
-  const downloadPDF = async () => {
-    setDownloading(true);
-    try {
-      const response = await fetch(`/api/certificates/${certificate.id}/pdf`);
-      if (!response.ok) throw new Error('Download failed');
-      const blob = await response.blob();
-      const url = window.URL.createObjectURL(blob);
-      const a = document.createElement('a');
-      a.href = url;
-      a.download = `certificate-${certificate.courseName.replace(/\s+/g, '-')}.pdf`;
-      document.body.appendChild(a);
-      a.click();
-      window.URL.revokeObjectURL(url);
-      document.body.removeChild(a);
-    } catch (error) {
-      console.error('Failed to download PDF:', error);
-    } finally {
-      setDownloading(false);
-    }
-  };
-
-  /* ── Print ── */
-  const handlePrint = () => window.print();
-
-  /* ── Share: LinkedIn ── */
-  const shareLinkedIn = () => {
-    const linkedInUrl = `https://www.linkedin.com/sharing/share-offsite/?url=${encodeURIComponent(certUrl)}`;
-    window.open(linkedInUrl, '_blank', 'width=600,height=600');
-  };
-
-  /* ── Share: X / Twitter ── */
-  const shareTwitter = () => {
-    const text = `I just earned a certificate for "${certificate.courseName}"! 🎓 #BrainStorm #Blockchain`;
-    const twitterUrl = `https://twitter.com/intent/tweet?text=${encodeURIComponent(text)}&url=${encodeURIComponent(certUrl)}`;
-    window.open(twitterUrl, '_blank', 'width=600,height=600');
-  };
-
-  /* ── Share: Facebook ── */
-  const shareFacebook = () => {
-    const fbUrl = `https://www.facebook.com/sharer/sharer.php?u=${encodeURIComponent(certUrl)}`;
-    window.open(fbUrl, '_blank', 'width=600,height=600');
-  };
-
-  /* ── Copy link ── */
-  const copyLink = async () => {
-    try {
-      await navigator.clipboard.writeText(certUrl);
-      setCopyFeedback(true);
-      setTimeout(() => setCopyFeedback(false), 2000);
-    } catch {
-      console.error('Failed to copy link');
-    }
-  };
-
-  /* ── Send via email ── */
-  const sendEmail = async (e: FormEvent) => {
-    e.preventDefault();
-    if (!emailAddress.trim()) return;
-    setEmailSending(true);
-    setEmailFeedback(null);
-    try {
-      const res = await fetch(`/api/certificates/${certificate.id}/share-email`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ email: emailAddress, certUrl }),
-      });
-      setEmailFeedback(res.ok ? 'Email sent successfully!' : 'Failed to send email. Try again.');
-    } catch {
-      setEmailFeedback('Failed to send email. Try again.');
-    } finally {
-      setEmailSending(false);
-    }
-  };
+  const {
+    isExpired,
+    downloading,
+    downloadPDF,
+    handlePrint,
+    shareLinkedIn,
+    shareTwitter,
+    shareFacebook,
+    copyLink,
+    copyFeedback,
+    emailOpen,
+    toggleEmailOpen,
+    emailAddress,
+    setEmailAddress,
+    emailSending,
+    emailFeedback,
+    sendEmail,
+  } = useCertificateActions(certificate);
 
   return (
     <Modal isOpen={isOpen} onClose={onClose} title="Certificate of Completion">
@@ -273,7 +196,7 @@ export function CertificateViewer({ certificate, isOpen, onClose }: CertificateV
             {/* Email share */}
             <button
               className="text-sm text-blue-600 dark:text-blue-400 hover:underline mt-1"
-              onClick={() => setEmailOpen((o) => !o)}
+              onClick={toggleEmailOpen}
               type="button"
             >
               ✉️ Share via Email {emailOpen ? '▲' : '▼'}

--- a/apps/frontend/src/hooks/useCertificateActions.ts
+++ b/apps/frontend/src/hooks/useCertificateActions.ts
@@ -1,0 +1,134 @@
+'use client';
+
+import { useState, type FormEvent } from 'react';
+
+export interface Certificate {
+  id: string;
+  courseId: string;
+  courseName: string;
+  studentName: string;
+  issuedAt: string;
+  expiresAt?: string;
+  txHash: string;
+  instructorName?: string;
+  description?: string;
+}
+
+/**
+ * Encapsulates all certificate-viewer behaviour — PDF download, printing,
+ * social sharing, link copying and email sharing — so any component that
+ * renders a certificate can reuse it.
+ */
+export function useCertificateActions(certificate: Certificate) {
+  const [downloading, setDownloading] = useState(false);
+  const [copyFeedback, setCopyFeedback] = useState(false);
+  const [emailOpen, setEmailOpen] = useState(false);
+  const [emailAddress, setEmailAddress] = useState('');
+  const [emailSending, setEmailSending] = useState(false);
+  const [emailFeedback, setEmailFeedback] = useState<string | null>(null);
+
+  const certUrl =
+    typeof window !== 'undefined'
+      ? `${window.location.origin}/credentials/${certificate.id}`
+      : '';
+
+  const isExpired =
+    certificate.expiresAt ? new Date(certificate.expiresAt) < new Date() : false;
+
+  /* ── Download PDF ── */
+  const downloadPDF = async () => {
+    setDownloading(true);
+    try {
+      const response = await fetch(`/api/certificates/${certificate.id}/pdf`);
+      if (!response.ok) throw new Error('Download failed');
+      const blob = await response.blob();
+      const url = window.URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = `certificate-${certificate.courseName.replace(/\s+/g, '-')}.pdf`;
+      document.body.appendChild(a);
+      a.click();
+      window.URL.revokeObjectURL(url);
+      document.body.removeChild(a);
+    } catch (error) {
+      console.error('Failed to download PDF:', error);
+    } finally {
+      setDownloading(false);
+    }
+  };
+
+  /* ── Print ── */
+  const handlePrint = () => window.print();
+
+  /* ── Share: LinkedIn ── */
+  const shareLinkedIn = () => {
+    const linkedInUrl = `https://www.linkedin.com/sharing/share-offsite/?url=${encodeURIComponent(certUrl)}`;
+    window.open(linkedInUrl, '_blank', 'width=600,height=600');
+  };
+
+  /* ── Share: X / Twitter ── */
+  const shareTwitter = () => {
+    const text = `I just earned a certificate for "${certificate.courseName}"! 🎓 #BrainStorm #Blockchain`;
+    const twitterUrl = `https://twitter.com/intent/tweet?text=${encodeURIComponent(text)}&url=${encodeURIComponent(certUrl)}`;
+    window.open(twitterUrl, '_blank', 'width=600,height=600');
+  };
+
+  /* ── Share: Facebook ── */
+  const shareFacebook = () => {
+    const fbUrl = `https://www.facebook.com/sharer/sharer.php?u=${encodeURIComponent(certUrl)}`;
+    window.open(fbUrl, '_blank', 'width=600,height=600');
+  };
+
+  /* ── Copy link ── */
+  const copyLink = async () => {
+    try {
+      await navigator.clipboard.writeText(certUrl);
+      setCopyFeedback(true);
+      setTimeout(() => setCopyFeedback(false), 2000);
+    } catch {
+      console.error('Failed to copy link');
+    }
+  };
+
+  /* ── Send via email ── */
+  const sendEmail = async (e: FormEvent) => {
+    e.preventDefault();
+    if (!emailAddress.trim()) return;
+    setEmailSending(true);
+    setEmailFeedback(null);
+    try {
+      const res = await fetch(`/api/certificates/${certificate.id}/share-email`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email: emailAddress, certUrl }),
+      });
+      setEmailFeedback(res.ok ? 'Email sent successfully!' : 'Failed to send email. Try again.');
+    } catch {
+      setEmailFeedback('Failed to send email. Try again.');
+    } finally {
+      setEmailSending(false);
+    }
+  };
+
+  const toggleEmailOpen = () => setEmailOpen((o) => !o);
+
+  return {
+    certUrl,
+    isExpired,
+    downloading,
+    downloadPDF,
+    handlePrint,
+    shareLinkedIn,
+    shareTwitter,
+    shareFacebook,
+    copyLink,
+    copyFeedback,
+    emailOpen,
+    toggleEmailOpen,
+    emailAddress,
+    setEmailAddress,
+    emailSending,
+    emailFeedback,
+    sendEmail,
+  };
+}


### PR DESCRIPTION
## Summary

Extracts all non-presentational logic from `CertificateViewer` into a reusable hook, as requested in #777.

`CertificateViewer.tsx` mixed six pieces of state and seven handlers (PDF download, print, LinkedIn/X/Facebook sharing, copy-link with feedback, email sharing) with a large presentational tree, making the behaviour impossible to reuse or test in isolation.

## Changes

- Added `src/hooks/useCertificateActions.ts`:
  - Owns `certUrl` and `isExpired` derivation plus all download/print/share/copy/email state and handlers
  - Exports the `Certificate` interface so other certificate surfaces (e.g. the credentials page) can share the type and behaviour
- `CertificateViewer.tsx` is now purely presentational — it consumes the hook and renders the same markup as before (no visual or behavioural change)
- `Certificate` is re-exported from the component for backward compatibility

Closes #777

🤖 Generated with [Claude Code](https://claude.com/claude-code)