### PR TITLE
Minor modularization: split admin users controller and liquidity pool types

### DIFF
--- a/apps/backend/src/users/admin-users.controller.ts
+++ b/apps/backend/src/users/admin-users.controller.ts
@@ -1,0 +1,133 @@
+import {
+  Controller,
+  Get,
+  Param,
+  Query,
+  Patch,
+  Delete,
+  Post,
+  Body,
+  UseGuards,
+  Request,
+  NotFoundException,
+  UploadedFile,
+  UseInterceptors,
+} from '@nestjs/common';
+import { FileInterceptor } from '@nestjs/platform-express';
+import { UsersService } from './users.service';
+import { ApiBearerAuth, ApiTags, ApiOperation, ApiResponse, ApiBody, ApiConsumes } from '@nestjs/swagger';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { RolesGuard } from '../auth/roles.guard';
+import { Roles } from '../auth/roles.decorator';
+
+@ApiTags('admin')
+@ApiBearerAuth()
+@Controller('admin/users')
+@UseGuards(JwtAuthGuard, RolesGuard)
+export class AdminUsersController {
+  constructor(private readonly usersService: UsersService) {}
+
+  @Get()
+  @Roles('admin')
+  @ApiOperation({ summary: 'Get all users with filtering and pagination' })
+  @ApiResponse({
+    status: 200,
+    description: 'Returns paginated users',
+    schema: {
+      example: {
+        data: { users: [], total: 0, page: 1, limit: 10 },
+        statusCode: 200,
+        timestamp: '2024-01-01T00:00:00.000Z',
+      },
+    },
+  })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 403, description: 'Forbidden - admin role required' })
+  findAll(
+    @Query('page') page?: number,
+    @Query('limit') limit?: number,
+    @Query('role') role?: string,
+    @Query('isVerified') isVerified?: string,
+    @Query('search') search?: string
+  ) {
+    return this.usersService.findAll({
+      page: page ? Number(page) : 1,
+      limit: limit ? Number(limit) : 10,
+      role,
+      isVerified: isVerified === 'true' ? true : isVerified === 'false' ? false : undefined,
+      search,
+    });
+  }
+
+  @Post('import/csv')
+  @Roles('admin')
+  @ApiOperation({ summary: 'Bulk import users from a CSV file' })
+  @ApiConsumes('multipart/form-data')
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: {
+        file: { type: 'string', format: 'binary' },
+      },
+    },
+  })
+  @UseInterceptors(FileInterceptor('file', { limits: { fileSize: 20 * 1024 * 1024 } }))
+  importUsers(@UploadedFile() file: Express.Multer.File, @Request() req: { user: { id: string } }) {
+    if (!file) {
+      throw new NotFoundException('CSV file is required for bulk import');
+    }
+    return this.usersService.bulkImportUsersCsv(file.buffer, req.user.id);
+  }
+
+  @Get('import-jobs/:jobId')
+  @Roles('admin')
+  @ApiOperation({ summary: 'Get bulk user import job status' })
+  getUserImportJob(@Param('jobId') jobId: string) {
+    return this.usersService.findImportJob(jobId);
+  }
+
+  @Patch(':id/role')
+  @Roles('admin')
+  @ApiOperation({ summary: 'Change user role' })
+  @ApiResponse({
+    status: 200,
+    description: 'Role updated successfully',
+    schema: { example: { data: {}, statusCode: 200, timestamp: '2024-01-01T00:00:00.000Z' } },
+  })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 403, description: 'Forbidden - admin role required' })
+  @ApiResponse({ status: 404, description: 'User not found' })
+  changeRole(@Param('id') id: string, @Body('role') role: string) {
+    return this.usersService.changeRole(id, role);
+  }
+
+  @Patch(':id/ban')
+  @Roles('admin')
+  @ApiOperation({ summary: 'Ban or unban a user' })
+  @ApiResponse({
+    status: 200,
+    description: 'User ban status updated',
+    schema: { example: { data: {}, statusCode: 200, timestamp: '2024-01-01T00:00:00.000Z' } },
+  })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 403, description: 'Forbidden - admin role required' })
+  @ApiResponse({ status: 404, description: 'User not found' })
+  banUser(@Param('id') id: string, @Body('isBanned') isBanned: boolean) {
+    return this.usersService.banUser(id, isBanned);
+  }
+
+  @Delete(':id')
+  @Roles('admin')
+  @ApiOperation({ summary: 'Soft delete a user' })
+  @ApiResponse({
+    status: 200,
+    description: 'User deleted successfully',
+    schema: { example: { data: {}, statusCode: 200, timestamp: '2024-01-01T00:00:00.000Z' } },
+  })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 403, description: 'Forbidden - admin role required' })
+  @ApiResponse({ status: 404, description: 'User not found' })
+  deleteUser(@Param('id') id: string) {
+    return this.usersService.softDelete(id);
+  }
+}

--- a/apps/backend/src/users/users.controller.ts
+++ b/apps/backend/src/users/users.controller.ts
@@ -4,7 +4,6 @@ import {
   Param,
   Query,
   Patch,
-  Delete,
   Post,
   Body,
   UseGuards,
@@ -178,117 +177,5 @@ export class UsersController {
   @ApiOperation({ summary: 'Get referral count and earned BST for a user' })
   getReferrals(@Param('id') id: string) {
     return this.usersService.getReferralStats(id);
-  }
-}
-
-@ApiTags('admin')
-@ApiBearerAuth()
-@Controller('admin/users')
-@UseGuards(JwtAuthGuard, RolesGuard)
-export class AdminUsersController {
-  constructor(private readonly usersService: UsersService) {}
-
-  @Get()
-  @Roles('admin')
-  @ApiOperation({ summary: 'Get all users with filtering and pagination' })
-  @ApiResponse({
-    status: 200,
-    description: 'Returns paginated users',
-    schema: {
-      example: {
-        data: { users: [], total: 0, page: 1, limit: 10 },
-        statusCode: 200,
-        timestamp: '2024-01-01T00:00:00.000Z',
-      },
-    },
-  })
-  @ApiResponse({ status: 401, description: 'Unauthorized' })
-  @ApiResponse({ status: 403, description: 'Forbidden - admin role required' })
-  findAll(
-    @Query('page') page?: number,
-    @Query('limit') limit?: number,
-    @Query('role') role?: string,
-    @Query('isVerified') isVerified?: string,
-    @Query('search') search?: string
-  ) {
-    return this.usersService.findAll({
-      page: page ? Number(page) : 1,
-      limit: limit ? Number(limit) : 10,
-      role,
-      isVerified: isVerified === 'true' ? true : isVerified === 'false' ? false : undefined,
-      search,
-    });
-  }
-
-  @Post('import/csv')
-  @Roles('admin')
-  @ApiOperation({ summary: 'Bulk import users from a CSV file' })
-  @ApiConsumes('multipart/form-data')
-  @ApiBody({
-    schema: {
-      type: 'object',
-      properties: {
-        file: { type: 'string', format: 'binary' },
-      },
-    },
-  })
-  @UseInterceptors(FileInterceptor('file', { limits: { fileSize: 20 * 1024 * 1024 } }))
-  importUsers(@UploadedFile() file: Express.Multer.File, @Request() req: { user: { id: string } }) {
-    if (!file) {
-      throw new NotFoundException('CSV file is required for bulk import');
-    }
-    return this.usersService.bulkImportUsersCsv(file.buffer, req.user.id);
-  }
-
-  @Get('import-jobs/:jobId')
-  @Roles('admin')
-  @ApiOperation({ summary: 'Get bulk user import job status' })
-  getUserImportJob(@Param('jobId') jobId: string) {
-    return this.usersService.findImportJob(jobId);
-  }
-
-  @Patch(':id/role')
-  @Roles('admin')
-  @ApiOperation({ summary: 'Change user role' })
-  @ApiResponse({
-    status: 200,
-    description: 'Role updated successfully',
-    schema: { example: { data: {}, statusCode: 200, timestamp: '2024-01-01T00:00:00.000Z' } },
-  })
-  @ApiResponse({ status: 401, description: 'Unauthorized' })
-  @ApiResponse({ status: 403, description: 'Forbidden - admin role required' })
-  @ApiResponse({ status: 404, description: 'User not found' })
-  changeRole(@Param('id') id: string, @Body('role') role: string) {
-    return this.usersService.changeRole(id, role);
-  }
-
-  @Patch(':id/ban')
-  @Roles('admin')
-  @ApiOperation({ summary: 'Ban or unban a user' })
-  @ApiResponse({
-    status: 200,
-    description: 'User ban status updated',
-    schema: { example: { data: {}, statusCode: 200, timestamp: '2024-01-01T00:00:00.000Z' } },
-  })
-  @ApiResponse({ status: 401, description: 'Unauthorized' })
-  @ApiResponse({ status: 403, description: 'Forbidden - admin role required' })
-  @ApiResponse({ status: 404, description: 'User not found' })
-  banUser(@Param('id') id: string, @Body('isBanned') isBanned: boolean) {
-    return this.usersService.banUser(id, isBanned);
-  }
-
-  @Delete(':id')
-  @Roles('admin')
-  @ApiOperation({ summary: 'Soft delete a user' })
-  @ApiResponse({
-    status: 200,
-    description: 'User deleted successfully',
-    schema: { example: { data: {}, statusCode: 200, timestamp: '2024-01-01T00:00:00.000Z' } },
-  })
-  @ApiResponse({ status: 401, description: 'Unauthorized' })
-  @ApiResponse({ status: 403, description: 'Forbidden - admin role required' })
-  @ApiResponse({ status: 404, description: 'User not found' })
-  deleteUser(@Param('id') id: string) {
-    return this.usersService.softDelete(id);
   }
 }

--- a/apps/backend/src/users/users.module.ts
+++ b/apps/backend/src/users/users.module.ts
@@ -3,7 +3,8 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { ScheduleModule } from '@nestjs/schedule';
 import { User } from './user.entity';
 import { UsersService } from './users.service';
-import { UsersController, AdminUsersController } from './users.controller';
+import { UsersController } from './users.controller';
+import { AdminUsersController } from './admin-users.controller';
 import { StellarModule } from '../stellar/stellar.module';
 import { ImportJob } from '../import-export/import-job.entity';
 

--- a/contracts/liquidity_pool/src/lib.rs
+++ b/contracts/liquidity_pool/src/lib.rs
@@ -1,75 +1,8 @@
 #![no_std]
-use soroban_sdk::{
-    contract, contractimpl, contracttype, symbol_short, Address, Env, String, Symbol, Vec,
-};
+use soroban_sdk::{contract, contractimpl, symbol_short, Address, Env, String, Symbol, Vec};
 
-// =============================================================================
-// Storage keys
-// =============================================================================
-
-#[contracttype]
-pub enum DataKey {
-    Admin,
-    TokenA,                               // BST token contract
-    TokenB,                               // XLM (native asset)
-    ReserveA,                             // BST reserve
-    ReserveB,                             // XLM reserve
-    TotalLiquidity,                       // Total LP tokens minted
-    Liquidity(Address),                   // user → liquidity balance
-    FeeCollector,                         // Address to collect fees
-    PoolConfig,                          // PoolConfig
-    SwapHistory(u32),                    // index → SwapRecord
-    SwapHistoryCount,                    // u32
-    MiningRewards(Address),              // user → accumulated rewards
-    MiningConfig,                        // MiningConfig
-    AccumulatedFees,                     // i128 — total fees not yet collected
-    EmergencyDrained,                    // bool
-}
-
-// =============================================================================
-// Types
-// =============================================================================
-
-#[contracttype]
-#[derive(Clone)]
-pub struct PoolConfig {
-    pub fee_numerator: u32,               // Fee as fraction (e.g., 3 for 0.3%)
-    pub fee_denominator: u32,             // Fee denominator (e.g., 1000)
-    pub swap_enabled: bool,
-    pub add_liquidity_enabled: bool,
-    pub remove_liquidity_enabled: bool,
-}
-
-#[contracttype]
-#[derive(Clone)]
-pub struct SwapRecord {
-    pub timestamp: u64,
-    pub user: Address,
-    pub token_in: Symbol,                 // 'bst' or 'xlm'
-    pub amount_in: i128,
-    pub token_out: Symbol,
-    pub amount_out: i128,
-    pub fee: i128,
-}
-
-#[contracttype]
-#[derive(Clone)]
-pub struct MiningConfig {
-    pub enabled: bool,
-    pub reward_rate: i128,                // BST tokens per ledger per liquidity unit
-    pub reward_token: Address,            // BST token contract
-}
-
-#[contracttype]
-#[derive(Clone)]
-pub struct PoolStats {
-    pub reserve_a: i128,
-    pub reserve_b: i128,
-    pub total_liquidity: i128,
-    pub volume_24h: i128,
-    pub fees_24h: i128,
-    pub price_bst_xlm: i128,             // BST price in XLM (scaled)
-}
+mod types;
+use types::{DataKey, MiningConfig, PoolConfig, PoolStats, SwapRecord};
 
 // =============================================================================
 // Events

--- a/contracts/liquidity_pool/src/types.rs
+++ b/contracts/liquidity_pool/src/types.rs
@@ -1,0 +1,69 @@
+use soroban_sdk::{contracttype, Address, Symbol};
+
+// =============================================================================
+// Storage keys
+// =============================================================================
+
+#[contracttype]
+pub enum DataKey {
+    Admin,
+    TokenA,                               // BST token contract
+    TokenB,                               // XLM (native asset)
+    ReserveA,                             // BST reserve
+    ReserveB,                             // XLM reserve
+    TotalLiquidity,                       // Total LP tokens minted
+    Liquidity(Address),                   // user → liquidity balance
+    FeeCollector,                         // Address to collect fees
+    PoolConfig,                          // PoolConfig
+    SwapHistory(u32),                    // index → SwapRecord
+    SwapHistoryCount,                    // u32
+    MiningRewards(Address),              // user → accumulated rewards
+    MiningConfig,                        // MiningConfig
+    AccumulatedFees,                     // i128 — total fees not yet collected
+    EmergencyDrained,                    // bool
+}
+
+// =============================================================================
+// Types
+// =============================================================================
+
+#[contracttype]
+#[derive(Clone)]
+pub struct PoolConfig {
+    pub fee_numerator: u32,               // Fee as fraction (e.g., 3 for 0.3%)
+    pub fee_denominator: u32,             // Fee denominator (e.g., 1000)
+    pub swap_enabled: bool,
+    pub add_liquidity_enabled: bool,
+    pub remove_liquidity_enabled: bool,
+}
+
+#[contracttype]
+#[derive(Clone)]
+pub struct SwapRecord {
+    pub timestamp: u64,
+    pub user: Address,
+    pub token_in: Symbol,                 // 'bst' or 'xlm'
+    pub amount_in: i128,
+    pub token_out: Symbol,
+    pub amount_out: i128,
+    pub fee: i128,
+}
+
+#[contracttype]
+#[derive(Clone)]
+pub struct MiningConfig {
+    pub enabled: bool,
+    pub reward_rate: i128,                // BST tokens per ledger per liquidity unit
+    pub reward_token: Address,            // BST token contract
+}
+
+#[contracttype]
+#[derive(Clone)]
+pub struct PoolStats {
+    pub reserve_a: i128,
+    pub reserve_b: i128,
+    pub total_liquidity: i128,
+    pub volume_24h: i128,
+    pub fees_24h: i128,
+    pub price_bst_xlm: i128,             // BST price in XLM (scaled)
+}


### PR DESCRIPTION
## Summary

Both #796 and #797 originally described larger refactors ("modularize liquidity-pool UI" in apps/frontend, "refactor backend route handlers into controller/service layers") that didn't map to real seams in this codebase — there is no liquidity-pool UI in apps/frontend (only a Rust/Soroban contract at contracts/liquidity_pool), and apps/backend already consistently uses controller/service/module layering across all modules. This PR instead makes two small, real modularization improvements against the closest matching code in each area.

- **#797** — `apps/backend/src/users/users.controller.ts` mixed two unrelated controllers (`UsersController` for user-facing routes and `AdminUsersController` for admin-only routes) in a single file. Extracted `AdminUsersController` into its own `admin-users.controller.ts` file and updated `users.module.ts` to import it from there. No route paths, guards, or logic changed.
- **#796** — `contracts/liquidity_pool/src/lib.rs` mixed the Soroban contract implementation with its storage key enum and data structs. Extracted `DataKey`, `PoolConfig`, `SwapRecord`, `MiningConfig`, and `PoolStats` into a new `types.rs` module, with `lib.rs` now importing them via `mod types; use types::{...};`. No contract logic changed.

## Changes

- `apps/backend/src/users/admin-users.controller.ts` (new): `AdminUsersController` moved here verbatim from `users.controller.ts`.
- `apps/backend/src/users/users.controller.ts`: removed `AdminUsersController` and its now-unused imports (`Delete`, `RolesGuard` usage retained where still needed by `UsersController`).
- `apps/backend/src/users/users.module.ts`: updated import to pull `AdminUsersController` from the new file.
- `contracts/liquidity_pool/src/types.rs` (new): `DataKey`, `PoolConfig`, `SwapRecord`, `MiningConfig`, `PoolStats` moved here verbatim from `lib.rs`.
- `contracts/liquidity_pool/src/lib.rs`: removed the type definitions, added `mod types;` and a `use` import for the extracted types.

## Test plan

- [ ] Not run per request — testing skipped for this PR.

Closes #796
Closes #797

🤖 Generated with [Claude Code](https://claude.com/claude-code)