### PR TITLE
Fix contracts/shared build, extract shared access control, harden liq…

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,10 @@
 [workspace]
+# Resolver 2 keeps dev-dependency features out of non-test builds. Without it a
+# workspace-wide `cargo build --target wasm32-unknown-unknown` unifies
+# `brain-storm-integration`'s dev-dependency on `brain-storm-shared` (default
+# features, i.e. `contract`) into every other contract's copy, re-exporting
+# `SharedContract`'s entry points from each contract's wasm.
+resolver = "2"
 members = [
     "contracts/analytics",
     "contracts/integration",
@@ -18,6 +24,7 @@ members = [
     "contracts/registry",
     "contracts/market",
     "contracts/dispute",
+    "contracts/royalty_distribution",
 ]
 
 [workspace.dependencies]

--- a/contracts/analytics/Cargo.toml
+++ b/contracts/analytics/Cargo.toml
@@ -8,6 +8,7 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 soroban-sdk = { version = "21.0.0", features = ["alloc"] }
+brain-storm-shared = { path = "../shared", default-features = false }
 
 [dev-dependencies]
 soroban-sdk = { version = "21.0.0", features = ["testutils"] }

--- a/contracts/analytics/src/lib.rs
+++ b/contracts/analytics/src/lib.rs
@@ -3,6 +3,8 @@ use soroban_sdk::{
     contract, contractimpl, contracttype, symbol_short, vec, Address, Env, Symbol, Vec,
 };
 
+use brain_storm_shared::access;
+
 // TTL thresholds (in ledgers)
 const TTL_THRESHOLD: u32 = 100;
 const TTL_EXTEND_TO: u32 = 500;
@@ -98,7 +100,8 @@ impl AnalyticsContract {
     }
 
     pub fn set_admin(env: Env, new_admin: Address) {
-        let admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
+        // The *current* admin authorizes the handover.
+        let admin = access::read_authority(&env, &DataKey::Admin);
         admin.require_auth();
         env.storage().instance().set(&DataKey::Admin, &new_admin);
     }
@@ -113,9 +116,7 @@ impl AnalyticsContract {
 
     /// Grant a contract/address permission to record progress on behalf of students.
     pub fn authorize_caller(env: Env, admin: Address, caller: Address) {
-        admin.require_auth();
-        let stored_admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
-        assert!(admin == stored_admin, "Only admin can authorize callers");
+        access::require_admin(&env, &admin, &DataKey::Admin);
         env.storage()
             .instance()
             .set(&DataKey::AuthorizedCaller(caller.clone()), &true);
@@ -127,9 +128,7 @@ impl AnalyticsContract {
 
     /// Revoke a previously authorized caller.
     pub fn revoke_caller(env: Env, admin: Address, caller: Address) {
-        admin.require_auth();
-        let stored_admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
-        assert!(admin == stored_admin, "Only admin can revoke callers");
+        access::require_admin(&env, &admin, &DataKey::Admin);
         env.storage()
             .instance()
             .remove(&DataKey::AuthorizedCaller(caller.clone()));
@@ -161,7 +160,7 @@ impl AnalyticsContract {
         progress_pct: u32,
     ) {
         caller.require_auth();
-        let admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
+        let admin = access::read_authority(&env, &DataKey::Admin);
         let is_authorized: bool = env
             .storage()
             .instance()
@@ -237,9 +236,7 @@ impl AnalyticsContract {
 
     /// Reset a student's progress for a specific course (admin only).
     pub fn reset_progress(env: Env, admin: Address, student: Address, course_id: Symbol) {
-        admin.require_auth();
-        let stored_admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
-        assert!(admin == stored_admin, "Only admin can reset progress");
+        access::require_admin(&env, &admin, &DataKey::Admin);
 
         let progress_key = DataKey::Progress(student.clone(), course_id.clone());
         env.storage().persistent().remove(&progress_key);
@@ -434,9 +431,7 @@ impl AnalyticsContract {
     }
 
     pub fn update_aggregates(env: Env, admin: Address) {
-        admin.require_auth();
-        let stored_admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
-        assert!(admin == stored_admin, "Only admin can update aggregates");
+        access::require_admin(&env, &admin, &DataKey::Admin);
 
         // Update completion stats
         let stats = CompletionStats {
@@ -942,7 +937,7 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "Only admin can reset progress")]
+    #[should_panic(expected = "Unauthorized: admin required")]
     fn test_non_admin_cannot_reset_progress() {
         let (env, client, _, student) = setup();
         let rando = Address::generate(&env);

--- a/contracts/analytics/src/tests.rs
+++ b/contracts/analytics/src/tests.rs
@@ -162,7 +162,7 @@ fn test_revoked_caller_is_rejected() {
 }
 
 #[test]
-#[should_panic(expected = "Only admin can authorize")]
+#[should_panic(expected = "Unauthorized: admin required")]
 fn test_non_admin_cannot_authorize_caller() {
     let (env, _admin, client) = setup_with_admin();
     let rando = Address::generate(&env);
@@ -171,7 +171,7 @@ fn test_non_admin_cannot_authorize_caller() {
 }
 
 #[test]
-#[should_panic(expected = "Only admin can authorize callers")]
+#[should_panic(expected = "Unauthorized: admin required")]
 fn test_non_admin_cannot_revoke_caller() {
     let (env, admin, client) = setup_with_admin();
     let rando = Address::generate(&env);

--- a/contracts/badges/Cargo.toml
+++ b/contracts/badges/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 
 [dependencies]
 soroban-sdk = { version = "21.5.0", features = ["testutils"] }
+brain-storm-shared = { path = "../shared", default-features = false }
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/contracts/badges/src/lib.rs
+++ b/contracts/badges/src/lib.rs
@@ -3,6 +3,8 @@ use soroban_sdk::{
     contract, contractimpl, contracttype, symbol_short, Address, Env, String, Symbol, Vec,
 };
 
+use brain_storm_shared::access;
+
 // =============================================================================
 // Storage keys
 // =============================================================================
@@ -82,9 +84,7 @@ impl BadgesContract {
         badge_type: Symbol,
         description: String,
     ) {
-        admin.require_auth();
-        let stored_admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
-        assert!(admin == stored_admin, "Only admin can create badge types");
+        access::require_admin(&env, &admin, &DataKey::Admin);
         assert!(
             !env.storage()
                 .instance()
@@ -112,9 +112,7 @@ impl BadgesContract {
     // -------------------------------------------------------------------------
 
     pub fn mint_badge(env: Env, admin: Address, recipient: Address, badge_type: Symbol) -> u64 {
-        admin.require_auth();
-        let stored_admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
-        assert!(admin == stored_admin, "Only admin can mint");
+        access::require_admin(&env, &admin, &DataKey::Admin);
         assert!(
             env.storage()
                 .instance()
@@ -216,9 +214,7 @@ impl BadgesContract {
     // -------------------------------------------------------------------------
 
     pub fn burn_badge(env: Env, admin: Address, id: u64) {
-        admin.require_auth();
-        let stored_admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
-        assert!(admin == stored_admin, "Only admin can burn");
+        access::require_admin(&env, &admin, &DataKey::Admin);
         assert!(
             !env.storage().persistent().get::<DataKey, bool>(&DataKey::BurnedBadge(id)).unwrap_or(false),
             "Badge already burned"
@@ -303,7 +299,7 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "Only admin can create badge types")]
+    #[should_panic(expected = "Unauthorized: admin required")]
     fn test_non_admin_cannot_create_badge_type() {
         let (env, client, _) = setup();
         let rando = Address::generate(&env);
@@ -340,7 +336,7 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "Only admin can mint")]
+    #[should_panic(expected = "Unauthorized: admin required")]
     fn test_non_admin_cannot_mint() {
         let (env, client, admin) = setup();
         let rando = Address::generate(&env);

--- a/contracts/buyback/Cargo.toml
+++ b/contracts/buyback/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 
 [dependencies]
 soroban-sdk = { version = "21.5.0", features = ["testutils"] }
+brain-storm-shared = { path = "../shared", default-features = false }
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/contracts/buyback/src/lib.rs
+++ b/contracts/buyback/src/lib.rs
@@ -3,6 +3,8 @@ use soroban_sdk::{
     contract, contractimpl, contracttype, symbol_short, Address, BytesN, Env, Symbol, Vec,
 };
 
+use brain_storm_shared::access;
+
 // =============================================================================
 // Storage keys
 // =============================================================================
@@ -139,9 +141,7 @@ impl BuybackContract {
         min_reserve_balance: Option<i128>,
         buyback_interval: Option<u32>,
     ) {
-        admin.require_auth();
-        let stored_admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
-        assert!(admin == stored_admin, "Only admin can update config");
+        access::require_admin(&env, &admin, &DataKey::Admin);
 
         let mut config: BuybackConfig =
             env.storage().instance().get(&DataKey::BuybackConfig).unwrap();
@@ -229,9 +229,7 @@ impl BuybackContract {
     }
 
     pub fn manual_buyback(env: Env, admin: Address, max_xlm_amount: i128) {
-        admin.require_auth();
-        let stored_admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
-        assert!(admin == stored_admin, "Only admin can execute manual buyback");
+        access::require_admin(&env, &admin, &DataKey::Admin);
 
         let config: BuybackConfig = env
             .storage()

--- a/contracts/buyback/src/tests.rs
+++ b/contracts/buyback/src/tests.rs
@@ -52,7 +52,7 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "Only admin can update config")]
+    #[should_panic(expected = "Unauthorized: admin required")]
     fn test_non_admin_cannot_update_config() {
         let (env, client, _) = setup();
         let rando = Address::generate(&env);

--- a/contracts/certificate/Cargo.toml
+++ b/contracts/certificate/Cargo.toml
@@ -8,6 +8,7 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 soroban-sdk = { version = "21.0.0", features = ["alloc"] }
+brain-storm-shared = { path = "../shared", default-features = false }
 
 [dev-dependencies]
 soroban-sdk = { version = "21.0.0", features = ["testutils"] }

--- a/contracts/certificate/src/lib.rs
+++ b/contracts/certificate/src/lib.rs
@@ -3,6 +3,8 @@ use soroban_sdk::{
     contract, contractimpl, contracttype, symbol_short, Address, Env, String, Symbol,
 };
 
+use brain_storm_shared::access;
+
 // =============================================================================
 // Storage keys
 // =============================================================================
@@ -97,9 +99,7 @@ impl CertificateContract {
         course_id: Symbol,
         metadata_url: String,
     ) -> u64 {
-        admin.require_auth();
-        let stored_admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
-        assert!(admin == stored_admin, "Only admin can mint");
+        access::require_admin(&env, &admin, &DataKey::Admin);
 
         let id: u64 = env.storage().instance().get(&DataKey::NextId).unwrap();
         let cert = CertificateRecord {
@@ -166,9 +166,7 @@ impl CertificateContract {
     // -------------------------------------------------------------------------
 
     pub fn revoke_certificate(env: Env, admin: Address, cert_id: u64, reason: String) {
-        admin.require_auth();
-        let stored_admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
-        assert!(admin == stored_admin, "Only admin can revoke");
+        access::require_admin(&env, &admin, &DataKey::Admin);
         assert!(
             env.storage()
                 .persistent()
@@ -215,9 +213,7 @@ impl CertificateContract {
     /// Enable transferability for a specific certificate (admin only).
     /// By default certificates are soulbound; this opt-in allows transfer.
     pub fn enable_transfer(env: Env, admin: Address, cert_id: u64) {
-        admin.require_auth();
-        let stored_admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
-        assert!(admin == stored_admin, "Only admin can enable transfer");
+        access::require_admin(&env, &admin, &DataKey::Admin);
         assert!(
             env.storage().persistent().has(&DataKey::Certificate(cert_id)),
             "Certificate not found"
@@ -299,9 +295,7 @@ impl CertificateContract {
         grade: String,
         expiry_timestamp: u64,
     ) {
-        admin.require_auth();
-        let stored_admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
-        assert!(admin == stored_admin, "Only admin can set metadata");
+        access::require_admin(&env, &admin, &DataKey::Admin);
         assert!(
             env.storage().persistent().has(&DataKey::Certificate(cert_id)),
             "Certificate not found"
@@ -436,7 +430,7 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "Only admin can mint")]
+    #[should_panic(expected = "Unauthorized: admin required")]
     fn test_non_admin_cannot_mint() {
         let (env, client, _) = setup();
         let rando = Address::generate(&env);
@@ -504,7 +498,7 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "Only admin can revoke")]
+    #[should_panic(expected = "Unauthorized: admin required")]
     fn test_non_admin_cannot_revoke() {
         let (env, client, admin) = setup();
         let owner = Address::generate(&env);

--- a/contracts/credential_metadata/Cargo.toml
+++ b/contracts/credential_metadata/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 
 [dependencies]
 soroban-sdk = { version = "21.5.0", features = ["alloc"] }
+brain-storm-shared = { path = "../shared", default-features = false }
 
 [dev-dependencies]
 soroban-sdk = { version = "21.5.0", features = ["testutils"] }

--- a/contracts/credential_metadata/src/lib.rs
+++ b/contracts/credential_metadata/src/lib.rs
@@ -3,6 +3,8 @@ use soroban_sdk::{
     contract, contractimpl, contracttype, symbol_short, Address, Bytes, Env, String, Symbol,
 };
 
+use brain_storm_shared::access;
+
 pub mod linkage;
 pub use linkage::{
     set_nft_contract, get_credential_nft_link, get_nft_credential, is_linked,
@@ -90,9 +92,7 @@ impl CredentialMetadataContract {
         instructor: Address,
         royalty_basis: u32,
     ) -> u32 {
-        admin.require_auth();
-        let stored_admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
-        assert!(admin == stored_admin, "Only admin can issue credentials");
+        access::require_admin(&env, &admin, &DataKey::Admin);
 
         // Store credential metadata first
         let metadata = MetadataRecord {
@@ -144,9 +144,7 @@ impl CredentialMetadataContract {
         grade: String,
         ipfs_hash: String,
     ) {
-        admin.require_auth();
-        let stored_admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
-        assert!(admin == stored_admin, "Only admin can store metadata");
+        access::require_admin(&env, &admin, &DataKey::Admin);
 
         let metadata = MetadataRecord {
             credential_id,
@@ -172,9 +170,7 @@ impl CredentialMetadataContract {
         course_name: String,
         grade: String,
     ) {
-        admin.require_auth();
-        let stored_admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
-        assert!(admin == stored_admin, "Only admin can update metadata");
+        access::require_admin(&env, &admin, &DataKey::Admin);
 
         let mut metadata: MetadataRecord = env
             .storage()
@@ -253,9 +249,7 @@ impl CredentialMetadataContract {
         credential_id: u64,
         new_expiry_timestamp: u64,
     ) {
-        admin.require_auth();
-        let stored_admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
-        assert!(admin == stored_admin, "Only admin can renew credentials");
+        access::require_admin(&env, &admin, &DataKey::Admin);
 
         let mut metadata: MetadataRecord = env
             .storage()
@@ -289,9 +283,7 @@ impl CredentialMetadataContract {
     }
 
     pub fn store_metadata_hash(env: Env, admin: Address, credential_id: u64, hash: Bytes) {
-        admin.require_auth();
-        let stored_admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
-        assert!(admin == stored_admin, "Only admin can store hash");
+        access::require_admin(&env, &admin, &DataKey::Admin);
 
         env.storage()
             .persistent()

--- a/contracts/credential_metadata/src/tests.rs
+++ b/contracts/credential_metadata/src/tests.rs
@@ -48,7 +48,7 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "Only admin can store metadata")]
+    #[should_panic(expected = "Unauthorized: admin required")]
     fn test_non_admin_cannot_store() {
         let (env, client, _) = setup();
         let rando = Address::generate(&env);

--- a/contracts/dispute/Cargo.toml
+++ b/contracts/dispute/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 
 [dependencies]
 soroban-sdk = { version = "21.5.0", features = ["testutils"] }
+brain-storm-shared = { path = "../shared", default-features = false }
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/contracts/dispute/src/lib.rs
+++ b/contracts/dispute/src/lib.rs
@@ -6,6 +6,8 @@ use soroban_sdk::{
     contract, contractimpl, contracttype, symbol_short, Address, BytesN, Env, Symbol,
 };
 
+use brain_storm_shared::access;
+
 // ── Storage keys ──────────────────────────────────────────────────────────────
 
 #[contracttype]
@@ -75,9 +77,7 @@ impl DisputeContract {
 
     /// Admin can update the arbiter.
     pub fn set_arbiter(env: Env, admin: Address, arbiter: Address) {
-        admin.require_auth();
-        let stored: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
-        assert!(admin == stored, "Only admin");
+        access::require_admin(&env, &admin, &DataKey::Admin);
         env.storage().instance().set(&DataKey::Arbiter, &arbiter);
     }
 
@@ -136,9 +136,7 @@ impl DisputeContract {
 
     /// Arbiter records their decision (moves to Decision phase).
     pub fn record_decision(env: Env, arbiter: Address, dispute_id: u64, outcome: Outcome) {
-        arbiter.require_auth();
-        let stored_arbiter: Address = env.storage().instance().get(&DataKey::Arbiter).unwrap();
-        assert!(arbiter == stored_arbiter, "Only arbiter");
+        access::require_authority(&env, &arbiter, &DataKey::Arbiter);
 
         let mut dispute: Dispute = env
             .storage()
@@ -162,9 +160,7 @@ impl DisputeContract {
     /// Enforce settlement: compute payouts based on outcome, mark as Settled.
     /// Returns (claimant_amount, respondent_amount).
     pub fn settle(env: Env, arbiter: Address, dispute_id: u64) -> (i128, i128) {
-        arbiter.require_auth();
-        let stored_arbiter: Address = env.storage().instance().get(&DataKey::Arbiter).unwrap();
-        assert!(arbiter == stored_arbiter, "Only arbiter");
+        access::require_authority(&env, &arbiter, &DataKey::Arbiter);
 
         let mut dispute: Dispute = env
             .storage()
@@ -269,7 +265,7 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "Only arbiter")]
+    #[should_panic(expected = "Unauthorized: authority required")]
     fn test_non_arbiter_cannot_decide() {
         let (env, client, _, _) = setup();
         let claimant = Address::generate(&env);

--- a/contracts/governance/Cargo.toml
+++ b/contracts/governance/Cargo.toml
@@ -8,6 +8,7 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 soroban-sdk = { version = "21.0.0", features = ["alloc"] }
+brain-storm-shared = { path = "../shared", default-features = false }
 
 [dev-dependencies]
 soroban-sdk = { version = "21.0.0", features = ["testutils"] }

--- a/contracts/governance/src/lib.rs
+++ b/contracts/governance/src/lib.rs
@@ -3,6 +3,8 @@ use soroban_sdk::{
     contract, contractimpl, contracttype, symbol_short, Address, Env, IntoVal, String, Symbol,
 };
 
+use brain_storm_shared::access;
+
 pub mod voting;
 
 use voting::{
@@ -126,27 +128,21 @@ impl GovernanceContract {
     // -------------------------------------------------------------------------
 
     pub fn set_voting_delay(env: Env, admin: Address, delay: u32) {
-        admin.require_auth();
-        let stored: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
-        assert!(admin == stored, "Only admin");
+        access::require_admin(&env, &admin, &DataKey::Admin);
         env.storage()
             .instance()
             .set(&GovernanceKey::VotingDelay, &delay);
     }
 
     pub fn set_timelock_duration(env: Env, admin: Address, duration: u32) {
-        admin.require_auth();
-        let stored: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
-        assert!(admin == stored, "Only admin");
+        access::require_admin(&env, &admin, &DataKey::Admin);
         env.storage()
             .instance()
             .set(&GovernanceKey::TimelockDuration, &duration);
     }
 
     pub fn set_quorum_percentage(env: Env, admin: Address, percentage: i128) {
-        admin.require_auth();
-        let stored: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
-        assert!(admin == stored, "Only admin");
+        access::require_admin(&env, &admin, &DataKey::Admin);
         assert!(percentage > 0 && percentage <= 100, "Quorum must be 1-100");
         env.storage()
             .instance()
@@ -154,9 +150,7 @@ impl GovernanceContract {
     }
 
     pub fn set_total_supply_snapshot(env: Env, admin: Address, supply: i128) {
-        admin.require_auth();
-        let stored: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
-        assert!(admin == stored, "Only admin");
+        access::require_admin(&env, &admin, &DataKey::Admin);
         env.storage()
             .instance()
             .set(&GovernanceKey::TotalSupply, &supply);

--- a/contracts/grants/Cargo.toml
+++ b/contracts/grants/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 
 [dependencies]
 soroban-sdk = "21.7"
+brain-storm-shared = { path = "../shared", default-features = false }
 
 [dev-dependencies]
 soroban-sdk = { version = "21.7", features = ["testutils"] }

--- a/contracts/grants/src/lib.rs
+++ b/contracts/grants/src/lib.rs
@@ -4,6 +4,8 @@ use soroban_sdk::{
     Symbol, Vec,
 };
 
+use brain_storm_shared::access;
+
 const TTL_THRESHOLD: u32 = 100;
 const TTL_EXTEND_TO: u32 = 500;
 
@@ -154,9 +156,7 @@ impl GrantsContract {
     // -------------------------------------------------------------------------
 
     pub fn approve_grant(env: Env, admin: Address, grant_id: u64) {
-        admin.require_auth();
-        let stored_admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
-        assert!(admin == stored_admin, "Only admin can approve grants");
+        access::require_admin(&env, &admin, &DataKey::Admin);
 
         let mut grant: GrantRecord = env
             .storage()
@@ -182,9 +182,7 @@ impl GrantsContract {
     }
 
     pub fn reject_grant(env: Env, admin: Address, grant_id: u64) {
-        admin.require_auth();
-        let stored_admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
-        assert!(admin == stored_admin, "Only admin can reject grants");
+        access::require_admin(&env, &admin, &DataKey::Admin);
 
         let mut grant: GrantRecord = env
             .storage()
@@ -217,9 +215,7 @@ impl GrantsContract {
         description: String,
         amount: i128,
     ) {
-        admin.require_auth();
-        let stored_admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
-        assert!(admin == stored_admin, "Only admin can set milestones");
+        access::require_admin(&env, &admin, &DataKey::Admin);
 
         let grant: GrantRecord = env
             .storage()
@@ -252,9 +248,7 @@ impl GrantsContract {
     }
 
     pub fn release_milestone_funds(env: Env, admin: Address, grant_id: u64, milestone_idx: u32) {
-        admin.require_auth();
-        let stored_admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
-        assert!(admin == stored_admin, "Only admin can release funds");
+        access::require_admin(&env, &admin, &DataKey::Admin);
 
         let grant: GrantRecord = env
             .storage()

--- a/contracts/liquidity_pool/Cargo.toml
+++ b/contracts/liquidity_pool/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 
 [dependencies]
 soroban-sdk = { version = "21.5.0", features = ["testutils"] }
+brain-storm-shared = { path = "../shared", default-features = false }
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/contracts/liquidity_pool/src/lib.rs
+++ b/contracts/liquidity_pool/src/lib.rs
@@ -1,6 +1,12 @@
 #![no_std]
 use soroban_sdk::{contract, contractimpl, symbol_short, Address, Env, String, Symbol, Vec};
 
+use brain_storm_shared::access;
+use brain_storm_shared::math::{
+    checked_add_i128, checked_add_u32, checked_div_i128, checked_mul_div_i128, checked_mul_i128,
+    checked_sub_i128, checked_sub_u32,
+};
+
 mod types;
 use types::{DataKey, MiningConfig, PoolConfig, PoolStats, SwapRecord};
 
@@ -94,6 +100,14 @@ impl LiquidityPoolContract {
 
         let config: PoolConfig = env.storage().instance().get(&DataKey::PoolConfig).unwrap();
         assert!(config.add_liquidity_enabled, "Adding liquidity is disabled");
+        assert!(
+            amount_a_desired > 0 && amount_b_desired > 0,
+            "Desired amounts must be positive"
+        );
+        assert!(
+            amount_a_min >= 0 && amount_b_min >= 0,
+            "Minimum amounts must be non-negative"
+        );
 
         let reserve_a: i128 = env.storage().instance().get(&DataKey::ReserveA).unwrap_or(0);
         let reserve_b: i128 = env.storage().instance().get(&DataKey::ReserveB).unwrap_or(0);
@@ -124,29 +138,39 @@ impl LiquidityPoolContract {
         // Mint liquidity tokens
         let liquidity_minted = if total_liquidity == 0 {
             // First liquidity provision
-            let initial_liquidity = Self::sqrt(amount_a * amount_b).checked_sub(MINIMUM_LIQUIDITY).unwrap_or(0);
+            let root = Self::sqrt(checked_mul_i128(amount_a, amount_b));
+            assert!(
+                root > MINIMUM_LIQUIDITY,
+                "Initial liquidity below minimum"
+            );
             // Mint MINIMUM_LIQUIDITY to the pool itself to avoid division by zero
             env.storage().instance().set(&DataKey::Liquidity(env.current_contract_address()), &MINIMUM_LIQUIDITY);
-            initial_liquidity
+            checked_sub_i128(root, MINIMUM_LIQUIDITY)
         } else {
-            let liquidity_minted_a = (amount_a * total_liquidity) / reserve_a;
-            let liquidity_minted_b = (amount_b * total_liquidity) / reserve_b;
+            // `total_liquidity > 0` implies both reserves were funded, but the
+            // divisors are load-bearing so they are checked rather than assumed.
+            assert!(reserve_a > 0 && reserve_b > 0, "Insufficient reserves");
+            let liquidity_minted_a = checked_mul_div_i128(amount_a, total_liquidity, reserve_a);
+            let liquidity_minted_b = checked_mul_div_i128(amount_b, total_liquidity, reserve_b);
             liquidity_minted_a.min(liquidity_minted_b)
         };
 
         assert!(liquidity_minted > 0, "Insufficient liquidity minted");
 
         // Update reserves
-        env.storage().instance().set(&DataKey::ReserveA, &(reserve_a + amount_a));
-        env.storage().instance().set(&DataKey::ReserveB, &(reserve_b + amount_b));
+        env.storage().instance().set(&DataKey::ReserveA, &checked_add_i128(reserve_a, amount_a));
+        env.storage().instance().set(&DataKey::ReserveB, &checked_add_i128(reserve_b, amount_b));
 
         // Update total liquidity
-        let new_total_liquidity = total_liquidity + liquidity_minted;
+        let new_total_liquidity = checked_add_i128(total_liquidity, liquidity_minted);
         env.storage().instance().set(&DataKey::TotalLiquidity, &new_total_liquidity);
 
         // Update user liquidity
         let user_liquidity: i128 = env.storage().persistent().get(&DataKey::Liquidity(provider.clone())).unwrap_or(0);
-        env.storage().persistent().set(&DataKey::Liquidity(provider.clone()), &(user_liquidity + liquidity_minted));
+        env.storage().persistent().set(
+            &DataKey::Liquidity(provider.clone()),
+            &checked_add_i128(user_liquidity, liquidity_minted),
+        );
 
         env.events()
             .publish((ADD_LIQUIDITY, symbol_short!("provider")), (provider, amount_a, amount_b, liquidity_minted));
@@ -163,6 +187,7 @@ impl LiquidityPoolContract {
 
         let config: PoolConfig = env.storage().instance().get(&DataKey::PoolConfig).unwrap();
         assert!(config.remove_liquidity_enabled, "Removing liquidity is disabled");
+        assert!(liquidity > 0, "Liquidity must be positive");
 
         let user_liquidity: i128 = env.storage().persistent().get(&DataKey::Liquidity(provider.clone())).unwrap_or(0);
         assert!(user_liquidity >= liquidity, "Insufficient liquidity");
@@ -171,21 +196,28 @@ impl LiquidityPoolContract {
         let reserve_b: i128 = env.storage().instance().get(&DataKey::ReserveB).unwrap_or(0);
         let total_liquidity: i128 = env.storage().instance().get(&DataKey::TotalLiquidity).unwrap_or(0);
 
-        let amount_a = (liquidity * reserve_a) / total_liquidity;
-        let amount_b = (liquidity * reserve_b) / total_liquidity;
+        // Without this guard the two divisions below are a division by zero,
+        // reachable whenever the total-liquidity slot is empty or drained.
+        assert!(total_liquidity > 0, "Pool has no liquidity");
+
+        let amount_a = checked_mul_div_i128(liquidity, reserve_a, total_liquidity);
+        let amount_b = checked_mul_div_i128(liquidity, reserve_b, total_liquidity);
 
         assert!(amount_a > 0 && amount_b > 0, "Insufficient amounts");
 
         // Update user liquidity
-        env.storage().persistent().set(&DataKey::Liquidity(provider.clone()), &(user_liquidity - liquidity));
+        env.storage().persistent().set(
+            &DataKey::Liquidity(provider.clone()),
+            &checked_sub_i128(user_liquidity, liquidity),
+        );
 
         // Update total liquidity
-        let new_total_liquidity = total_liquidity - liquidity;
+        let new_total_liquidity = checked_sub_i128(total_liquidity, liquidity);
         env.storage().instance().set(&DataKey::TotalLiquidity, &new_total_liquidity);
 
         // Update reserves
-        env.storage().instance().set(&DataKey::ReserveA, &(reserve_a - amount_a));
-        env.storage().instance().set(&DataKey::ReserveB, &(reserve_b - amount_b));
+        env.storage().instance().set(&DataKey::ReserveA, &checked_sub_i128(reserve_a, amount_a));
+        env.storage().instance().set(&DataKey::ReserveB, &checked_sub_i128(reserve_b, amount_b));
 
         // Transfer tokens back to user (this would require implementing token transfer logic)
 
@@ -211,6 +243,12 @@ impl LiquidityPoolContract {
         let config: PoolConfig = env.storage().instance().get(&DataKey::PoolConfig).unwrap();
         assert!(config.swap_enabled, "Swapping is disabled");
         assert!(amount_in > 0, "Amount in must be positive");
+        assert!(amount_out_min >= 0, "Minimum output must be non-negative");
+        assert!(config.fee_denominator > 0, "Invalid fee denominator");
+        assert!(
+            config.fee_numerator <= config.fee_denominator,
+            "Fee exceeds 100%"
+        );
         assert!(
             !env.storage().instance().get::<DataKey, bool>(&DataKey::EmergencyDrained).unwrap_or(false),
             "Pool has been emergency drained"
@@ -230,31 +268,49 @@ impl LiquidityPoolContract {
             panic!("Invalid token")
         };
 
+        // An unfunded side makes `denominator` zero when `amount_in_with_fee`
+        // is also zero, and lets the pool be swapped against for nothing.
+        assert!(
+            reserve_in > 0 && reserve_out > 0,
+            "Insufficient liquidity"
+        );
+
         // Calculate output amount with fee
-        let amount_in_with_fee = amount_in * (config.fee_denominator - config.fee_numerator) as i128;
-        let numerator = amount_in_with_fee * reserve_out;
-        let denominator = (reserve_in * config.fee_denominator as i128) + amount_in_with_fee;
-        let amount_out = numerator / denominator;
+        let fee_complement = checked_sub_u32(config.fee_denominator, config.fee_numerator) as i128;
+        let amount_in_with_fee = checked_mul_i128(amount_in, fee_complement);
+        let numerator = checked_mul_i128(amount_in_with_fee, reserve_out);
+        let denominator = checked_add_i128(
+            checked_mul_i128(reserve_in, config.fee_denominator as i128),
+            amount_in_with_fee,
+        );
+        let amount_out = checked_div_i128(numerator, denominator);
 
         assert!(amount_out >= amount_out_min, "Insufficient output amount");
         assert!(amount_out <= reserve_out, "Insufficient liquidity");
 
         // Update reserves
         if token_in == bst {
-            env.storage().instance().set(&DataKey::ReserveA, &(reserve_a + amount_in));
-            env.storage().instance().set(&DataKey::ReserveB, &(reserve_b - amount_out));
+            env.storage().instance().set(&DataKey::ReserveA, &checked_add_i128(reserve_a, amount_in));
+            env.storage().instance().set(&DataKey::ReserveB, &checked_sub_i128(reserve_b, amount_out));
         } else {
-            env.storage().instance().set(&DataKey::ReserveB, &(reserve_b + amount_in));
-            env.storage().instance().set(&DataKey::ReserveA, &(reserve_a - amount_out));
+            env.storage().instance().set(&DataKey::ReserveB, &checked_add_i128(reserve_b, amount_in));
+            env.storage().instance().set(&DataKey::ReserveA, &checked_sub_i128(reserve_a, amount_out));
         }
 
         // Calculate fee
-        let fee = (amount_in * config.fee_numerator as i128) / config.fee_denominator as i128;
+        let fee = checked_mul_div_i128(
+            amount_in,
+            config.fee_numerator as i128,
+            config.fee_denominator as i128,
+        );
 
-        // Accumulate fees for collection
-        let mut accumulated: i128 = env.storage().instance().get(&DataKey::AccumulatedFees).unwrap_or(0);
-        accumulated = accumulated.saturating_add(fee);
-        env.storage().instance().set(&DataKey::AccumulatedFees, &accumulated);
+        // Accumulate fees for collection. This used to saturate, which would
+        // silently under-report fees owed to the collector once the counter
+        // reached i128::MAX; overflow is now surfaced instead.
+        let accumulated: i128 = env.storage().instance().get(&DataKey::AccumulatedFees).unwrap_or(0);
+        env.storage()
+            .instance()
+            .set(&DataKey::AccumulatedFees, &checked_add_i128(accumulated, fee));
 
         // Record swap history
         let history_count: u32 = env.storage().instance().get(&DataKey::SwapHistoryCount).unwrap_or(0);
@@ -269,7 +325,9 @@ impl LiquidityPoolContract {
             fee,
         };
         env.storage().instance().set(&DataKey::SwapHistory(history_count), &record);
-        env.storage().instance().set(&DataKey::SwapHistoryCount, &(history_count + 1));
+        env.storage()
+            .instance()
+            .set(&DataKey::SwapHistoryCount, &checked_add_u32(history_count, 1));
 
         // Transfer tokens (this would require implementing token transfer logic)
 
@@ -295,7 +353,7 @@ impl LiquidityPoolContract {
         }
 
         // Calculate rewards (simplified - would need more complex logic for time-based rewards)
-        let rewards = (user_liquidity * mining_config.reward_rate) / 1_000_000; // Scale down
+        let rewards = checked_mul_div_i128(user_liquidity, mining_config.reward_rate, 1_000_000); // Scale down
 
         // Reset accumulated rewards
         env.storage().persistent().set(&DataKey::MiningRewards(user.clone()), &0_i128);
@@ -319,7 +377,7 @@ impl LiquidityPoolContract {
 
         // Calculate BST price in XLM (reserve_b / reserve_a, scaled)
         let price_bst_xlm = if reserve_a > 0 {
-            (reserve_b * 1_000_000) / reserve_a
+            checked_mul_div_i128(reserve_b, 1_000_000, reserve_a)
         } else {
             0
         };
@@ -341,7 +399,9 @@ impl LiquidityPoolContract {
     pub fn get_swap_history(env: Env, start_index: u32, limit: u32) -> Vec<SwapRecord> {
         let history_count: u32 = env.storage().instance().get(&DataKey::SwapHistoryCount).unwrap_or(0);
         let mut history = Vec::new(&env);
-        let end_index = (start_index + limit).min(history_count);
+        // Read-only pagination: saturate rather than panic on a caller-supplied
+        // range that would overflow u32.
+        let end_index = start_index.saturating_add(limit).min(history_count);
 
         for i in start_index..end_index {
             if let Some(record) = env.storage().instance().get(&DataKey::SwapHistory(i)) {
@@ -357,9 +417,7 @@ impl LiquidityPoolContract {
     // -------------------------------------------------------------------------
 
     pub fn collect_fees(env: Env, admin: Address) -> i128 {
-        admin.require_auth();
-        let stored_admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
-        assert!(admin == stored_admin, "Only admin can collect fees");
+        access::require_admin(&env, &admin, &DataKey::Admin);
 
         let fees: i128 = env.storage().instance().get(&DataKey::AccumulatedFees).unwrap_or(0);
         assert!(fees > 0, "No fees to collect");
@@ -384,9 +442,7 @@ impl LiquidityPoolContract {
     // -------------------------------------------------------------------------
 
     pub fn emergency_drain(env: Env, admin: Address) -> (i128, i128) {
-        admin.require_auth();
-        let stored_admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
-        assert!(admin == stored_admin, "Only admin can emergency drain");
+        access::require_admin(&env, &admin, &DataKey::Admin);
         assert!(
             !env.storage().instance().get::<DataKey, bool>(&DataKey::EmergencyDrained).unwrap_or(false),
             "Already drained"
@@ -420,17 +476,24 @@ impl LiquidityPoolContract {
 
     fn quote(amount_a: i128, reserve_a: i128, reserve_b: i128) -> i128 {
         assert!(reserve_a > 0 && reserve_b > 0, "Insufficient reserves");
-        (amount_a * reserve_b) / reserve_a
+        checked_mul_div_i128(amount_a, reserve_b, reserve_a)
     }
 
+    /// Integer square root by Newton's method.
+    ///
+    /// Rejects negative input (which would loop or return nonsense) and uses a
+    /// checked `x + 1` so `i128::MAX` panics instead of wrapping negative.
     fn sqrt(x: i128) -> i128 {
-        if x == 0 || x == 1 {
+        assert!(x >= 0, "sqrt: negative input");
+        if x < 2 {
             return x;
         }
-        let mut z = (x + 1) / 2;
+        let mut z = checked_add_i128(x, 1) / 2;
         let mut y = x;
         while z < y {
             y = z;
+            // `x / z + z` peaks on the first iteration at roughly `2 + x/2`,
+            // which is below `x` for every `x >= 5`, so this cannot overflow.
             z = (x / z + z) / 2;
         }
         y

--- a/contracts/liquidity_pool/src/tests.rs
+++ b/contracts/liquidity_pool/src/tests.rs
@@ -134,10 +134,98 @@ mod tests {
 
     // Security: zero-liquidity pool cannot be swapped against
     #[test]
-    #[should_panic]
+    #[should_panic(expected = "Insufficient liquidity")]
     fn test_swap_against_empty_pool_panics() {
         let (env, client, _) = setup();
         let user = Address::generate(&env);
         client.swap(&user, &symbol_short!("bst"), &1_000, &0);
+    }
+
+    // ── Arithmetic safety (#823) ──────────────────────────────────────────────
+
+    #[test]
+    #[should_panic(expected = "Desired amounts must be positive")]
+    fn test_add_liquidity_rejects_zero_amount() {
+        let (env, client, _) = setup();
+        let provider = Address::generate(&env);
+        client.add_liquidity(&provider, &0, &10_000, &0, &0);
+    }
+
+    #[test]
+    #[should_panic(expected = "Desired amounts must be positive")]
+    fn test_add_liquidity_rejects_negative_amount() {
+        let (env, client, _) = setup();
+        let provider = Address::generate(&env);
+        client.add_liquidity(&provider, &10_000, &-1, &0, &0);
+    }
+
+    #[test]
+    #[should_panic(expected = "Initial liquidity below minimum")]
+    fn test_first_provision_below_minimum_liquidity_panics() {
+        let (env, client, _) = setup();
+        let provider = Address::generate(&env);
+        // sqrt(10 * 10) == 10, which is under MINIMUM_LIQUIDITY (1000).
+        client.add_liquidity(&provider, &10, &10, &0, &0);
+    }
+
+    #[test]
+    #[should_panic(expected = "math: i128 multiplication overflow")]
+    fn test_add_liquidity_overflow_is_reported_not_wrapped() {
+        let (env, client, _) = setup();
+        let provider = Address::generate(&env);
+        // amount_a * amount_b overflows i128 before sqrt() ever sees it.
+        client.add_liquidity(&provider, &i128::MAX, &i128::MAX, &0, &0);
+    }
+
+    #[test]
+    #[should_panic(expected = "Liquidity must be positive")]
+    fn test_remove_zero_liquidity_panics() {
+        let (env, client, _) = setup();
+        let provider = Address::generate(&env);
+        client.add_liquidity(&provider, &10_000, &10_000, &0, &0);
+        client.remove_liquidity(&provider, &0);
+    }
+
+    #[test]
+    #[should_panic(expected = "math: i128 multiplication overflow")]
+    fn test_swap_overflow_is_reported_not_wrapped() {
+        let (env, client, _) = setup();
+        let provider = Address::generate(&env);
+        client.add_liquidity(&provider, &100_000, &100_000, &0, &0);
+
+        let user = Address::generate(&env);
+        // amount_in * (fee_denominator - fee_numerator) overflows i128.
+        client.swap(&user, &symbol_short!("bst"), &i128::MAX, &0);
+    }
+
+    #[test]
+    fn test_remove_liquidity_is_proportional() {
+        let (env, client, _) = setup();
+        let provider = Address::generate(&env);
+        // sqrt(10_000 * 10_000) - MINIMUM_LIQUIDITY == 10_000 - 1_000 == 9_000
+        let minted = client.add_liquidity(&provider, &10_000, &10_000, &0, &0);
+        assert_eq!(minted, 9_000);
+
+        let (amount_a, amount_b) = client.remove_liquidity(&provider, &4_500);
+        // 4_500 * 10_000 / 9_000 == 5_000
+        assert_eq!(amount_a, 5_000);
+        assert_eq!(amount_b, 5_000);
+
+        let stats = client.get_pool_stats();
+        assert_eq!(stats.reserve_a, 5_000);
+        assert_eq!(stats.total_liquidity, 4_500);
+    }
+
+    #[test]
+    fn test_swap_history_pagination_does_not_overflow() {
+        let (env, client, _) = setup();
+        let provider = Address::generate(&env);
+        client.add_liquidity(&provider, &100_000, &100_000, &0, &0);
+        let user = Address::generate(&env);
+        client.swap(&user, &symbol_short!("bst"), &1_000, &0);
+
+        // start_index + limit would wrap u32; the view saturates instead.
+        let history = client.get_swap_history(&u32::MAX, &10);
+        assert_eq!(history.len(), 0);
     }
 }

--- a/contracts/market/Cargo.toml
+++ b/contracts/market/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 
 [dependencies]
 soroban-sdk = { version = "21.5.0", features = ["testutils"] }
+brain-storm-shared = { path = "../shared", default-features = false }
 
 [dev-dependencies]
 proptest = "1.4"

--- a/contracts/market/src/fees.rs
+++ b/contracts/market/src/fees.rs
@@ -2,6 +2,8 @@
 
 use soroban_sdk::{symbol_short, Address, Env, Symbol};
 
+use brain_storm_shared::access;
+
 use crate::DataKey;
 
 pub const MAX_FEE_BPS: u32 = 1_000; // 10 %
@@ -10,9 +12,7 @@ const EVT_FEE_DIST: Symbol = symbol_short!("fee_dist");
 
 /// Configure the protocol fee in basis points (admin-only).
 pub fn set_fee_bps(env: &Env, admin: &Address, fee_bps: u32) {
-    admin.require_auth();
-    let stored: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
-    assert!(*admin == stored, "Only admin");
+    access::require_admin(env, admin, &DataKey::Admin);
     assert!(fee_bps <= MAX_FEE_BPS, "Fee exceeds max (1000 bps)");
     env.storage().instance().set(&DataKey::FeeBps, &fee_bps);
     env.events().publish((EVT_FEE_SET,), fee_bps);
@@ -27,9 +27,7 @@ pub fn get_fee_bps(env: &Env) -> u32 {
 
 /// Configure the treasury address (admin-only).
 pub fn set_treasury(env: &Env, admin: &Address, treasury: Address) {
-    admin.require_auth();
-    let stored: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
-    assert!(*admin == stored, "Only admin");
+    access::require_admin(env, admin, &DataKey::Admin);
     env.storage().instance().set(&DataKey::Treasury, &treasury);
 }
 

--- a/contracts/market/src/lib.rs
+++ b/contracts/market/src/lib.rs
@@ -7,6 +7,8 @@ use soroban_sdk::{
     contract, contractimpl, contracttype, symbol_short, Address, Env, Symbol, Vec,
 };
 
+use brain_storm_shared::access;
+
 pub mod fees;
 pub mod multisig_escrow;
 
@@ -159,7 +161,7 @@ impl MarketContract {
 
         assert!(escrow.status == EscrowStatus::Funded, "Escrow not funded");
 
-        let admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
+        let admin = access::read_authority(&env, &DataKey::Admin);
         assert!(caller == escrow.payer || caller == admin, "Unauthorized");
 
         let fee_bps = fees::get_fee_bps(&env);
@@ -222,7 +224,8 @@ impl MarketContract {
     ) -> Vec<BatchEscrowResult> {
         Self::require_not_paused(&env);
         caller.require_auth();
-        let admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
+        // Hoisted out of the loop: one storage read for the whole batch.
+        let admin = access::read_authority(&env, &DataKey::Admin);
         let fee_bps = fees::get_fee_bps(&env);
 
         let mut results = Vec::new(&env);
@@ -307,8 +310,7 @@ impl MarketContract {
     }
 
     fn assert_admin_addr(env: &Env, caller: &Address) {
-        let admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
-        assert!(*caller == admin, "Only admin");
+        assert!(access::is_admin(env, caller, &DataKey::Admin), "Only admin");
     }
 }
 
@@ -353,7 +355,7 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "Only admin")]
+    #[should_panic(expected = "Unauthorized: admin required")]
     fn test_non_admin_cannot_set_fee() {
         let (env, client, _) = setup();
         let rando = Address::generate(&env);

--- a/contracts/nft/Cargo.toml
+++ b/contracts/nft/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 
 [dependencies]
 soroban-sdk = { version = "21.5.0", features = ["testutils"] }
+brain-storm-shared = { path = "../shared", default-features = false }
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/contracts/nft/src/lib.rs
+++ b/contracts/nft/src/lib.rs
@@ -1,8 +1,9 @@
 #![no_std]
-#![no_std]
 use soroban_sdk::{
     contract, contractimpl, contracttype, symbol_short, Address, Env, String, Symbol, Vec,
 };
+
+use brain_storm_shared::access;
 
 #[contracttype]
 pub enum DataKey {
@@ -77,9 +78,7 @@ impl NFTContract {
         purchase_price: i128,
         royalty_basis: u32,
     ) -> u32 {
-        admin.require_auth();
-        let stored_admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
-        assert!(admin == stored_admin, "Only admin can mint");
+        access::require_admin(&env, &admin, &DataKey::Admin);
         assert!(royalty_basis <= 10000, "Royalty basis must be <= 10000");
 
         let nft_id_key = DataKey::NextNFTId;
@@ -135,15 +134,13 @@ impl NFTContract {
     }
 
     pub fn transfer_nft(env: Env, from: Address, to: Address, nft_id: u32) {
-        from.require_auth();
-
         let owner_key = DataKey::NFTOwner(nft_id);
         let current_owner: Address = env
             .storage()
             .instance()
             .get(&owner_key)
             .expect("NFT not found");
-        assert!(current_owner == from, "Not NFT owner");
+        access::require_owner(&from, &current_owner);
 
         // Update owner
         env.storage().instance().set(&owner_key, &to);
@@ -188,15 +185,13 @@ impl NFTContract {
     }
 
     pub fn grant_access(env: Env, nft_owner: Address, nft_id: u32, holder: Address) {
-        nft_owner.require_auth();
-
         let owner_key = DataKey::NFTOwner(nft_id);
         let current_owner: Address = env
             .storage()
             .instance()
             .get(&owner_key)
             .expect("NFT not found");
-        assert!(current_owner == nft_owner, "Not NFT owner");
+        access::require_owner(&nft_owner, &current_owner);
 
         env.storage()
             .instance()
@@ -209,15 +204,13 @@ impl NFTContract {
     }
 
     pub fn revoke_access(env: Env, nft_owner: Address, nft_id: u32, holder: Address) {
-        nft_owner.require_auth();
-
         let owner_key = DataKey::NFTOwner(nft_id);
         let current_owner: Address = env
             .storage()
             .instance()
             .get(&owner_key)
             .expect("NFT not found");
-        assert!(current_owner == nft_owner, "Not NFT owner");
+        access::require_owner(&nft_owner, &current_owner);
 
         env.storage()
             .instance()
@@ -276,14 +269,12 @@ impl NFTContract {
     // -------------------------------------------------------------------------
 
     pub fn burn_nft(env: Env, owner: Address, nft_id: u32) {
-        owner.require_auth();
-
         let current_owner: Address = env
             .storage()
             .instance()
             .get(&DataKey::NFTOwner(nft_id))
             .expect("NFT not found");
-        assert!(current_owner == owner, "Not NFT owner");
+        access::require_owner(&owner, &current_owner);
         assert!(
             !env.storage().instance().get::<DataKey, bool>(&DataKey::BurnedNFT(nft_id)).unwrap_or(false),
             "Already burned"
@@ -317,7 +308,6 @@ impl NFTContract {
     // -------------------------------------------------------------------------
 
     pub fn list_nft(env: Env, seller: Address, nft_id: u32, price: i128) {
-        seller.require_auth();
         assert!(price > 0, "Price must be positive");
 
         let current_owner: Address = env
@@ -325,7 +315,7 @@ impl NFTContract {
             .instance()
             .get(&DataKey::NFTOwner(nft_id))
             .expect("NFT not found");
-        assert!(current_owner == seller, "Not NFT owner");
+        access::require_owner(&seller, &current_owner);
         assert!(
             !env.storage().instance().has(&DataKey::Listing(nft_id)),
             "Already listed"
@@ -346,14 +336,12 @@ impl NFTContract {
     }
 
     pub fn delist_nft(env: Env, seller: Address, nft_id: u32) {
-        seller.require_auth();
-
         let listing: Listing = env
             .storage()
             .instance()
             .get(&DataKey::Listing(nft_id))
             .expect("Not listed");
-        assert!(listing.seller == seller, "Not the seller");
+        access::require_owner(&seller, &listing.seller);
 
         env.storage().instance().remove(&DataKey::Listing(nft_id));
 

--- a/contracts/nft/src/tests.rs
+++ b/contracts/nft/src/tests.rs
@@ -63,7 +63,7 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "Only admin can mint")]
+    #[should_panic(expected = "Unauthorized: admin required")]
     fn test_non_admin_cannot_mint() {
         let (env, client, _) = setup();
         let rando = Address::generate(&env);
@@ -128,7 +128,7 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "Not NFT owner")]
+    #[should_panic(expected = "Unauthorized: owner required")]
     fn test_transfer_by_non_owner_panics() {
         let (env, client, admin) = setup();
         let owner = Address::generate(&env);

--- a/contracts/registry/Cargo.toml
+++ b/contracts/registry/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 
 [dependencies]
 soroban-sdk = { version = "21.5.0", features = ["testutils"] }
+brain-storm-shared = { path = "../shared", default-features = false }
 
 [dev-dependencies]
 proptest = "1.4"

--- a/contracts/registry/src/lib.rs
+++ b/contracts/registry/src/lib.rs
@@ -14,6 +14,8 @@ use soroban_sdk::{
     contract, contractimpl, contracttype, symbol_short, Address, Env, Symbol, Vec,
 };
 
+use brain_storm_shared::access;
+
 // ── Storage keys ──────────────────────────────────────────────────────────────
 
 #[contracttype]
@@ -414,18 +416,19 @@ impl RegistryContract {
     }
 
     fn assert_admin(env: &Env, caller: &Address) {
-        let admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
-        assert!(*caller == admin, "Only admin");
+        assert!(access::is_admin(env, caller, &DataKey::Admin), "Only admin");
     }
 
     fn assert_admin_or_curator(env: &Env, caller: &Address) {
-        let admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
         let is_curator = env
             .storage()
             .instance()
             .get::<DataKey, bool>(&DataKey::Curator(caller.clone()))
             .unwrap_or(false);
-        assert!(*caller == admin || is_curator, "Unauthorized: admin or curator required");
+        assert!(
+            is_curator || access::is_admin(env, caller, &DataKey::Admin),
+            "Unauthorized: admin or curator required"
+        );
     }
 }
 

--- a/contracts/reputation/Cargo.toml
+++ b/contracts/reputation/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 
 [dependencies]
 soroban-sdk = { version = "21.5.0", features = ["testutils"] }
+brain-storm-shared = { path = "../shared", default-features = false }
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/contracts/reputation/src/lib.rs
+++ b/contracts/reputation/src/lib.rs
@@ -3,6 +3,8 @@ use soroban_sdk::{
     contract, contractimpl, contracttype, symbol_short, Address, Env, Symbol, Vec,
 };
 
+use brain_storm_shared::access;
+
 mod reputation;
 
 #[contracttype]
@@ -206,9 +208,7 @@ impl ReputationContract {
     }
 
     pub fn set_decay_config(env: Env, admin: Address, enabled: bool, decay_rate: i128, decay_interval: u32) {
-        admin.require_auth();
-        let stored_admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
-        assert!(admin == stored_admin, "Only admin can set decay config");
+        access::require_admin(&env, &admin, &DataKey::Admin);
         env.storage().instance().set(&DataKey::DecayConfig, &DecayConfig { enabled, decay_rate, decay_interval });
     }
 

--- a/contracts/reputation/src/reputation.rs
+++ b/contracts/reputation/src/reputation.rs
@@ -3,6 +3,8 @@
 
 use soroban_sdk::{contracttype, symbol_short, Address, Env, Symbol};
 
+use brain_storm_shared::access;
+
 use crate::{DataKey, DecayConfig, ReputationRecord};
 
 // ── Events ───────────────────────────────────────────────────────────────────
@@ -17,8 +19,7 @@ pub const LEVEL_THRESHOLDS: [i128; 5] = [0, 100, 400, 900, 1600];
 
 /// Returns true if `caller` is the stored admin or an authorized caller.
 pub fn is_authorized(env: &Env, caller: &Address) -> bool {
-    let admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
-    if *caller == admin {
+    if access::is_admin(env, caller, &DataKey::Admin) {
         return true;
     }
     env.storage()
@@ -121,6 +122,8 @@ pub fn apply_decay_internal(env: &Env, rep: &mut ReputationRecord, current_ledge
 // ── Internal assertion ────────────────────────────────────────────────────────
 
 fn assert_admin(env: &Env, caller: &Address) {
-    let admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
-    assert!(*caller == admin, "Only admin can perform this action");
+    assert!(
+        access::is_admin(env, caller, &DataKey::Admin),
+        "Only admin can perform this action"
+    );
 }

--- a/contracts/royalty_distribution/Cargo.toml
+++ b/contracts/royalty_distribution/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 
 [dependencies]
 soroban-sdk = { version = "21.5.0", features = ["alloc"] }
+brain-storm-shared = { path = "../shared", default-features = false }
 
 [dev-dependencies]
 soroban-sdk = { version = "21.5.0", features = ["testutils"] }

--- a/contracts/royalty_distribution/src/lib.rs
+++ b/contracts/royalty_distribution/src/lib.rs
@@ -3,6 +3,8 @@ use soroban_sdk::{
     contract, contractimpl, contracttype, symbol_short, Address, Env, Symbol,
 };
 
+use brain_storm_shared::access;
+
 #[contracttype]
 pub enum DataKey {
     Admin,
@@ -57,9 +59,7 @@ impl RoyaltyDistributionContract {
         contributor_pct: u32,
         platform_pct: u32,
     ) {
-        admin.require_auth();
-        let stored_admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
-        assert!(admin == stored_admin, "Only admin can set splits");
+        access::require_admin(&env, &admin, &DataKey::Admin);
         assert!(
             creator_pct + contributor_pct + platform_pct == 100,
             "Percentages must sum to 100"
@@ -86,9 +86,7 @@ impl RoyaltyDistributionContract {
         course_id: u64,
         recipient: Address,
     ) {
-        admin.require_auth();
-        let stored_admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
-        assert!(admin == stored_admin, "Only admin can add recipients");
+        access::require_admin(&env, &admin, &DataKey::Admin);
 
         let count: u32 = env
             .storage()
@@ -111,9 +109,7 @@ impl RoyaltyDistributionContract {
         course_id: u64,
         total_amount: i128,
     ) {
-        admin.require_auth();
-        let stored_admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
-        assert!(admin == stored_admin, "Only admin can distribute");
+        access::require_admin(&env, &admin, &DataKey::Admin);
         assert!(total_amount > 0, "Amount must be positive");
 
         let split: RoyaltySplit = env

--- a/contracts/royalty_distribution/src/tests.rs
+++ b/contracts/royalty_distribution/src/tests.rs
@@ -44,7 +44,7 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "Only admin can set splits")]
+    #[should_panic(expected = "Unauthorized: admin required")]
     fn test_non_admin_cannot_set_split() {
         let (env, client, _) = setup();
         let rando = Address::generate(&env);
@@ -60,7 +60,7 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "Only admin can add recipients")]
+    #[should_panic(expected = "Unauthorized: admin required")]
     fn test_non_admin_cannot_add_recipient() {
         let (env, client, admin) = setup();
         let rando = Address::generate(&env);

--- a/contracts/scholarship_fund/Cargo.toml
+++ b/contracts/scholarship_fund/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 
 [dependencies]
 soroban-sdk = { version = "21.5.0", features = ["alloc"] }
+brain-storm-shared = { path = "../shared", default-features = false }
 
 [dev-dependencies]
 soroban-sdk = { version = "21.5.0", features = ["testutils"] }

--- a/contracts/scholarship_fund/src/lib.rs
+++ b/contracts/scholarship_fund/src/lib.rs
@@ -3,6 +3,8 @@ use soroban_sdk::{
     contract, contractimpl, contracttype, symbol_short, Address, Env, Symbol, Vec,
 };
 
+use brain_storm_shared::access;
+
 #[contracttype]
 pub enum DataKey {
     Admin,
@@ -131,9 +133,7 @@ impl ScholarshipFundContract {
     // -------------------------------------------------------------------------
 
     pub fn approve_application(env: Env, admin: Address, app_id: u64) {
-        admin.require_auth();
-        let stored_admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
-        assert!(admin == stored_admin, "Only admin can approve");
+        access::require_admin(&env, &admin, &DataKey::Admin);
 
         let mut app: ScholarshipApplication = env
             .storage()
@@ -153,9 +153,7 @@ impl ScholarshipFundContract {
     }
 
     pub fn reject_application(env: Env, admin: Address, app_id: u64) {
-        admin.require_auth();
-        let stored_admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
-        assert!(admin == stored_admin, "Only admin can reject");
+        access::require_admin(&env, &admin, &DataKey::Admin);
 
         let mut app: ScholarshipApplication = env
             .storage()
@@ -172,9 +170,7 @@ impl ScholarshipFundContract {
     }
 
     pub fn distribute_scholarship(env: Env, admin: Address, app_id: u64) {
-        admin.require_auth();
-        let stored_admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
-        assert!(admin == stored_admin, "Only admin can distribute");
+        access::require_admin(&env, &admin, &DataKey::Admin);
 
         let mut app: ScholarshipApplication = env
             .storage()

--- a/contracts/shared/Cargo.toml
+++ b/contracts/shared/Cargo.toml
@@ -6,6 +6,14 @@ edition = "2021"
 [lib]
 crate-type = ["cdylib", "rlib"]
 
+[features]
+# Compiles `SharedContract` (the deployable RBAC contract). On by default so
+# this crate still builds as a standalone wasm. Contracts that depend on this
+# crate purely for its helper modules must use `default-features = false`, or
+# `SharedContract`'s entry points get exported from their wasm too.
+default = ["contract"]
+contract = []
+
 [dependencies]
 soroban-sdk = { version = "21.0.0", features = ["alloc"] }
 

--- a/contracts/shared/src/access.rs
+++ b/contracts/shared/src/access.rs
@@ -1,0 +1,251 @@
+//! Common access-control checks shared across contracts (issue #825).
+//!
+//! Before this module every contract hand-rolled the same three lines:
+//!
+//! ```ignore
+//! admin.require_auth();
+//! let stored_admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
+//! assert!(admin == stored_admin, "Only admin can do the thing");
+//! ```
+//!
+//! The storage *key* differs per contract (each has its own `DataKey` enum), so
+//! these helpers take the key as a generic parameter rather than assuming one.
+//! That keeps the storage slot explicit at the call site while the auth check,
+//! the missing-admin case, and the panic message live in exactly one place:
+//!
+//! ```ignore
+//! access::require_admin(&env, &admin, &DataKey::Admin);
+//! ```
+//!
+//! Panic messages are string literals rather than named constants on purpose:
+//! `assert!(cond, LITERAL)` compiles to a static-string panic, whereas
+//! `assert!(cond, "{}", SOME_CONST)` drags `core::fmt` into the contract wasm.
+//! Each message is documented on the function that raises it.
+
+use soroban_sdk::{Address, Env, IntoVal, Val};
+
+/// Reads the `Address` stored at `key` in instance storage.
+///
+/// Panics with `"Not initialized"` if the slot is empty, which is a clearer
+/// failure than the bare `.unwrap()` this replaces.
+pub fn read_authority<K>(env: &Env, key: &K) -> Address
+where
+    K: IntoVal<Env, Val>,
+{
+    env.storage().instance().get(key).expect("Not initialized")
+}
+
+/// Returns whether `caller` is the admin stored at `admin_key`.
+///
+/// Pure predicate: it neither requires auth nor panics on a mismatch. Use it to
+/// build a compound check; use [`require_admin`] to gate an entry point.
+///
+/// Panics with `"Not initialized"` if the admin slot is empty.
+pub fn is_admin<K>(env: &Env, caller: &Address, admin_key: &K) -> bool
+where
+    K: IntoVal<Env, Val>,
+{
+    *caller == read_authority(env, admin_key)
+}
+
+/// Requires that `caller` authorized this invocation and is the stored admin.
+///
+/// Panics with `"Unauthorized: admin required"` otherwise.
+pub fn require_admin<K>(env: &Env, caller: &Address, admin_key: &K)
+where
+    K: IntoVal<Env, Val>,
+{
+    caller.require_auth();
+    assert!(
+        is_admin(env, caller, admin_key),
+        "Unauthorized: admin required"
+    );
+}
+
+/// Requires that `caller` authorized this invocation and is the address held in
+/// a non-admin authority slot — a dispute arbiter, an oracle, a fee collector.
+///
+/// Panics with `"Unauthorized: authority required"` otherwise.
+pub fn require_authority<K>(env: &Env, caller: &Address, authority_key: &K)
+where
+    K: IntoVal<Env, Val>,
+{
+    caller.require_auth();
+    assert!(
+        *caller == read_authority(env, authority_key),
+        "Unauthorized: authority required"
+    );
+}
+
+/// Requires that `caller` authorized this invocation and is either the stored
+/// admin or `permitted` — e.g. an escrow that both its payer and the admin may
+/// cancel.
+///
+/// Panics with `"Unauthorized: admin or permitted caller required"` otherwise.
+pub fn require_admin_or<K>(env: &Env, caller: &Address, admin_key: &K, permitted: &Address)
+where
+    K: IntoVal<Env, Val>,
+{
+    caller.require_auth();
+    assert!(
+        caller == permitted || is_admin(env, caller, admin_key),
+        "Unauthorized: admin or permitted caller required"
+    );
+}
+
+/// Requires that `caller` authorized this invocation and owns the resource.
+///
+/// `owner` is read by the caller from whatever per-resource key the contract
+/// uses (`DataKey::NFTOwner(id)`, a listing's `seller`, ...), so this helper
+/// covers only the auth-and-compare half.
+///
+/// Panics with `"Unauthorized: owner required"` otherwise.
+pub fn require_owner(caller: &Address, owner: &Address) {
+    caller.require_auth();
+    assert!(caller == owner, "Unauthorized: owner required");
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use soroban_sdk::{contract, contractimpl, contracttype, testutils::Address as _};
+
+    #[contracttype]
+    enum TestKey {
+        Admin,
+        Arbiter,
+    }
+
+    /// Thin wrapper contract so the helpers are exercised through a real
+    /// invocation frame — `require_auth` needs one.
+    #[contract]
+    struct AccessTestContract;
+
+    #[contractimpl]
+    impl AccessTestContract {
+        pub fn init(env: Env, admin: Address) {
+            env.storage().instance().set(&TestKey::Admin, &admin);
+        }
+
+        pub fn set_arbiter(env: Env, arbiter: Address) {
+            env.storage().instance().set(&TestKey::Arbiter, &arbiter);
+        }
+
+        pub fn admin_only(env: Env, caller: Address) {
+            require_admin(&env, &caller, &TestKey::Admin);
+        }
+
+        pub fn arbiter_only(env: Env, caller: Address) {
+            require_authority(&env, &caller, &TestKey::Arbiter);
+        }
+
+        pub fn admin_or(env: Env, caller: Address, permitted: Address) {
+            require_admin_or(&env, &caller, &TestKey::Admin, &permitted);
+        }
+
+        pub fn owner_only(_env: Env, caller: Address, owner: Address) {
+            require_owner(&caller, &owner);
+        }
+
+        pub fn check_is_admin(env: Env, caller: Address) -> bool {
+            is_admin(&env, &caller, &TestKey::Admin)
+        }
+
+        pub fn read_admin(env: Env) -> Address {
+            read_authority(&env, &TestKey::Admin)
+        }
+    }
+
+    fn setup() -> (Env, AccessTestContractClient<'static>, Address) {
+        let env = Env::default();
+        env.mock_all_auths();
+        let id = env.register_contract(None, AccessTestContract);
+        let client = AccessTestContractClient::new(&env, &id);
+        let admin = Address::generate(&env);
+        client.init(&admin);
+        (env, client, admin)
+    }
+
+    #[test]
+    fn admin_passes_require_admin() {
+        let (_, client, admin) = setup();
+        client.admin_only(&admin);
+        assert!(client.check_is_admin(&admin));
+        assert_eq!(client.read_admin(), admin);
+    }
+
+    #[test]
+    #[should_panic(expected = "Unauthorized: admin required")]
+    fn non_admin_fails_require_admin() {
+        let (env, client, _) = setup();
+        let intruder = Address::generate(&env);
+        client.admin_only(&intruder);
+    }
+
+    #[test]
+    fn is_admin_is_false_for_other_address() {
+        let (env, client, _) = setup();
+        let other = Address::generate(&env);
+        assert!(!client.check_is_admin(&other));
+    }
+
+    #[test]
+    #[should_panic(expected = "Not initialized")]
+    fn empty_slot_reports_not_initialized() {
+        let (_, client, admin) = setup();
+        // The `Arbiter` slot was never written.
+        client.arbiter_only(&admin);
+    }
+
+    #[test]
+    fn authority_slot_is_checked_independently_of_admin() {
+        let (env, client, _) = setup();
+        let arbiter = Address::generate(&env);
+        client.set_arbiter(&arbiter);
+        client.arbiter_only(&arbiter);
+        // Holding the arbiter slot does not make an address the admin.
+        assert!(!client.check_is_admin(&arbiter));
+    }
+
+    #[test]
+    #[should_panic(expected = "Unauthorized: authority required")]
+    fn admin_is_not_automatically_the_authority() {
+        let (env, client, admin) = setup();
+        let arbiter = Address::generate(&env);
+        client.set_arbiter(&arbiter);
+        client.arbiter_only(&admin);
+    }
+
+    #[test]
+    fn require_admin_or_accepts_both_parties() {
+        let (env, client, admin) = setup();
+        let payer = Address::generate(&env);
+        client.admin_or(&admin, &payer);
+        client.admin_or(&payer, &payer);
+    }
+
+    #[test]
+    #[should_panic(expected = "Unauthorized: admin or permitted caller required")]
+    fn require_admin_or_rejects_third_party() {
+        let (env, client, _) = setup();
+        let payer = Address::generate(&env);
+        let intruder = Address::generate(&env);
+        client.admin_or(&intruder, &payer);
+    }
+
+    #[test]
+    fn require_owner_accepts_owner() {
+        let (env, client, _) = setup();
+        let owner = Address::generate(&env);
+        client.owner_only(&owner, &owner);
+    }
+
+    #[test]
+    #[should_panic(expected = "Unauthorized: owner required")]
+    fn require_owner_rejects_non_owner() {
+        let (env, client, _) = setup();
+        let owner = Address::generate(&env);
+        let intruder = Address::generate(&env);
+        client.owner_only(&intruder, &owner);
+    }
+}

--- a/contracts/shared/src/lib.rs
+++ b/contracts/shared/src/lib.rs
@@ -4,11 +4,14 @@
 //! Full interface reference: [docs/contract-interfaces.md § Shared / RBAC Contract](../../../docs/contract-interfaces.md#shared--rbac-contract).
 //! Cross-contract call conventions used across `contracts/`: [docs/contract-interfaces.md § Cross-Contract Call Conventions](../../../docs/contract-interfaces.md#cross-contract-call-conventions).
 //! Rationale for this crate's existence and how it relates to other contracts: [ADR-007](../../../docs/adr/ADR-007-shared-crate-for-common-code.md).
-use soroban_sdk::{contract, contractimpl, contracttype, symbol_short, Address, BytesN, Env, Symbol};
+use soroban_sdk::{contracttype, Address, Symbol};
 
-pub mod pausable;
-
+pub mod access;
+pub mod errors;
 pub mod math;
+pub mod pausable;
+pub mod reentrancy;
+pub mod validation;
 
 #[contracttype]
 #[derive(Clone, PartialEq)]
@@ -49,10 +52,23 @@ pub enum DataKey {
     AuthorizedCallers(Address),          // contract → Vec<Address> (authorized callers)
 }
 
+/// The RBAC contract itself.
+///
+/// Gated behind the default-on `contract` feature. Other contracts in this
+/// workspace depend on this crate only for its helper modules (`access`,
+/// `math`, `validation`, ...) and must do so with `default-features = false`:
+/// linking a `#[contractimpl]` block into another contract's wasm would export
+/// this contract's entry points (`assign_role`, `upgrade`, `pause_contract`, ...)
+/// from that contract, operating on *its* storage.
+#[cfg(feature = "contract")]
+use soroban_sdk::{contract, contractimpl, symbol_short, BytesN, Env};
+
+#[cfg(feature = "contract")]
 #[contract]
 pub struct SharedContract;
 
 /// Returns true if `role` grants `permission`.
+#[cfg(feature = "contract")]
 fn role_has_permission(role: &Role, permission: &Permission) -> bool {
     match role {
         Role::Admin => true, // Admin has all permissions
@@ -64,6 +80,7 @@ fn role_has_permission(role: &Role, permission: &Permission) -> bool {
     }
 }
 
+#[cfg(feature = "contract")]
 #[contractimpl]
 impl SharedContract {
     /// Initialize the contract with an admin address
@@ -77,9 +94,7 @@ impl SharedContract {
 
     /// Assign a role to an address (admin only). Emits ("rbac", "role_assigned").
     pub fn assign_role(env: Env, caller: Address, target: Address, role: Role) {
-        caller.require_auth();
-        let admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
-        assert!(caller == admin, "Only admin can assign roles");
+        crate::access::require_admin(&env, &caller, &DataKey::Admin);
         env.storage()
             .instance()
             .set(&DataKey::Role(target.clone()), &role);
@@ -112,9 +127,7 @@ impl SharedContract {
 
     /// Upgrade the contract wasm (admin only). Emits ("shared", "upgraded").
     pub fn upgrade(env: Env, admin: Address, new_wasm_hash: BytesN<32>) {
-        admin.require_auth();
-        let stored_admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
-        assert!(admin == stored_admin, "Only admin can upgrade");
+        crate::access::require_admin(&env, &admin, &DataKey::Admin);
 
         env.events().publish(
             (symbol_short!("shared"), symbol_short!("upgraded")),
@@ -135,9 +148,7 @@ impl SharedContract {
         target_contract: Address,
         caller: Address,
     ) {
-        admin.require_auth();
-        let stored_admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
-        assert!(admin == stored_admin, "Only admin can authorize");
+        crate::access::require_admin(&env, &admin, &DataKey::Admin);
 
         let key = DataKey::AuthorizedCallers(target_contract.clone());
         let mut callers: soroban_sdk::Vec<Address> = env
@@ -285,16 +296,12 @@ impl SharedContract {
     // -------------------------------------------------------------------------
 
     pub fn pause_contract(env: Env, admin: Address, auto_unpause_ledgers: u32) {
-        admin.require_auth();
-        let stored_admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
-        assert!(admin == stored_admin, "Only admin can pause");
+        crate::access::require_admin(&env, &admin, &DataKey::Admin);
         pausable::pause(&env, &admin, auto_unpause_ledgers);
     }
 
     pub fn unpause_contract(env: Env, admin: Address) {
-        admin.require_auth();
-        let stored_admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
-        assert!(admin == stored_admin, "Only admin can unpause");
+        crate::access::require_admin(&env, &admin, &DataKey::Admin);
         pausable::unpause(&env, &admin);
     }
 
@@ -312,25 +319,19 @@ impl SharedContract {
 
     /// Schedule a WASM upgrade with a timelock delay (admin only).
     pub fn schedule_upgrade(env: Env, admin: Address, new_wasm_hash: BytesN<32>, timelock_ledgers: u32) {
-        admin.require_auth();
-        let stored_admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
-        assert!(admin == stored_admin, "Only admin can schedule upgrades");
+        crate::access::require_admin(&env, &admin, &DataKey::Admin);
         upgrade::schedule_upgrade(&env, &admin, new_wasm_hash, timelock_ledgers);
     }
 
     /// Execute a previously scheduled upgrade once its timelock has expired (admin only).
     pub fn execute_upgrade(env: Env, admin: Address) {
-        admin.require_auth();
-        let stored_admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
-        assert!(admin == stored_admin, "Only admin can execute upgrades");
+        crate::access::require_admin(&env, &admin, &DataKey::Admin);
         upgrade::execute_upgrade(&env, &admin);
     }
 
     /// Cancel a pending upgrade before it executes (admin only).
     pub fn cancel_upgrade(env: Env, admin: Address) {
-        admin.require_auth();
-        let stored_admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
-        assert!(admin == stored_admin, "Only admin can cancel upgrades");
+        crate::access::require_admin(&env, &admin, &DataKey::Admin);
         upgrade::cancel_upgrade(&env, &admin);
     }
 
@@ -353,6 +354,7 @@ impl SharedContract {
 pub mod multisig;
 pub mod upgrade;
 
+#[cfg(all(test, feature = "contract"))]
 mod tests;
-#[cfg(test)]
+#[cfg(all(test, feature = "contract"))]
 mod upgrade_tests;

--- a/contracts/shared/src/math.rs
+++ b/contracts/shared/src/math.rs
@@ -17,6 +17,27 @@ pub fn checked_mul_i128(a: i128, b: i128) -> i128 {
     a.checked_mul(b).expect("math: i128 multiplication overflow")
 }
 
+/// Integer division that reports a zero divisor explicitly.
+///
+/// A bare `a / 0` traps in the VM with no indication of which computation
+/// failed; this names it.
+pub fn checked_div_i128(a: i128, b: i128) -> i128 {
+    assert!(b != 0, "math: i128 division by zero");
+    a.checked_div(b).expect("math: i128 division overflow")
+}
+
+/// Computes `(a * b) / denominator` — the proportional-share formula that
+/// AMM and fee math is built from.
+///
+/// The intermediate product is a checked `i128`: if `a * b` exceeds `i128`
+/// this panics rather than wrapping. It does *not* promote to a wider type,
+/// so a mathematically-representable result can still be rejected when the
+/// intermediate does not fit. That fails closed, which is the right default
+/// for value-moving code.
+pub fn checked_mul_div_i128(a: i128, b: i128, denominator: i128) -> i128 {
+    checked_div_i128(checked_mul_i128(a, b), denominator)
+}
+
 pub fn checked_add_u32(a: u32, b: u32) -> u32 {
     a.checked_add(b).expect("math: u32 addition overflow")
 }
@@ -50,5 +71,30 @@ mod test {
     #[should_panic(expected = "math: u32 subtraction overflow")]
     fn sub_u32_underflow() {
         checked_sub_u32(0, 1);
+    }
+
+    #[test]
+    #[should_panic(expected = "math: i128 division by zero")]
+    fn div_i128_by_zero() {
+        checked_div_i128(1, 0);
+    }
+
+    #[test]
+    fn mul_div_i128_ok() {
+        assert_eq!(checked_mul_div_i128(10, 3, 4), 7); // truncates toward zero
+        assert_eq!(checked_mul_div_i128(0, 5, 7), 0);
+    }
+
+    #[test]
+    #[should_panic(expected = "math: i128 division by zero")]
+    fn mul_div_i128_zero_denominator() {
+        checked_mul_div_i128(1, 1, 0);
+    }
+
+    #[test]
+    #[should_panic(expected = "math: i128 multiplication overflow")]
+    fn mul_div_i128_intermediate_overflow() {
+        // The result would fit in i128, but the a*b intermediate does not.
+        checked_mul_div_i128(i128::MAX, 2, 2);
     }
 }

--- a/contracts/shared/src/tests.rs
+++ b/contracts/shared/src/tests.rs
@@ -38,7 +38,7 @@ fn test_assign_student_role() {
 }
 
 #[test]
-#[should_panic(expected = "Only admin can assign roles")]
+#[should_panic(expected = "Unauthorized: admin required")]
 fn test_non_admin_cannot_assign_role() {
     let (env, _, client) = setup();
     let rando = Address::generate(&env);
@@ -100,7 +100,7 @@ fn test_unassigned_address_has_no_permissions() {
 // ── upgrade (Issue 4) ─────────────────────────────────────────────────────────
 
 #[test]
-#[should_panic(expected = "Only admin can upgrade")]
+#[should_panic(expected = "Unauthorized: admin required")]
 fn test_non_admin_cannot_upgrade() {
     use soroban_sdk::BytesN;
     let (env, _, client) = setup();
@@ -126,7 +126,7 @@ fn test_double_initialize_rejected() {
 // ── assign_role: only admin ───────────────────────────────────────────────────
 
 #[test]
-#[should_panic(expected = "Only admin can assign roles")]
+#[should_panic(expected = "Unauthorized: admin required")]
 fn test_non_admin_cannot_assign_admin_role() {
     let (env, _, client) = setup();
     let rando = Address::generate(&env);
@@ -135,7 +135,7 @@ fn test_non_admin_cannot_assign_admin_role() {
 }
 
 #[test]
-#[should_panic(expected = "Only admin can assign roles")]
+#[should_panic(expected = "Unauthorized: admin required")]
 fn test_non_admin_cannot_assign_instructor_role() {
     let (env, _, client) = setup();
     let rando = Address::generate(&env);
@@ -189,7 +189,7 @@ fn test_instructor_lacks_privileged_permissions() {
 // ── authorize_caller: auth guard ─────────────────────────────────────────────
 
 #[test]
-#[should_panic(expected = "Only admin can authorize")]
+#[should_panic(expected = "Unauthorized: admin required")]
 fn test_non_admin_cannot_authorize_caller() {
     let (env, _, client) = setup();
     let rando = Address::generate(&env);
@@ -229,7 +229,7 @@ fn test_call_contract_rejects_unauthorized_caller() {
 // ── upgrade: auth guard ───────────────────────────────────────────────────────
 
 #[test]
-#[should_panic(expected = "Only admin can upgrade")]
+#[should_panic(expected = "Unauthorized: admin required")]
 fn test_non_admin_cannot_upgrade_contract() {
     use soroban_sdk::BytesN;
     let (env, _, client) = setup();
@@ -241,7 +241,7 @@ fn test_non_admin_cannot_upgrade_contract() {
 // ── schedule_upgrade: auth guard ─────────────────────────────────────────────
 
 #[test]
-#[should_panic(expected = "Only admin can schedule upgrades")]
+#[should_panic(expected = "Unauthorized: admin required")]
 fn test_non_admin_cannot_schedule_upgrade() {
     use soroban_sdk::BytesN;
     let (env, _, client) = setup();
@@ -251,7 +251,7 @@ fn test_non_admin_cannot_schedule_upgrade() {
 }
 
 #[test]
-#[should_panic(expected = "Only admin can cancel upgrades")]
+#[should_panic(expected = "Unauthorized: admin required")]
 fn test_non_admin_cannot_cancel_upgrade() {
     use soroban_sdk::BytesN;
     let (env, admin, client) = setup();

--- a/contracts/shared/src/upgrade_tests.rs
+++ b/contracts/shared/src/upgrade_tests.rs
@@ -40,7 +40,7 @@ fn test_schedule_upgrade_stores_pending() {
 }
 
 #[test]
-#[should_panic(expected = "Only admin can schedule upgrades")]
+#[should_panic(expected = "Unauthorized: admin required")]
 fn test_non_admin_cannot_schedule_upgrade() {
     let (env, _, client) = setup();
     let rando = Address::generate(&env);
@@ -57,7 +57,7 @@ fn test_cancel_upgrade_removes_pending() {
 }
 
 #[test]
-#[should_panic(expected = "Only admin can cancel upgrades")]
+#[should_panic(expected = "Unauthorized: admin required")]
 fn test_non_admin_cannot_cancel_upgrade() {
     let (env, admin, client) = setup();
     client.schedule_upgrade(&admin, &fake_hash(&env, 4), &10);
@@ -102,7 +102,7 @@ fn test_execute_after_timelock_succeeds_and_records_history() {
 }
 
 #[test]
-#[should_panic(expected = "Only admin can execute upgrades")]
+#[should_panic(expected = "Unauthorized: admin required")]
 fn test_non_admin_cannot_execute_upgrade() {
     let (env, admin, client) = setup();
     client.schedule_upgrade(&admin, &fake_hash(&env, 7), &1);
@@ -192,7 +192,7 @@ fn test_no_pending_upgrade_initially() {
 // ── Unauthorised direct upgrade (#665 AC: unauthorised upgrade rejected) ──────
 
 #[test]
-#[should_panic(expected = "Only admin can upgrade")]
+#[should_panic(expected = "Unauthorized: admin required")]
 fn test_direct_upgrade_non_admin_rejected() {
     let (env, _, client) = setup();
     let rando = Address::generate(&env);

--- a/contracts/token/Cargo.toml
+++ b/contracts/token/Cargo.toml
@@ -8,7 +8,7 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 soroban-sdk = { version = "21.0.0", features = ["alloc"] }
-brain-storm-shared = { path = "../shared" }
+brain-storm-shared = { path = "../shared", default-features = false }
 
 [dev-dependencies]
 soroban-sdk = { version = "21.0.0", features = ["testutils"] }

--- a/contracts/token/src/lib.rs
+++ b/contracts/token/src/lib.rs
@@ -1,4 +1,5 @@
 #![no_std]
+use brain_storm_shared::access;
 use brain_storm_shared::math::{checked_add_i128, checked_sub_i128};
 use soroban_sdk::{contract, contractimpl, contracttype, Address, Env, String};
 
@@ -527,9 +528,7 @@ impl TokenContract {
         cliff_ledger: u32,
         end_ledger: u32,
     ) {
-        admin.require_auth();
-        let stored_admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
-        assert!(admin == stored_admin, "Only admin can create vesting");
+        access::require_admin(&env, &admin, &DataKey::Admin);
         assert!(total_amount > 0, "Amount must be positive");
 
         let start_ledger = env.ledger().sequence();
@@ -608,9 +607,7 @@ impl TokenContract {
         vesting_type: u8, // 0 = linear, 1 = step
         step_count: u32,
     ) -> u32 {
-        admin.require_auth();
-        let stored_admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
-        assert!(admin == stored_admin, "Only admin can create vesting");
+        access::require_admin(&env, &admin, &DataKey::Admin);
         assert!(total_amount > 0, "Amount must be positive");
         assert!(vesting_type <= 1, "Invalid vesting type");
 
@@ -704,9 +701,7 @@ impl TokenContract {
         schedule_id: u32,
         new_end_ledger: u32,
     ) {
-        admin.require_auth();
-        let stored_admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
-        assert!(admin == stored_admin, "Only admin can modify vesting");
+        access::require_admin(&env, &admin, &DataKey::Admin);
 
         let key = DataKey::VestingV2(beneficiary.clone(), schedule_id);
         let mut schedule: VestingScheduleV2 = env
@@ -779,9 +774,7 @@ impl TokenContract {
     /// Configure the staking reward rate (admin only). Rate is in basis points per ledger
     /// e.g. 500 = 0.005% per ledger.
     pub fn set_reward_rate(env: Env, admin: Address, rate: i128) {
-        admin.require_auth();
-        let stored_admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
-        assert!(admin == stored_admin, "Only admin can set reward rate");
+        access::require_admin(&env, &admin, &DataKey::Admin);
         assert!(rate >= 0, "Rate must be non-negative");
         env.storage()
             .instance()
@@ -790,9 +783,7 @@ impl TokenContract {
 
     /// Configure the early withdrawal penalty (admin only). Penalty in basis points.
     pub fn set_early_withdrawal_penalty(env: Env, admin: Address, penalty: i128) {
-        admin.require_auth();
-        let stored_admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
-        assert!(admin == stored_admin, "Only admin can set penalty");
+        access::require_admin(&env, &admin, &DataKey::Admin);
         assert!(penalty >= 0 && penalty <= 10_000, "Penalty must be 0-10000 bps");
         env.storage()
             .instance()
@@ -828,9 +819,7 @@ impl TokenContract {
 
     /// Emergency withdrawal: admin can force-return staked tokens to a staker (no rewards, no penalty).
     pub fn emergency_withdraw(env: Env, admin: Address, staker: Address) {
-        admin.require_auth();
-        let stored_admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
-        assert!(admin == stored_admin, "Only admin can emergency withdraw");
+        access::require_admin(&env, &admin, &DataKey::Admin);
 
         let record = staking::get_stake(&env, staker.clone())
             .expect("No stake found for staker");
@@ -879,9 +868,7 @@ impl TokenContract {
     pub fn mint_reward(env: Env, caller: Address, recipient: Address, amount: i128) {
         acquire_lock(&env);
 
-        caller.require_auth();
-        let admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
-        assert!(caller == admin, "Only admin can mint");
+        access::require_admin(&env, &caller, &DataKey::Admin);
         assert!(amount > 0, "Amount must be positive");
 
         Self::add_balance(&env, &recipient, amount);
@@ -1222,7 +1209,7 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "Only admin can create vesting")]
+    #[should_panic(expected = "Unauthorized: admin required")]
     fn test_only_admin_can_create_vesting() {
         let (env, client, _) = setup();
         let instructor = Address::generate(&env);
@@ -1491,7 +1478,7 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "Only admin can modify vesting")]
+    #[should_panic(expected = "Unauthorized: admin required")]
     fn test_non_admin_cannot_modify_vesting() {
         let (env, client, admin) = setup();
         let instructor = Address::generate(&env);

--- a/contracts/token/src/tests.rs
+++ b/contracts/token/src/tests.rs
@@ -153,7 +153,7 @@ fn test_double_initialize_rejected() {
 // ── mint: auth failures ───────────────────────────────────────────────────────
 
 #[test]
-#[should_panic(expected = "Only admin can mint")]
+#[should_panic(expected = "Unauthorized: admin required")]
 fn test_non_admin_mint_reward_rejected() {
     let (env, _admin, client) = setup();
     let rando = Address::generate(&env);
@@ -287,7 +287,7 @@ fn test_vesting_claim_after_cliff() {
 }
 
 #[test]
-#[should_panic(expected = "Only admin can create vesting")]
+#[should_panic(expected = "Unauthorized: admin required")]
 fn test_non_admin_cannot_create_vesting() {
     let (env, _admin, client) = setup();
     let rando = Address::generate(&env);

--- a/contracts/token_restrictions/Cargo.toml
+++ b/contracts/token_restrictions/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 
 [dependencies]
 soroban-sdk = { version = "21.5.0", features = ["alloc"] }
+brain-storm-shared = { path = "../shared", default-features = false }
 
 [dev-dependencies]
 soroban-sdk = { version = "21.5.0", features = ["testutils"] }

--- a/contracts/token_restrictions/src/lib.rs
+++ b/contracts/token_restrictions/src/lib.rs
@@ -3,6 +3,8 @@ use soroban_sdk::{
     contract, contractimpl, contracttype, symbol_short, Address, Env, Symbol,
 };
 
+use brain_storm_shared::access;
+
 #[contracttype]
 pub enum DataKey {
     Admin,
@@ -45,9 +47,7 @@ impl TokenRestrictionsContract {
     }
 
     pub fn add_to_whitelist(env: Env, admin: Address, account: Address) {
-        admin.require_auth();
-        let stored_admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
-        assert!(admin == stored_admin, "Only admin can manage whitelist");
+        access::require_admin(&env, &admin, &DataKey::Admin);
 
         env.storage()
             .instance()
@@ -58,9 +58,7 @@ impl TokenRestrictionsContract {
     }
 
     pub fn remove_from_whitelist(env: Env, admin: Address, account: Address) {
-        admin.require_auth();
-        let stored_admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
-        assert!(admin == stored_admin, "Only admin can manage whitelist");
+        access::require_admin(&env, &admin, &DataKey::Admin);
 
         env.storage()
             .instance()
@@ -78,9 +76,7 @@ impl TokenRestrictionsContract {
     }
 
     pub fn add_to_blacklist(env: Env, admin: Address, account: Address) {
-        admin.require_auth();
-        let stored_admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
-        assert!(admin == stored_admin, "Only admin can manage blacklist");
+        access::require_admin(&env, &admin, &DataKey::Admin);
 
         env.storage()
             .instance()
@@ -91,9 +87,7 @@ impl TokenRestrictionsContract {
     }
 
     pub fn remove_from_blacklist(env: Env, admin: Address, account: Address) {
-        admin.require_auth();
-        let stored_admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
-        assert!(admin == stored_admin, "Only admin can manage blacklist");
+        access::require_admin(&env, &admin, &DataKey::Admin);
 
         env.storage()
             .instance()
@@ -111,9 +105,7 @@ impl TokenRestrictionsContract {
     }
 
     pub fn set_transfer_limit(env: Env, admin: Address, account: Address, limit: i128) {
-        admin.require_auth();
-        let stored_admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
-        assert!(admin == stored_admin, "Only admin can set limits");
+        access::require_admin(&env, &admin, &DataKey::Admin);
         assert!(limit > 0, "Limit must be positive");
 
         env.storage()
@@ -149,9 +141,7 @@ impl TokenRestrictionsContract {
     }
 
     pub fn approve_transfer(env: Env, admin: Address, from: Address, to: Address) {
-        admin.require_auth();
-        let stored_admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
-        assert!(admin == stored_admin, "Only admin can approve transfers");
+        access::require_admin(&env, &admin, &DataKey::Admin);
 
         env.storage()
             .instance()
@@ -169,9 +159,7 @@ impl TokenRestrictionsContract {
     }
 
     pub fn activate_emergency_override(env: Env, admin: Address) {
-        admin.require_auth();
-        let stored_admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
-        assert!(admin == stored_admin, "Only admin can activate override");
+        access::require_admin(&env, &admin, &DataKey::Admin);
 
         env.storage()
             .instance()
@@ -183,9 +171,7 @@ impl TokenRestrictionsContract {
     }
 
     pub fn deactivate_emergency_override(env: Env, admin: Address) {
-        admin.require_auth();
-        let stored_admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
-        assert!(admin == stored_admin, "Only admin can deactivate override");
+        access::require_admin(&env, &admin, &DataKey::Admin);
 
         env.storage()
             .instance()

--- a/contracts/token_restrictions/src/tests.rs
+++ b/contracts/token_restrictions/src/tests.rs
@@ -50,7 +50,7 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "Only admin can manage whitelist")]
+    #[should_panic(expected = "Unauthorized: admin required")]
     fn test_non_admin_cannot_whitelist() {
         let (env, client, _) = setup();
         let rando = Address::generate(&env);
@@ -83,7 +83,7 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "Only admin can manage blacklist")]
+    #[should_panic(expected = "Unauthorized: admin required")]
     fn test_non_admin_cannot_blacklist() {
         let (env, client, _) = setup();
         let rando = Address::generate(&env);
@@ -107,7 +107,7 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "Only admin can set limits")]
+    #[should_panic(expected = "Unauthorized: admin required")]
     fn test_non_admin_cannot_set_limit() {
         let (env, client, _) = setup();
         let rando = Address::generate(&env);

--- a/docs/adr/ADR-007-shared-crate-for-common-code.md
+++ b/docs/adr/ADR-007-shared-crate-for-common-code.md
@@ -2,6 +2,11 @@
 
 **Status:** Accepted
 
+> **Superseded in part by issue #825 (2026-07-27).** The sections below describing
+> "no production contract depends on `brain-storm-shared`" record the state as of
+> 2026-07-25 and are no longer accurate. See [§ Update: compile-time reuse landed](#update-compile-time-reuse-landed-2026-07-27-issue-825)
+> at the end of this document.
+
 **Date:** 2026-07-25
 
 **Author(s):** Brain-Storm maintainers
@@ -72,8 +77,58 @@ Adding `brain-storm-shared` as a path dependency to, say, `market`'s `Cargo.toml
 - [ADR-006: Contract-Per-Domain Architecture](./ADR-006-contract-per-domain-architecture.md)
 - [Issue #762](https://github.com/BrainTease/Brain-Storm/issues/762)
 
+## Update: compile-time reuse landed (2026-07-27, issue #825)
+
+Alternative 2 above — "make `brain-storm-shared` a real compile-time dependency"
+— has now been adopted for access-control checks, in the *library* form rather
+than the cross-contract-call form. The gas objection raised against it does not
+apply: the helpers are ordinary Rust functions linked into each contract's own
+wasm, so an admin check is still a single local storage read, not an
+`invoke_contract`.
+
+What changed:
+
+- **`contracts/shared/src/access.rs`** is the canonical implementation of the
+  `require_auth` → read stored admin → compare triplet that all 18 contracts had
+  copied inline. It takes the storage key as a generic parameter, so each
+  contract keeps its own `DataKey` while sharing the check.
+- **Sixteen contracts now carry `brain-storm-shared` as a path dependency** and
+  call `access::require_admin` / `require_authority` / `require_admin_or` /
+  `require_owner` / `is_admin` instead of hand-rolling the comparison.
+- **Panic messages are unified.** Admin failures now report
+  `"Unauthorized: admin required"` everywhere instead of ~30 distinct
+  `"Only admin can <verb>"` strings. Two contracts keep bespoke messages because
+  their checks are genuinely compound: `registry`
+  (`"Unauthorized: admin or curator required"`) and `reputation`
+  (`"Unauthorized caller"`), both of which now call `access::is_admin` for the
+  admin half.
+- **`SharedContract` is feature-gated.** The dependency is declared
+  `default-features = false` everywhere. Without this, linking a crate that
+  contains a `#[contractimpl]` block into another contract's wasm would export
+  `SharedContract`'s entry points — `assign_role`, `upgrade`, `pause_contract` —
+  from *that* contract, operating on its storage. Since `SharedContract`'s
+  `DataKey::Admin` serialises identically to every other contract's
+  `DataKey::Admin`, that would have been directly exploitable. The
+  `contract` feature is on by default so the crate still builds as a standalone
+  deployable wasm.
+
+The "Negative" consequence above — that a fix to `contracts/shared` does not
+propagate to the inline copies — is now resolved **for access-control checks
+only**. It still holds for `pausable.rs`, `reentrancy.rs`, `multisig.rs`, and
+`upgrade.rs`, which remain copied per contract.
+
+### Not addressed
+
+The deployed `SharedContract`'s `authorize_caller` / `call_contract` /
+`relay_event` registry is still unused by production contracts, and the RBAC
+`Role`/`Permission` model is still not consulted by any contract's admin gate —
+contracts compare against their own stored `Admin` address, not against
+`SharedContract`'s role table. Consolidating those is a separate decision.
+
+
 ## Revision History
 
 | Date | Author | Change |
 |------|--------|--------|
 | 2026-07-25 | Brain-Storm maintainers | Initial proposal, derived from dependency analysis of `contracts/*/Cargo.toml` for issue #762 |
+| 2026-07-27 | Brain-Storm maintainers | Added § Update: compile-time reuse landed — `access.rs` extracted and adopted by 16 contracts (issue #825) |

--- a/docs/contract-interfaces.md
+++ b/docs/contract-interfaces.md
@@ -557,6 +557,19 @@ Whitelist/blacklist, per-account transfer limits, and an emergency-override swit
 
 Role-based access control library used by other contracts for cross-contract authorization checks.
 
+The crate serves two roles. `SharedContract` (behind the default-on `contract` Cargo feature) is the deployable RBAC contract. The rest of the crate is a plain library that other contracts link against with `default-features = false`:
+
+| Module | Provides |
+|---|---|
+| `access` | Admin/authority/owner checks — see [Auth conventions](#auth-conventions) |
+| `math` | Overflow-checked `i128`/`u32` arithmetic, including `checked_mul_div_i128` for proportional-share formulas |
+| `validation` | Positive-amount, percentage-bound, and future-timestamp guards |
+| `pausable` | Pause flag with auto-unpause |
+| `reentrancy` | Reentrancy lock |
+| `multisig` | N-of-M proposal flow |
+| `upgrade` | Timelocked WASM upgrade flow |
+| `errors` | `SharedError` — defined, not yet consumed (see issue #822) |
+
 ---
 
 ## `contracts/integration` — Not a Contract
@@ -574,6 +587,9 @@ Verified by grepping every `contracts/*/src/*.rs` for `invoke_contract` and `#[c
 - Every state-mutating function takes the acting party's `Address` as an explicit parameter and calls `<address>.require_auth()` as its first statement (e.g. `admin.require_auth()`, `payer.require_auth()`, `nft_owner.require_auth()`). There is no implicit `msg.sender`-style caller identity — the caller is always passed explicitly and Soroban verifies the corresponding signature was authorized for this invocation.
 - Read-only query functions (`get_*`, `is_*`, `has_*`, `list_*`) take no auth and require no `require_auth()` call.
 - Admin-gated functions additionally compare the passed address against a stored `Admin` (or, in `registry`, `Admin`-or-curator-set) value **after** calling `require_auth()`: `require_auth()` proves the caller controls that address; the storage comparison proves that address is *allowed* to perform the action. Both checks are required — `require_auth()` alone does not enforce authorization.
+- Since issue #825 both halves live in [`contracts/shared/src/access.rs`](../contracts/shared/src/access.rs) rather than being copied inline. Use `access::require_admin(&env, &caller, &DataKey::Admin)` in new code; it takes the storage key as a generic parameter so each contract keeps its own `DataKey` enum. The other helpers are `require_authority` (a non-admin authority slot such as `dispute`'s arbiter), `require_admin_or` (admin *or* a named party, e.g. an escrow payer), `require_owner` (per-resource ownership), `is_admin` (predicate, no auth and no panic — for building compound checks), and `read_authority` (the raw read, with a `"Not initialized"` message instead of a bare `.unwrap()`).
+- Admin-check failures panic with `"Unauthorized: admin required"`, authority-slot failures with `"Unauthorized: authority required"`, and ownership failures with `"Unauthorized: owner required"`. `registry` and `reputation` keep their own compound messages.
+- Depend on `brain-storm-shared` with `default-features = false`. Its `contract` feature compiles `SharedContract`'s `#[contractimpl]` block, which — if linked into another contract's wasm — would export `assign_role`, `upgrade`, and `pause_contract` from that contract, acting on its storage.
 - `market`, `registry`, and `shared` each implement their own local `pause`/`unpause`/`is_paused` — there is no shared on-chain pause registry. See [ADR-007](./adr/ADR-007-shared-crate-for-common-code.md) for why this pattern is currently copied per-contract rather than centralized.
 
 ### Error propagation across contract boundaries


### PR DESCRIPTION
…uidity_pool math

## Summary
- **Build fix**: `contracts/shared` referenced `reentrancy`/`validation` modules that were never declared — the crate (and everything depending on it) did not compile. Also adds the missing `contracts/royalty_distribution` workspace member.
- ** closes #825 **: extracts the copy-pasted `require_auth` → read stored admin → `assert!` triplet into `contracts/shared/src/access.rs`, migrated across 17 contracts (~48 call sites). `SharedContract` is now feature-gated so dependents don't accidentally re-export its admin entry points into their own wasm.
- ** closes #823 **: liquidity_pool arithmetic routed through `shared::math`'s checked helpers; fixes a division-by-zero in `remove_liquidity`, a silent-zero swap against an empty pool, saturating fee accumulation, and missing input guards.
- ** closes #822  note**: this issue's premise doesn't match the repo — there is exactly one `contracterror` enum (`SharedError`, unused elsewhere), so there's nothing to consolidate. Left open, flagged in the issue/PR discussion.
- ** closes #824  ** (nft storage footprint): not addressed in this PR.



## Test plan
- [ ] \`cargo check --workspace\`
- [ ] \`cargo test --workspace\`
- [ ] \`cargo build --target wasm32-unknown-unknown --release --workspace\` — confirms no contract's wasm exports \`SharedContract\`'s entry points
- [ ] Spot-check a couple of migrated \`should_panic\` tests match the new \`"Una