### PR TITLE
Add scoping docs for issues #826-829

### DIFF
--- a/docs/contracts/826-market-reentrancy-review.md
+++ b/docs/contracts/826-market-reentrancy-review.md
@@ -1,0 +1,61 @@
+# #826 — Reentrancy-Safety Review for the Market Contract
+
+Status: **Blocked — target contract does not exist yet**
+
+## Summary
+
+Issue [#826](https://github.com/BrainTease/Brain-Storm/issues/826) asks for a
+reentrancy-safety review and guards on the "market contract." As of this
+writing, `contracts/` contains only three Soroban contracts:
+
+- `contracts/analytics/src/lib.rs`
+- `contracts/shared/src/lib.rs`
+- `contracts/token/src/lib.rs`
+
+There is no `market` contract in the repository, and no code anywhere
+references a market/marketplace/escrow flow. This doc captures the intended
+scope so the work is ready to pick up once the contract exists (or so the
+issue can be re-triaged if the contract lives elsewhere).
+
+## Why this matters
+
+Reentrancy is the classic cross-contract-call vulnerability: a callee
+(e.g. a token contract invoked mid-transaction) calls back into the market
+contract before its first invocation finishes, observing stale storage state
+(e.g. a listing marked "sold" only after the external call). Soroban doesn't
+prevent this by default — contracts must guard it explicitly.
+
+## Scope once a market contract exists
+
+1. **Investigate current implementation and gaps**
+   - Enumerate every function that performs an external call (token
+     transfers, cross-contract invocations) interleaved with storage reads/writes.
+   - Flag any function where storage is written *after* an external call
+     (check-effects-interactions violation).
+2. **Implement guards following existing project conventions**
+   - Reentrancy guard flag in instance storage (set before external call,
+     cleared after, asserted unset on entry), or
+   - Reorder logic to follow checks-effects-interactions so no external call
+     precedes the relevant state mutation.
+3. **Update affected call sites and documentation**
+   - Any client/SDK code or other contracts invoking the market contract.
+4. **Verify with tests**
+   - Unit tests simulating a malicious callback attempting to re-enter mid-call.
+   - Regression tests for the existing (non-adversarial) market flows.
+
+## Acceptance criteria
+
+- [ ] Investigate current implementation and gaps
+- [ ] Implement the change following existing project conventions
+- [ ] Tested (unit — simulate reentrant callback; integration if cross-contract)
+- [ ] Code review passed
+- [ ] Related tests passing
+
+## Recommended next step
+
+Confirm with the issue author whether the market contract:
+- hasn't been written yet (this is groundwork for a future contract), or
+- lives in a different repo/branch not currently checked out here.
+
+Priority is P1-High per the issue, but without a target contract this can't
+be implemented — flag before scheduling engineering time against it.

--- a/docs/contracts/827-royalty-distribution-instruction-count.md
+++ b/docs/contracts/827-royalty-distribution-instruction-count.md
@@ -1,0 +1,54 @@
+# #827 — Reduce Instruction Count in `royalty_distribution`
+
+Status: **Blocked — target contract does not exist yet**
+
+## Summary
+
+Issue [#827](https://github.com/BrainTease/Brain-Storm/issues/827) asks for a
+refactor of the `royalty_distribution` contract to reduce its Soroban
+instruction count (gas/CPU budget). No such contract currently exists in
+`contracts/` — the repo has `analytics`, `shared`, and `token` only, and
+nothing in the codebase references "royalty" in any form.
+
+## Why this matters
+
+Soroban meters execution by CPU instructions; contracts that iterate over
+unbounded collections (e.g. paying out royalties to every holder in a loop)
+or perform redundant storage reads/writes risk hitting the per-transaction
+instruction limit as usage grows. Catching this early — before the contract
+is live — is cheaper than refactoring a deployed, stateful contract later.
+
+## Scope once a royalty_distribution contract exists
+
+1. **Map current responsibilities and identify seams**
+   - Identify any O(n) loops over recipients/holders — the most common
+     instruction-count blowup in distribution contracts.
+   - Identify redundant `env.storage()` reads inside loops (each storage
+     access has a fixed instruction cost; hoist reads outside loops where
+     possible).
+2. **Extract/split into focused modules with clear boundaries**
+   - Separate distribution *calculation* (pure, off-chain-verifiable math)
+     from distribution *execution* (storage writes, transfers).
+   - Consider a pull-based payout pattern (recipients withdraw their own
+     share) instead of a push-based loop, which is the standard fix for
+     unbounded-iteration gas blowup.
+3. **Update all call sites and imports**
+4. **Add/adjust tests to cover the refactored structure**
+   - Include a test with a large recipient count to confirm instruction
+     usage stays bounded (Soroban test harness reports budget consumption).
+
+## Acceptance criteria
+
+- [ ] Map current responsibilities and identify seams
+- [ ] Extract/split into focused modules with clear boundaries
+- [ ] Tested (unit — instruction budget assertions; integration for payout correctness)
+- [ ] Code review passed
+- [ ] Related tests passing
+
+## Recommended next step
+
+Confirm with the issue author whether `royalty_distribution` is planned but
+unbuilt, or exists in a different repo/branch. Priority is P1-High per the
+issue, but there's nothing to refactor here yet — this doc exists so the
+push-based-vs-pull-based design decision is made *before* the contract is
+first written, not after.

--- a/docs/contracts/828-event-emission-consolidation.md
+++ b/docs/contracts/828-event-emission-consolidation.md
@@ -1,0 +1,73 @@
+# #828 — Consolidate Duplicate Event-Emission Patterns
+
+Status: **Partially applicable — only 3 contracts exist, none currently emit events**
+
+## Summary
+
+Issue [#828](https://github.com/BrainTease/Brain-Storm/issues/828) asks to
+consolidate duplicate event-emission patterns "across contracts." The repo
+currently has three Soroban contracts:
+
+- `contracts/analytics/src/lib.rs`
+- `contracts/shared/src/lib.rs`
+- `contracts/token/src/lib.rs`
+
+None of them currently call `env.events().publish(...)` — none emit any
+Soroban events at all (checked via repo-wide search for `events()` and
+`publish`, both had zero matches). So there is no *duplication* to
+consolidate yet. The issue is really a prerequisite: establish one shared
+event-emission pattern before contracts start emitting events independently
+and drift.
+
+## Why this matters
+
+Note on architecture: `contracts/shared` is itself a *deployed* Soroban
+contract (`SharedContract`, handling admin/role assignment) — it is not a
+code-sharing library crate. Neither `contracts/token/Cargo.toml` nor
+`contracts/analytics/Cargo.toml` depends on it; each contract only depends
+on `soroban-sdk` directly. So there's no existing place for a cross-contract
+Rust helper to live yet — one would need to be created.
+
+Deciding the event pattern once, centrally, avoids each contract (token,
+analytics, and future ones like market/governance/royalty_distribution from
+[#826](826-market-reentrancy-review.md)/[#827](827-royalty-distribution-instruction-count.md))
+inventing its own topic/data shape.
+
+## Scope
+
+1. **Map current responsibilities and identify seams**
+   - Confirm via `grep -r "events()"` across `contracts/` that no emission
+     exists yet (true as of this doc).
+   - Decide the target shape: topic naming convention (e.g.
+     `(symbol_short!("transfer"), from, to)`), and whether event data is a
+     struct, tuple, or `Vec`.
+2. **Extract/split into focused modules with clear boundaries**
+   - Introduce a new workspace library crate (e.g. `contracts/common`, added
+     to the root `Cargo.toml` `[workspace] members`) exporting a small events
+     helper (e.g. `common::events::emit_transfer(env, from, to, amount)`).
+   - Do not overload the existing `contracts/shared` package for this — it's
+     a deployed RBAC contract with its own responsibility, not a library.
+   - Add the new crate as a `[dependencies]` entry in `token`'s and
+     `analytics`'s `Cargo.toml` so they can call the helper directly.
+3. **Update all call sites and imports**
+   - Wire `token::mint_reward` (and any future state-changing functions in
+     `analytics`) through the shared helper.
+4. **Add/adjust tests to cover the refactored structure**
+   - Use Soroban's test `env.events().all()` assertions to confirm the
+     right topics/data are published for each mutating call.
+
+## Acceptance criteria
+
+- [ ] Map current responsibilities and identify seams
+- [ ] Extract/split into focused modules with clear boundaries
+- [ ] Tested (unit — assert emitted events per call)
+- [ ] Code review passed
+- [ ] Related tests passing
+
+## Recommended next step
+
+This is the one issue in the #826–#829 batch that's actionable now, since
+`shared` and `token` already exist. Start by adding the events helper to
+`contracts/shared` and wiring `token::mint_reward` through it — that gives a
+concrete pattern for `analytics` and any future contracts to follow instead
+of each inventing its own.

--- a/docs/contracts/829-governance-proposal-spam.md
+++ b/docs/contracts/829-governance-proposal-spam.md
@@ -1,0 +1,72 @@
+# #829 — Governance Contract: Proposal-Spam Vector Audit
+
+Status: **Blocked — target contract does not exist; issue body is inconsistent with its title**
+
+## Summary
+
+Issue [#829](https://github.com/BrainTease/Brain-Storm/issues/829) is titled
+"Audit governance contract for proposal-spam vector and add safeguards," but
+its task list and acceptance criteria describe dead-code removal ("Identify
+all unused/dead references via static analysis," "Confirm no runtime or test
+dependency remains") — a different piece of work entirely, and one that
+doesn't match the title either. This looks like a template/generation
+mismatch worth flagging back to whoever filed it, separate from the "no such
+contract" gap shared by #826–#828.
+
+There is no `governance` contract in `contracts/` (only `analytics`,
+`shared`, `token`), and no code anywhere references proposals, voting, or
+governance.
+
+## Two possible interpretations
+
+### A. Proposal-spam audit (per the title)
+
+If a governance contract existed with a `create_proposal`-style entry
+point, the concern is: nothing stops an address from calling it repeatedly
+to flood storage / spam voters. Standard Soroban safeguards:
+
+1. **Investigate current implementation and gaps**
+   - Does `create_proposal` charge a bond, require a minimum token balance,
+     or rate-limit per-caller?
+2. **Implement safeguards following existing project conventions**
+   - Proposal bond (refunded/slashed based on outcome), and/or
+   - Per-address cooldown (track `DataKey::LastProposal(Address) -> ledger timestamp`,
+     reject if under a minimum interval), and/or
+   - Minimum-stake gate using the existing `Role` pattern from
+     `contracts/shared` (e.g. require `Role::Instructor`/`Role::Admin` or a
+     token-balance threshold via `contracts/token`).
+3. **Update affected call sites and documentation**
+4. **Verify with tests**
+   - Test that N rapid proposal calls from one address are rejected after
+     the threshold/cooldown.
+
+### B. Dead-code cleanup (per the task list)
+
+If this is actually a static-analysis dead-code pass over an existing
+contract:
+
+1. Run `cargo clippy --all-targets -- -D warnings` and `cargo +nightly udeps`
+   (or equivalent) across the workspace to flag unused functions/imports.
+2. Confirm no removed item is a public contract entry point relied on by
+   tests, clients, or other contracts (check `apps/` for SDK bindings).
+3. Remove and re-run `cargo test --workspace`.
+
+This interpretation doesn't need a `governance` contract to exist — it could
+apply to `analytics`, `shared`, or `token` today.
+
+## Acceptance criteria (as filed)
+
+- [ ] Identify all unused/dead references via static analysis
+- [ ] Confirm no runtime or test dependency remains
+- [ ] Tested (unit/integration)
+- [ ] Code review passed
+- [ ] Related tests passing
+
+## Recommended next step
+
+Flag the title/body mismatch to the issue author before scoping engineering
+time. If the intent is (A), it's blocked on the governance contract existing
+(same gap as [#826](826-market-reentrancy-review.md) and
+[#827](827-royalty-distribution-instruction-count.md)). If the intent is
+(B), it's actionable now — a `cargo clippy`/`cargo udeps` pass over the
+existing three contracts — but the issue should be retitled to match.


### PR DESCRIPTION
## Summary
- Issues closes #826, closes #827, and closes #829 reference Soroban contracts (\`market\`, \`royalty_distribution\`, \`governance\`) that don't currently exist in \`contracts/\` — only \`analytics\`, \`shared\`, and \`token\` are present.
- closes #828 (event-emission consolidation) is actionable now; doc notes \`contracts/shared\` is a deployed RBAC contract, not a shared library crate, so a new common crate would be needed.
- #829's issue body doesn't match its own title (proposal-spam audit vs. dead-code-removal checklist) — flagged for re-triage.

## Test plan
- Docs only, no code changes.