### PR TITLE
Feat/targeted unit tests p2

### DIFF
--- a/apps/backend/src/access-control/access-control.service.spec.ts
+++ b/apps/backend/src/access-control/access-control.service.spec.ts
@@ -1,0 +1,192 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { AccessControlService } from './access-control.service';
+import { CourseAccessControl, AccessRole } from './course-access-control.entity';
+import { AccessLog } from './access-log.entity';
+
+describe('AccessControlService', () => {
+  let service: AccessControlService;
+
+  const mockAccessRepo = {
+    create: jest.fn(),
+    save: jest.fn(),
+    findOne: jest.fn(),
+    find: jest.fn(),
+    update: jest.fn(),
+    createQueryBuilder: jest.fn(),
+  };
+  const mockLogRepo = {
+    create: jest.fn(),
+    save: jest.fn(),
+    createQueryBuilder: jest.fn(),
+  };
+
+  const makeAccess = (overrides: Partial<CourseAccessControl> = {}): CourseAccessControl =>
+    ({
+      id: 'ac-1',
+      courseId: 'c1',
+      userId: 'u1',
+      role: AccessRole.STUDENT,
+      isActive: true,
+      subscriptionExpiryDate: null,
+      allowedIpAddresses: null,
+      ...overrides,
+    } as CourseAccessControl);
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        AccessControlService,
+        { provide: getRepositoryToken(CourseAccessControl), useValue: mockAccessRepo },
+        { provide: getRepositoryToken(AccessLog), useValue: mockLogRepo },
+      ],
+    }).compile();
+    service = module.get<AccessControlService>(AccessControlService);
+  });
+
+  afterEach(() => jest.clearAllMocks());
+
+  // ── grantAccess ─────────────────────────────────────────────────────────────
+
+  describe('grantAccess', () => {
+    it('creates and saves an access record', async () => {
+      const access = makeAccess();
+      mockAccessRepo.create.mockReturnValue(access);
+      mockAccessRepo.save.mockResolvedValue(access);
+
+      const result = await service.grantAccess('c1', 'u1', AccessRole.STUDENT);
+
+      expect(mockAccessRepo.create).toHaveBeenCalledWith(
+        expect.objectContaining({ courseId: 'c1', userId: 'u1', role: AccessRole.STUDENT }),
+      );
+      expect(result).toEqual(access);
+    });
+
+    it('passes optional expiry and IP list to create', async () => {
+      const expiry = new Date('2030-01-01');
+      const ips = ['1.2.3.4'];
+      const access = makeAccess({ subscriptionExpiryDate: expiry, allowedIpAddresses: ips });
+      mockAccessRepo.create.mockReturnValue(access);
+      mockAccessRepo.save.mockResolvedValue(access);
+
+      await service.grantAccess('c1', 'u1', AccessRole.STUDENT, expiry, ips);
+
+      expect(mockAccessRepo.create).toHaveBeenCalledWith(
+        expect.objectContaining({ subscriptionExpiryDate: expiry, allowedIpAddresses: ips }),
+      );
+    });
+  });
+
+  // ── checkAccess ──────────────────────────────────────────────────────────────
+
+  describe('checkAccess', () => {
+    const logEntry = {};
+
+    beforeEach(() => {
+      mockLogRepo.create.mockReturnValue(logEntry);
+      mockLogRepo.save.mockResolvedValue(logEntry);
+    });
+
+    it('returns allowed:false with reason when no access record exists', async () => {
+      mockAccessRepo.findOne.mockResolvedValue(null);
+
+      const result = await service.checkAccess('c1', 'u1', '1.2.3.4');
+
+      expect(result).toEqual({ allowed: false, reason: 'No access granted' });
+    });
+
+    it('returns allowed:false when subscription is expired', async () => {
+      const access = makeAccess({ subscriptionExpiryDate: new Date('2000-01-01') });
+      mockAccessRepo.findOne.mockResolvedValue(access);
+
+      const result = await service.checkAccess('c1', 'u1', '1.2.3.4');
+
+      expect(result).toEqual({ allowed: false, reason: 'Subscription expired' });
+    });
+
+    it('returns allowed:false when IP is not in allowed list', async () => {
+      const access = makeAccess({ allowedIpAddresses: ['10.0.0.1'], subscriptionExpiryDate: null });
+      mockAccessRepo.findOne.mockResolvedValue(access);
+
+      const result = await service.checkAccess('c1', 'u1', '9.9.9.9');
+
+      expect(result).toEqual({ allowed: false, reason: 'IP not allowed' });
+    });
+
+    it('returns allowed:true when IP is in allowed list', async () => {
+      const access = makeAccess({ allowedIpAddresses: ['10.0.0.1'], subscriptionExpiryDate: null });
+      mockAccessRepo.findOne.mockResolvedValue(access);
+
+      const result = await service.checkAccess('c1', 'u1', '10.0.0.1');
+
+      expect(result).toEqual({ allowed: true });
+    });
+
+    it('returns allowed:true when no IP restriction is set', async () => {
+      const access = makeAccess({ allowedIpAddresses: null, subscriptionExpiryDate: null });
+      mockAccessRepo.findOne.mockResolvedValue(access);
+
+      const result = await service.checkAccess('c1', 'u1', '99.99.99.99');
+
+      expect(result).toEqual({ allowed: true });
+    });
+
+    it('returns allowed:true when IP list is empty (no restriction)', async () => {
+      const access = makeAccess({ allowedIpAddresses: [], subscriptionExpiryDate: null });
+      mockAccessRepo.findOne.mockResolvedValue(access);
+
+      const result = await service.checkAccess('c1', 'u1', '99.99.99.99');
+
+      expect(result).toEqual({ allowed: true });
+    });
+
+    it('returns allowed:true when subscription has a future expiry', async () => {
+      const access = makeAccess({ subscriptionExpiryDate: new Date('2099-01-01'), allowedIpAddresses: null });
+      mockAccessRepo.findOne.mockResolvedValue(access);
+
+      const result = await service.checkAccess('c1', 'u1');
+
+      expect(result).toEqual({ allowed: true });
+    });
+
+    it('logs each access check', async () => {
+      mockAccessRepo.findOne.mockResolvedValue(null);
+
+      await service.checkAccess('c1', 'u1', '1.2.3.4');
+
+      expect(mockLogRepo.create).toHaveBeenCalled();
+      expect(mockLogRepo.save).toHaveBeenCalled();
+    });
+  });
+
+  // ── revokeAccess ─────────────────────────────────────────────────────────────
+
+  describe('revokeAccess', () => {
+    it('sets isActive to false for the given course+user', async () => {
+      mockAccessRepo.update.mockResolvedValue({ affected: 1 });
+
+      await service.revokeAccess('c1', 'u1');
+
+      expect(mockAccessRepo.update).toHaveBeenCalledWith(
+        { courseId: 'c1', userId: 'u1' },
+        { isActive: false },
+      );
+    });
+  });
+
+  // ── updateSubscription ───────────────────────────────────────────────────────
+
+  describe('updateSubscription', () => {
+    it('updates the expiry date for the given course+user', async () => {
+      const expiry = new Date('2030-06-01');
+      mockAccessRepo.update.mockResolvedValue({ affected: 1 });
+
+      await service.updateSubscription('c1', 'u1', expiry);
+
+      expect(mockAccessRepo.update).toHaveBeenCalledWith(
+        { courseId: 'c1', userId: 'u1' },
+        { subscriptionExpiryDate: expiry },
+      );
+    });
+  });
+});

--- a/apps/backend/src/bookings/bookings.service.spec.ts
+++ b/apps/backend/src/bookings/bookings.service.spec.ts
@@ -1,0 +1,197 @@
+import { ConflictException, ForbiddenException, NotFoundException } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { BookingService } from './booking.service';
+import { BookingRequest, BookingStatus } from './booking-request.entity';
+import { AvailabilitySlot } from './availability-slot.entity';
+import { NotificationsService } from '../notifications/notifications.service';
+
+describe('BookingService', () => {
+  let service: BookingService;
+
+  const mockBookingRepo = {
+    create: jest.fn(),
+    save: jest.fn(),
+    findOne: jest.fn(),
+    find: jest.fn(),
+    createQueryBuilder: jest.fn(),
+  };
+  const mockSlotRepo = {
+    create: jest.fn(),
+    save: jest.fn(),
+    find: jest.fn(),
+    delete: jest.fn(),
+  };
+  const mockNotifications = { create: jest.fn().mockResolvedValue(undefined) };
+
+  const qb: any = {
+    where: jest.fn().mockReturnThis(),
+    andWhere: jest.fn().mockReturnThis(),
+    getOne: jest.fn(),
+  };
+
+  const makeBooking = (overrides: Partial<BookingRequest> = {}): BookingRequest =>
+    ({
+      id: 'b1',
+      requesterId: 'req-1',
+      workerId: 'wrk-1',
+      startTime: new Date('2030-01-01T09:00:00Z'),
+      endTime: new Date('2030-01-01T10:00:00Z'),
+      status: BookingStatus.PENDING,
+      ...overrides,
+    } as BookingRequest);
+
+  beforeEach(async () => {
+    mockBookingRepo.createQueryBuilder.mockReturnValue(qb);
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        BookingService,
+        { provide: getRepositoryToken(BookingRequest), useValue: mockBookingRepo },
+        { provide: getRepositoryToken(AvailabilitySlot), useValue: mockSlotRepo },
+        { provide: NotificationsService, useValue: mockNotifications },
+      ],
+    }).compile();
+
+    service = module.get<BookingService>(BookingService);
+    jest.spyOn((service as any).logger, 'log').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => jest.clearAllMocks());
+
+  // ── createBooking ────────────────────────────────────────────────────────────
+
+  describe('createBooking', () => {
+    it('creates a booking when no conflict exists', async () => {
+      const booking = makeBooking();
+      qb.getOne.mockResolvedValue(null); // no conflict
+      mockBookingRepo.create.mockReturnValue(booking);
+      mockBookingRepo.save.mockResolvedValue(booking);
+
+      const result = await service.createBooking(
+        'req-1', 'wrk-1', '2030-01-01T09:00:00Z', '2030-01-01T10:00:00Z',
+      );
+
+      expect(result).toEqual(booking);
+      expect(mockNotifications.create).toHaveBeenCalledTimes(2); // worker + requester
+    });
+
+    it('throws ConflictException when worker already has a confirmed booking', async () => {
+      qb.getOne.mockResolvedValue(makeBooking({ status: BookingStatus.CONFIRMED }));
+
+      await expect(
+        service.createBooking('req-1', 'wrk-1', '2030-01-01T09:00:00Z', '2030-01-01T10:00:00Z'),
+      ).rejects.toThrow(ConflictException);
+
+      expect(mockBookingRepo.save).not.toHaveBeenCalled();
+    });
+  });
+
+  // ── respondToBooking ─────────────────────────────────────────────────────────
+
+  describe('respondToBooking', () => {
+    it('confirms a pending booking when worker accepts', async () => {
+      const booking = makeBooking();
+      const saved = makeBooking({ status: BookingStatus.CONFIRMED });
+      mockBookingRepo.findOne.mockResolvedValue(booking);
+      mockBookingRepo.save.mockResolvedValue(saved);
+
+      const result = await service.respondToBooking('wrk-1', 'b1', true);
+
+      expect(booking.status).toBe(BookingStatus.CONFIRMED);
+      expect(result).toEqual(saved);
+      expect(mockNotifications.create).toHaveBeenCalledTimes(1);
+    });
+
+    it('rejects a pending booking when worker declines', async () => {
+      const booking = makeBooking();
+      const saved = makeBooking({ status: BookingStatus.REJECTED });
+      mockBookingRepo.findOne.mockResolvedValue(booking);
+      mockBookingRepo.save.mockResolvedValue(saved);
+
+      await service.respondToBooking('wrk-1', 'b1', false);
+
+      expect(booking.status).toBe(BookingStatus.REJECTED);
+    });
+
+    it('throws NotFoundException when booking not found', async () => {
+      mockBookingRepo.findOne.mockResolvedValue(null);
+
+      await expect(service.respondToBooking('wrk-1', 'missing', true)).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+
+    it('throws ForbiddenException when worker does not own the booking', async () => {
+      const booking = makeBooking({ workerId: 'other-worker' });
+      mockBookingRepo.findOne.mockResolvedValue(booking);
+
+      await expect(service.respondToBooking('wrk-1', 'b1', true)).rejects.toThrow(
+        ForbiddenException,
+      );
+    });
+
+    it('throws ConflictException when booking is no longer pending', async () => {
+      const booking = makeBooking({ status: BookingStatus.CONFIRMED });
+      mockBookingRepo.findOne.mockResolvedValue(booking);
+
+      await expect(service.respondToBooking('wrk-1', 'b1', true)).rejects.toThrow(
+        ConflictException,
+      );
+    });
+  });
+
+  // ── cancelBooking ─────────────────────────────────────────────────────────────
+
+  describe('cancelBooking', () => {
+    it('cancels a booking when requester cancels', async () => {
+      const booking = makeBooking();
+      const saved = makeBooking({ status: BookingStatus.CANCELLED });
+      mockBookingRepo.findOne.mockResolvedValue(booking);
+      mockBookingRepo.save.mockResolvedValue(saved);
+
+      const result = await service.cancelBooking('req-1', 'b1');
+
+      expect(booking.status).toBe(BookingStatus.CANCELLED);
+      expect(result).toEqual(saved);
+      expect(mockNotifications.create).toHaveBeenCalledTimes(1);
+    });
+
+    it('cancels a booking when worker cancels', async () => {
+      const booking = makeBooking();
+      mockBookingRepo.findOne.mockResolvedValue(booking);
+      mockBookingRepo.save.mockResolvedValue(booking);
+
+      await service.cancelBooking('wrk-1', 'b1');
+
+      expect(booking.status).toBe(BookingStatus.CANCELLED);
+    });
+
+    it('throws NotFoundException when booking not found', async () => {
+      mockBookingRepo.findOne.mockResolvedValue(null);
+
+      await expect(service.cancelBooking('req-1', 'missing')).rejects.toThrow(NotFoundException);
+    });
+
+    it('throws ForbiddenException when user is neither requester nor worker', async () => {
+      const booking = makeBooking();
+      mockBookingRepo.findOne.mockResolvedValue(booking);
+
+      await expect(service.cancelBooking('stranger', 'b1')).rejects.toThrow(ForbiddenException);
+    });
+
+    it('throws ConflictException when booking is already rejected', async () => {
+      const booking = makeBooking({ status: BookingStatus.REJECTED });
+      mockBookingRepo.findOne.mockResolvedValue(booking);
+
+      await expect(service.cancelBooking('req-1', 'b1')).rejects.toThrow(ConflictException);
+    });
+
+    it('throws ConflictException when booking is already cancelled', async () => {
+      const booking = makeBooking({ status: BookingStatus.CANCELLED });
+      mockBookingRepo.findOne.mockResolvedValue(booking);
+
+      await expect(service.cancelBooking('req-1', 'b1')).rejects.toThrow(ConflictException);
+    });
+  });
+});

--- a/apps/backend/src/coupons/coupons.service.spec.ts
+++ b/apps/backend/src/coupons/coupons.service.spec.ts
@@ -1,0 +1,247 @@
+import { BadRequestException, NotFoundException } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { CouponsService } from './coupons.service';
+import { Coupon } from './coupon.entity';
+import { CreateCouponDto, ValidateCouponDto } from './dto';
+
+describe('CouponsService', () => {
+  let service: CouponsService;
+
+  const mockRepo = {
+    findOne: jest.fn(),
+    find: jest.fn(),
+    create: jest.fn(),
+    save: jest.fn(),
+    increment: jest.fn(),
+    delete: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        CouponsService,
+        { provide: getRepositoryToken(Coupon), useValue: mockRepo },
+      ],
+    }).compile();
+
+    service = module.get<CouponsService>(CouponsService);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('create', () => {
+    const dto: CreateCouponDto = {
+      code: 'SAVE20',
+      discountType: 'percentage',
+      discountValue: 20,
+    };
+
+    it('creates a new coupon when code does not exist', async () => {
+      const created = { id: 'cp1', ...dto, isActive: true, usageCount: 0 } as unknown as Coupon;
+      mockRepo.findOne.mockResolvedValue(null);
+      mockRepo.create.mockReturnValue(created);
+      mockRepo.save.mockResolvedValue(created);
+
+      const result = await service.create(dto);
+
+      expect(mockRepo.findOne).toHaveBeenCalledWith({ where: { code: dto.code } });
+      expect(mockRepo.create).toHaveBeenCalledWith(expect.objectContaining({ code: dto.code }));
+      expect(result).toEqual(created);
+    });
+
+    it('converts expiresAt string to Date', async () => {
+      const expiresAt = '2030-01-01T00:00:00Z';
+      const dtoWithExpiry: CreateCouponDto = { ...dto, code: 'EXPIRY20', expiresAt };
+      const created = { id: 'cp2', ...dtoWithExpiry } as unknown as Coupon;
+      mockRepo.findOne.mockResolvedValue(null);
+      mockRepo.create.mockReturnValue(created);
+      mockRepo.save.mockResolvedValue(created);
+
+      await service.create(dtoWithExpiry);
+
+      expect(mockRepo.create).toHaveBeenCalledWith(
+        expect.objectContaining({ expiresAt: new Date(expiresAt) }),
+      );
+    });
+
+    it('sets expiresAt to null when not provided', async () => {
+      const created = { id: 'cp3', ...dto } as unknown as Coupon;
+      mockRepo.findOne.mockResolvedValue(null);
+      mockRepo.create.mockReturnValue(created);
+      mockRepo.save.mockResolvedValue(created);
+
+      await service.create(dto);
+
+      expect(mockRepo.create).toHaveBeenCalledWith(
+        expect.objectContaining({ expiresAt: null }),
+      );
+    });
+
+    it('throws BadRequestException when coupon code already exists', async () => {
+      const existing = { id: 'cp1', code: dto.code } as Coupon;
+      mockRepo.findOne.mockResolvedValue(existing);
+
+      await expect(service.create(dto)).rejects.toThrow(BadRequestException);
+      expect(mockRepo.save).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('validate', () => {
+    const validateDto: ValidateCouponDto = { code: 'SAVE20' };
+
+    it('returns valid discount for an active, unexpired coupon', async () => {
+      const coupon = {
+        code: 'SAVE20',
+        isActive: true,
+        expiresAt: null,
+        maxUsage: null,
+        usageCount: 0,
+        discountValue: 20,
+      } as Coupon;
+      mockRepo.findOne.mockResolvedValue(coupon);
+
+      const result = await service.validate(validateDto);
+
+      expect(result).toEqual({ valid: true, discount: 20 });
+    });
+
+    it('throws NotFoundException when coupon code does not exist', async () => {
+      mockRepo.findOne.mockResolvedValue(null);
+
+      await expect(service.validate(validateDto)).rejects.toThrow(NotFoundException);
+    });
+
+    it('throws BadRequestException when coupon is inactive', async () => {
+      const coupon = { code: 'SAVE20', isActive: false } as Coupon;
+      mockRepo.findOne.mockResolvedValue(coupon);
+
+      await expect(service.validate(validateDto)).rejects.toThrow(BadRequestException);
+    });
+
+    it('throws BadRequestException when coupon has expired', async () => {
+      const coupon = {
+        code: 'SAVE20',
+        isActive: true,
+        expiresAt: new Date('2000-01-01'), // past date
+        maxUsage: null,
+        usageCount: 0,
+      } as Coupon;
+      mockRepo.findOne.mockResolvedValue(coupon);
+
+      await expect(service.validate(validateDto)).rejects.toThrow(BadRequestException);
+    });
+
+    it('does not throw for coupon with future expiry', async () => {
+      const coupon = {
+        code: 'SAVE20',
+        isActive: true,
+        expiresAt: new Date('2099-12-31'),
+        maxUsage: null,
+        usageCount: 0,
+        discountValue: 20,
+      } as Coupon;
+      mockRepo.findOne.mockResolvedValue(coupon);
+
+      await expect(service.validate(validateDto)).resolves.toMatchObject({ valid: true });
+    });
+
+    it('throws BadRequestException when usage limit is reached', async () => {
+      const coupon = {
+        code: 'SAVE20',
+        isActive: true,
+        expiresAt: null,
+        maxUsage: 100,
+        usageCount: 100,
+      } as Coupon;
+      mockRepo.findOne.mockResolvedValue(coupon);
+
+      await expect(service.validate(validateDto)).rejects.toThrow(BadRequestException);
+    });
+
+    it('does not throw when usage is below the limit', async () => {
+      const coupon = {
+        code: 'SAVE20',
+        isActive: true,
+        expiresAt: null,
+        maxUsage: 100,
+        usageCount: 99,
+        discountValue: 15,
+      } as Coupon;
+      mockRepo.findOne.mockResolvedValue(coupon);
+
+      await expect(service.validate(validateDto)).resolves.toMatchObject({ valid: true, discount: 15 });
+    });
+
+    it('does not check usage limit when maxUsage is null', async () => {
+      const coupon = {
+        code: 'SAVE20',
+        isActive: true,
+        expiresAt: null,
+        maxUsage: null,
+        usageCount: 999,
+        discountValue: 10,
+      } as Coupon;
+      mockRepo.findOne.mockResolvedValue(coupon);
+
+      await expect(service.validate(validateDto)).resolves.toMatchObject({ valid: true });
+    });
+  });
+
+  describe('incrementUsage', () => {
+    it('increments usageCount by 1 for the given code', async () => {
+      mockRepo.increment.mockResolvedValue(undefined);
+
+      await service.incrementUsage('SAVE20');
+
+      expect(mockRepo.increment).toHaveBeenCalledWith({ code: 'SAVE20' }, 'usageCount', 1);
+    });
+  });
+
+  describe('findById', () => {
+    it('returns coupon when found', async () => {
+      const coupon = { id: 'cp1', code: 'SAVE20' } as Coupon;
+      mockRepo.findOne.mockResolvedValue(coupon);
+
+      const result = await service.findById('cp1');
+
+      expect(result).toEqual(coupon);
+    });
+
+    it('throws NotFoundException when id not found', async () => {
+      mockRepo.findOne.mockResolvedValue(null);
+
+      await expect(service.findById('nonexistent')).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('delete', () => {
+    it('deletes coupon when it exists', async () => {
+      mockRepo.delete.mockResolvedValue({ affected: 1 });
+
+      await service.delete('cp1');
+
+      expect(mockRepo.delete).toHaveBeenCalledWith('cp1');
+    });
+
+    it('throws NotFoundException when coupon does not exist', async () => {
+      mockRepo.delete.mockResolvedValue({ affected: 0 });
+
+      await expect(service.delete('nonexistent')).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('findAll', () => {
+    it('returns all coupons', async () => {
+      const coupons = [{ id: 'cp1' }, { id: 'cp2' }] as Coupon[];
+      mockRepo.find.mockResolvedValue(coupons);
+
+      const result = await service.findAll();
+
+      expect(result).toEqual(coupons);
+      expect(mockRepo.find).toHaveBeenCalledWith();
+    });
+  });
+});

--- a/apps/backend/src/credentials/credentials.service.spec.ts
+++ b/apps/backend/src/credentials/credentials.service.spec.ts
@@ -1,0 +1,150 @@
+import { ForbiddenException, NotFoundException } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { CredentialsService } from './credentials.service';
+import { Credential } from './credential.entity';
+import { StellarService } from '../stellar/stellar.service';
+import { KycService } from '../kyc/kyc.service';
+import { CoursesService } from '../courses/courses.service';
+
+describe('CredentialsService', () => {
+  let service: CredentialsService;
+
+  const mockRepo = {
+    findOne: jest.fn(),
+    create: jest.fn(),
+    save: jest.fn(),
+    find: jest.fn(),
+  };
+  const mockStellar = { issueCredential: jest.fn(), mintReward: jest.fn() };
+  const mockKyc = { isApproved: jest.fn() };
+  const mockCourses = { findOne: jest.fn() };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        CredentialsService,
+        { provide: getRepositoryToken(Credential), useValue: mockRepo },
+        { provide: StellarService, useValue: mockStellar },
+        { provide: KycService, useValue: mockKyc },
+        { provide: CoursesService, useValue: mockCourses },
+      ],
+    }).compile();
+    service = module.get<CredentialsService>(CredentialsService);
+  });
+
+  afterEach(() => jest.clearAllMocks());
+
+  describe('issue', () => {
+    const userId = 'u1', courseId = 'c1', key = 'GKEY';
+
+    it('returns existing credential without re-issuing (idempotent)', async () => {
+      const existing = { id: 'cred-1', userId, courseId } as Credential;
+      mockRepo.findOne.mockResolvedValue(existing);
+
+      const result = await service.issue(userId, courseId, key);
+
+      expect(result).toEqual(existing);
+      expect(mockStellar.issueCredential).not.toHaveBeenCalled();
+    });
+
+    it('issues credential when no KYC requirement', async () => {
+      mockRepo.findOne.mockResolvedValue(null);
+      mockCourses.findOne.mockResolvedValue({ id: courseId, requiresKyc: false });
+      mockStellar.issueCredential.mockResolvedValue('tx123');
+      mockStellar.mintReward.mockResolvedValue(undefined);
+      const cred = { id: 'cred-1', userId, courseId, txHash: 'tx123' } as Credential;
+      mockRepo.create.mockReturnValue(cred);
+      mockRepo.save.mockResolvedValue(cred);
+
+      const result = await service.issue(userId, courseId, key);
+
+      expect(mockStellar.issueCredential).toHaveBeenCalledWith(key, courseId);
+      expect(result).toEqual(cred);
+    });
+
+    it('issues credential when KYC required and user is approved', async () => {
+      mockRepo.findOne.mockResolvedValue(null);
+      mockCourses.findOne.mockResolvedValue({ id: courseId, requiresKyc: true });
+      mockKyc.isApproved.mockResolvedValue(true);
+      mockStellar.issueCredential.mockResolvedValue('tx456');
+      mockStellar.mintReward.mockResolvedValue(undefined);
+      const cred = { id: 'cred-2', userId, courseId } as Credential;
+      mockRepo.create.mockReturnValue(cred);
+      mockRepo.save.mockResolvedValue(cred);
+
+      await expect(service.issue(userId, courseId, key)).resolves.toEqual(cred);
+      expect(mockKyc.isApproved).toHaveBeenCalledWith(key);
+    });
+
+    it('throws ForbiddenException when KYC required but user not approved', async () => {
+      mockRepo.findOne.mockResolvedValue(null);
+      mockCourses.findOne.mockResolvedValue({ id: courseId, requiresKyc: true });
+      mockKyc.isApproved.mockResolvedValue(false);
+
+      await expect(service.issue(userId, courseId, key)).rejects.toThrow(ForbiddenException);
+      expect(mockStellar.issueCredential).not.toHaveBeenCalled();
+    });
+
+    it('saves credential even when mintReward fails (non-fatal)', async () => {
+      mockRepo.findOne.mockResolvedValue(null);
+      mockCourses.findOne.mockResolvedValue({ id: courseId, requiresKyc: false });
+      mockStellar.issueCredential.mockResolvedValue('tx789');
+      mockStellar.mintReward.mockRejectedValue(new Error('mint failed'));
+      const cred = { id: 'cred-3', userId, courseId } as Credential;
+      mockRepo.create.mockReturnValue(cred);
+      mockRepo.save.mockResolvedValue(cred);
+
+      await expect(service.issue(userId, courseId, key)).resolves.toEqual(cred);
+      expect(mockRepo.save).toHaveBeenCalled();
+    });
+  });
+
+  describe('findByUser', () => {
+    it('returns credentials ordered by issuedAt DESC', async () => {
+      const creds = [{ id: 'c1' }, { id: 'c2' }] as Credential[];
+      mockRepo.find.mockResolvedValue(creds);
+
+      const result = await service.findByUser('u1');
+
+      expect(result).toEqual(creds);
+      expect(mockRepo.find).toHaveBeenCalledWith({ where: { userId: 'u1' }, order: { issuedAt: 'DESC' } });
+    });
+  });
+
+  describe('findOne', () => {
+    it('returns credential with relations when found', async () => {
+      const cred = { id: 'c1', user: {}, course: {} } as unknown as Credential;
+      mockRepo.findOne.mockResolvedValue(cred);
+
+      const result = await service.findOne('c1');
+
+      expect(result).toEqual(cred);
+      expect(mockRepo.findOne).toHaveBeenCalledWith({ where: { id: 'c1' }, relations: ['user', 'course'] });
+    });
+
+    it('throws NotFoundException when credential not found', async () => {
+      mockRepo.findOne.mockResolvedValue(null);
+      await expect(service.findOne('missing')).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('verify', () => {
+    it('returns verified true when txHash matches', async () => {
+      const cred = { id: 'c1', txHash: 'txABC' } as Credential;
+      mockRepo.findOne.mockResolvedValue(cred);
+
+      const result = await service.verify('txABC');
+
+      expect(result).toEqual({ credential: cred, verified: true });
+    });
+
+    it('returns verified false when txHash not found', async () => {
+      mockRepo.findOne.mockResolvedValue(null);
+
+      const result = await service.verify('unknown-tx');
+
+      expect(result).toEqual({ credential: null, verified: false });
+    });
+  });
+});

--- a/apps/backend/src/enrollments/enrollments.service.spec.ts
+++ b/apps/backend/src/enrollments/enrollments.service.spec.ts
@@ -1,0 +1,198 @@
+import { ConflictException, NotFoundException } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { EventEmitter2 } from '@nestjs/event-emitter';
+import { EnrollmentsService } from './enrollments.service';
+import { Enrollment } from './enrollment.entity';
+import { PrerequisitesService } from '../courses/prerequisites.service';
+
+describe('EnrollmentsService', () => {
+  let service: EnrollmentsService;
+
+  const mockRepo = {
+    findOne: jest.fn(),
+    create: jest.fn(),
+    save: jest.fn(),
+    find: jest.fn(),
+    remove: jest.fn(),
+  };
+
+  const mockEventEmitter = {
+    emit: jest.fn(),
+  };
+
+  const mockPrereqService = {
+    enforcePrerequisites: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        EnrollmentsService,
+        { provide: getRepositoryToken(Enrollment), useValue: mockRepo },
+        { provide: EventEmitter2, useValue: mockEventEmitter },
+        { provide: PrerequisitesService, useValue: mockPrereqService },
+      ],
+    }).compile();
+
+    service = module.get<EnrollmentsService>(EnrollmentsService);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('enroll', () => {
+    const userId = 'user-1';
+    const courseId = 'course-1';
+
+    it('creates a new enrollment on the happy path', async () => {
+      const created = { id: 'enr-1', userId, courseId, enrolledAt: new Date() } as Enrollment;
+
+      mockRepo.findOne.mockResolvedValue(null);
+      mockPrereqService.enforcePrerequisites.mockResolvedValue(undefined);
+      mockRepo.create.mockReturnValue(created);
+      mockRepo.save.mockResolvedValue(created);
+
+      const result = await service.enroll(userId, courseId);
+
+      expect(mockRepo.findOne).toHaveBeenCalledWith({ where: { userId, courseId } });
+      expect(mockPrereqService.enforcePrerequisites).toHaveBeenCalledWith(userId, courseId, false);
+      expect(mockRepo.create).toHaveBeenCalledWith({ userId, courseId });
+      expect(mockRepo.save).toHaveBeenCalledWith(created);
+      expect(result).toEqual(created);
+    });
+
+    it('emits enrollment.created event on successful enroll', async () => {
+      const created = { id: 'enr-1', userId, courseId, enrolledAt: new Date() } as Enrollment;
+
+      mockRepo.findOne.mockResolvedValue(null);
+      mockPrereqService.enforcePrerequisites.mockResolvedValue(undefined);
+      mockRepo.create.mockReturnValue(created);
+      mockRepo.save.mockResolvedValue(created);
+
+      await service.enroll(userId, courseId);
+
+      expect(mockEventEmitter.emit).toHaveBeenCalledWith('enrollment.created', {
+        enrollmentId: created.id,
+        userId,
+        courseId,
+        enrolledAt: created.enrolledAt,
+      });
+    });
+
+    it('throws ConflictException when already enrolled', async () => {
+      const existing = { id: 'enr-1', userId, courseId } as Enrollment;
+      mockRepo.findOne.mockResolvedValue(existing);
+
+      await expect(service.enroll(userId, courseId)).rejects.toThrow(ConflictException);
+      expect(mockPrereqService.enforcePrerequisites).not.toHaveBeenCalled();
+      expect(mockRepo.save).not.toHaveBeenCalled();
+    });
+
+    it('passes adminOverride flag to prerequisites check', async () => {
+      const created = { id: 'enr-1', userId, courseId, enrolledAt: new Date() } as Enrollment;
+
+      mockRepo.findOne.mockResolvedValue(null);
+      mockPrereqService.enforcePrerequisites.mockResolvedValue(undefined);
+      mockRepo.create.mockReturnValue(created);
+      mockRepo.save.mockResolvedValue(created);
+
+      await service.enroll(userId, courseId, true);
+
+      expect(mockPrereqService.enforcePrerequisites).toHaveBeenCalledWith(userId, courseId, true);
+    });
+  });
+
+  describe('unenroll', () => {
+    it('removes enrollment when found', async () => {
+      const enrollment = { id: 'enr-1', userId: 'u1', courseId: 'c1' } as Enrollment;
+      mockRepo.findOne.mockResolvedValue(enrollment);
+      mockRepo.remove.mockResolvedValue(enrollment);
+
+      await service.unenroll('u1', 'c1');
+
+      expect(mockRepo.findOne).toHaveBeenCalledWith({ where: { userId: 'u1', courseId: 'c1' } });
+      expect(mockRepo.remove).toHaveBeenCalledWith(enrollment);
+    });
+
+    it('throws NotFoundException when enrollment not found', async () => {
+      mockRepo.findOne.mockResolvedValue(null);
+
+      await expect(service.unenroll('u1', 'missing-course')).rejects.toThrow(NotFoundException);
+      expect(mockRepo.remove).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('findById', () => {
+    it('returns enrollment with relations when found', async () => {
+      const enrollment = {
+        id: 'enr-1',
+        userId: 'u1',
+        courseId: 'c1',
+        user: { id: 'u1' },
+        course: { id: 'c1' },
+      } as unknown as Enrollment;
+
+      mockRepo.findOne.mockResolvedValue(enrollment);
+
+      const result = await service.findById('enr-1');
+
+      expect(mockRepo.findOne).toHaveBeenCalledWith({
+        where: { id: 'enr-1' },
+        relations: ['user', 'course'],
+      });
+      expect(result).toEqual(enrollment);
+    });
+
+    it('throws NotFoundException when enrollment id not found', async () => {
+      mockRepo.findOne.mockResolvedValue(null);
+
+      await expect(service.findById('nonexistent')).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('deleteById', () => {
+    it('removes enrollment found by id', async () => {
+      const enrollment = { id: 'enr-1', userId: 'u1', courseId: 'c1' } as Enrollment;
+      // findById is called internally, which calls repo.findOne with relations
+      mockRepo.findOne.mockResolvedValue(enrollment);
+      mockRepo.remove.mockResolvedValue(enrollment);
+
+      await service.deleteById('enr-1');
+
+      expect(mockRepo.remove).toHaveBeenCalledWith(enrollment);
+    });
+
+    it('throws NotFoundException when id does not exist', async () => {
+      mockRepo.findOne.mockResolvedValue(null);
+
+      await expect(service.deleteById('missing')).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('findByUser', () => {
+    it('returns all enrollments for user ordered by enrolledAt DESC', async () => {
+      const enrollments = [
+        { id: 'enr-1', userId: 'u1', course: {} } as Enrollment,
+        { id: 'enr-2', userId: 'u1', course: {} } as Enrollment,
+      ];
+      mockRepo.find.mockResolvedValue(enrollments);
+
+      const result = await service.findByUser('u1');
+
+      expect(result).toEqual(enrollments);
+      expect(mockRepo.find).toHaveBeenCalledWith({
+        where: { userId: 'u1' },
+        relations: ['course'],
+        order: { enrolledAt: 'DESC' },
+      });
+    });
+
+    it('returns empty array when user has no enrollments', async () => {
+      mockRepo.find.mockResolvedValue([]);
+      const result = await service.findByUser('u1');
+      expect(result).toEqual([]);
+    });
+  });
+});

--- a/apps/backend/src/forums/forums.service.spec.ts
+++ b/apps/backend/src/forums/forums.service.spec.ts
@@ -1,0 +1,199 @@
+import { ForbiddenException, NotFoundException } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { ForumsService } from './forums.service';
+import { Post } from './post.entity';
+import { Reply } from './reply.entity';
+import { Course } from '../courses/course.entity';
+import { ModerationService } from '../moderation/moderation.service';
+import { SearchService } from '../search/search.service';
+import { CreatePostDto } from './dto/create-post.dto';
+import { CreateReplyDto } from './dto/create-reply.dto';
+
+describe('ForumsService', () => {
+  let service: ForumsService;
+
+  const mockPostRepo = {
+    create: jest.fn(), save: jest.fn(), findOne: jest.fn(), find: jest.fn(), update: jest.fn(),
+  };
+  const mockReplyRepo = {
+    create: jest.fn(), save: jest.fn(), update: jest.fn(),
+  };
+  const mockCourseRepo = { findOne: jest.fn() };
+  const mockModerationService = { analyzeContent: jest.fn().mockResolvedValue(false) };
+  const mockSearchService = { indexPost: jest.fn().mockResolvedValue(undefined) };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ForumsService,
+        { provide: getRepositoryToken(Post), useValue: mockPostRepo },
+        { provide: getRepositoryToken(Reply), useValue: mockReplyRepo },
+        { provide: getRepositoryToken(Course), useValue: mockCourseRepo },
+        { provide: ModerationService, useValue: mockModerationService },
+        { provide: SearchService, useValue: mockSearchService },
+      ],
+    }).compile();
+    service = module.get<ForumsService>(ForumsService);
+  });
+
+  afterEach(() => jest.clearAllMocks());
+
+  // ── createPost ───────────────────────────────────────────────────────────────
+
+  describe('createPost', () => {
+    const courseId = 'c1', userId = 'u1';
+    const dto: CreatePostDto = { title: 'Help', content: 'Question here', isPinned: false };
+
+    it('creates a post for any role when not pinning', async () => {
+      mockCourseRepo.findOne.mockResolvedValue({ id: courseId });
+      const post = { id: 'p1', courseId, userId, isPinned: false } as Post;
+      mockPostRepo.create.mockReturnValue(post);
+      mockPostRepo.save.mockResolvedValue(post);
+
+      const result = await service.createPost(courseId, userId, 'student', dto);
+
+      expect(mockPostRepo.create).toHaveBeenCalledWith(
+        expect.objectContaining({ courseId, userId, isPinned: false }),
+      );
+      expect(result).toEqual(post);
+    });
+
+    it('allows instructor to create a pinned post', async () => {
+      mockCourseRepo.findOne.mockResolvedValue({ id: courseId });
+      const pinnedDto: CreatePostDto = { title: 'Announcement', content: 'Read this', isPinned: true };
+      const post = { id: 'p2', courseId, userId, isPinned: true } as Post;
+      mockPostRepo.create.mockReturnValue(post);
+      mockPostRepo.save.mockResolvedValue(post);
+
+      const result = await service.createPost(courseId, userId, 'instructor', pinnedDto);
+
+      expect(mockPostRepo.create).toHaveBeenCalledWith(
+        expect.objectContaining({ isPinned: true }),
+      );
+      expect(result).toEqual(post);
+    });
+
+    it('allows admin to create a pinned post', async () => {
+      mockCourseRepo.findOne.mockResolvedValue({ id: courseId });
+      const pinnedDto: CreatePostDto = { title: 'Notice', content: 'Important', isPinned: true };
+      const post = { id: 'p3', courseId, userId, isPinned: true } as Post;
+      mockPostRepo.create.mockReturnValue(post);
+      mockPostRepo.save.mockResolvedValue(post);
+
+      await expect(service.createPost(courseId, userId, 'admin', pinnedDto)).resolves.toEqual(post);
+    });
+
+    it('throws ForbiddenException when student tries to pin a post', async () => {
+      mockCourseRepo.findOne.mockResolvedValue({ id: courseId });
+      const pinnedDto: CreatePostDto = { title: 'Pin me', content: 'Nope', isPinned: true };
+
+      await expect(service.createPost(courseId, userId, 'student', pinnedDto)).rejects.toThrow(
+        ForbiddenException,
+      );
+      expect(mockPostRepo.save).not.toHaveBeenCalled();
+    });
+
+    it('throws NotFoundException when course does not exist', async () => {
+      mockCourseRepo.findOne.mockResolvedValue(null);
+
+      await expect(service.createPost('nonexistent', userId, 'student', dto)).rejects.toThrow(
+        NotFoundException,
+      );
+      expect(mockPostRepo.save).not.toHaveBeenCalled();
+    });
+
+    it('runs moderation analysis after saving', async () => {
+      mockCourseRepo.findOne.mockResolvedValue({ id: courseId });
+      const post = { id: 'p1', courseId, userId, title: 'Help', content: 'Question here' } as Post;
+      mockPostRepo.create.mockReturnValue(post);
+      mockPostRepo.save.mockResolvedValue(post);
+
+      await service.createPost(courseId, userId, 'student', dto);
+
+      expect(mockModerationService.analyzeContent).toHaveBeenCalled();
+    });
+  });
+
+  // ── createReply ──────────────────────────────────────────────────────────────
+
+  describe('createReply', () => {
+    const postId = 'p1', userId = 'u1';
+    const dto: CreateReplyDto = { content: 'My reply', isAnswer: false };
+
+    it('creates a reply when post exists', async () => {
+      const post = { id: postId, courseId: 'c1' } as Post;
+      const reply = { id: 'r1', postId, userId, content: 'My reply', isAnswer: false } as Reply;
+      mockPostRepo.findOne.mockResolvedValue(post);
+      mockReplyRepo.create.mockReturnValue(reply);
+      mockReplyRepo.save.mockResolvedValue(reply);
+
+      const result = await service.createReply(postId, userId, 'student', dto);
+
+      expect(result).toEqual(reply);
+    });
+
+    it('throws NotFoundException when post does not exist', async () => {
+      mockPostRepo.findOne.mockResolvedValue(null);
+
+      await expect(service.createReply('missing', userId, 'student', dto)).rejects.toThrow(
+        NotFoundException,
+      );
+      expect(mockReplyRepo.save).not.toHaveBeenCalled();
+    });
+
+    it('throws ForbiddenException when student tries to mark answer', async () => {
+      const post = { id: postId, courseId: 'c1' } as Post;
+      mockPostRepo.findOne.mockResolvedValue(post);
+      const answerDto: CreateReplyDto = { content: 'Answer', isAnswer: true };
+
+      await expect(service.createReply(postId, userId, 'student', answerDto)).rejects.toThrow(
+        ForbiddenException,
+      );
+    });
+
+    it('allows instructor to mark a reply as the answer', async () => {
+      const post = { id: postId, courseId: 'c1' } as Post;
+      const reply = { id: 'r1', postId, userId, content: 'Correct!', isAnswer: true } as Reply;
+      mockPostRepo.findOne.mockResolvedValue(post);
+      mockReplyRepo.update.mockResolvedValue(undefined);
+      mockReplyRepo.create.mockReturnValue(reply);
+      mockReplyRepo.save.mockResolvedValue(reply);
+      mockPostRepo.save.mockResolvedValue(post);
+
+      const answerDto: CreateReplyDto = { content: 'Correct!', isAnswer: true };
+      const result = await service.createReply(postId, userId, 'instructor', answerDto);
+
+      // Previous answers cleared
+      expect(mockReplyRepo.update).toHaveBeenCalledWith(
+        { postId, isAnswer: true },
+        { isAnswer: false },
+      );
+      expect(result).toEqual(reply);
+    });
+  });
+
+  // ── findPostsByCourse ─────────────────────────────────────────────────────────
+
+  describe('findPostsByCourse', () => {
+    it('throws NotFoundException when course does not exist', async () => {
+      mockCourseRepo.findOne.mockResolvedValue(null);
+
+      await expect(service.findPostsByCourse('nonexistent')).rejects.toThrow(NotFoundException);
+    });
+
+    it('returns posts ordered by isPinned and createdAt', async () => {
+      const course = { id: 'c1' } as Course;
+      const posts = [{ id: 'p1', isPinned: true }, { id: 'p2', isPinned: false }] as Post[];
+      mockCourseRepo.findOne.mockResolvedValue(course);
+      mockPostRepo.find.mockResolvedValue(posts);
+
+      const result = await service.findPostsByCourse('c1');
+
+      expect(result).toEqual(posts);
+      expect(mockPostRepo.find).toHaveBeenCalledWith(
+        expect.objectContaining({ order: { isPinned: 'DESC', createdAt: 'DESC' } }),
+      );
+    });
+  });
+});

--- a/apps/backend/src/moderation/moderation.service.spec.ts
+++ b/apps/backend/src/moderation/moderation.service.spec.ts
@@ -1,0 +1,356 @@
+import { BadRequestException, NotFoundException } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { ConfigService } from '@nestjs/config';
+import { ModerationService } from './moderation.service';
+import { ModerationItem } from './moderation-item.entity';
+import { ModerationLog } from './moderation-log.entity';
+import { ContentType, ModerationAction, ModerationStatus } from './moderation.enums';
+import { FlagContentDto, ReviewItemDto, AppealDto } from './dto/moderation.dto';
+
+// Prevent real AWS Comprehend client instantiation
+jest.mock('@aws-sdk/client-comprehend', () => ({
+  ComprehendClient: jest.fn().mockImplementation(() => ({
+    send: jest.fn(),
+  })),
+  DetectToxicContentCommand: jest.fn(),
+}));
+
+describe('ModerationService', () => {
+  let service: ModerationService;
+
+  const mockItemRepo = {
+    findOne: jest.fn(),
+    find: jest.fn(),
+    create: jest.fn(),
+    save: jest.fn(),
+  };
+
+  const mockLogRepo = {
+    create: jest.fn(),
+    save: jest.fn(),
+    find: jest.fn(),
+  };
+
+  const mockConfigService = {
+    get: jest.fn((key: string) => {
+      const config: Record<string, unknown> = {
+        'aws.region': 'us-east-1',
+        'aws.accessKeyId': 'test-key',
+        'aws.secretAccessKey': 'test-secret',
+        'moderation.toxicityThreshold': 0.7,
+      };
+      return config[key];
+    }),
+  };
+
+  const makeItem = (overrides: Partial<ModerationItem> = {}): ModerationItem =>
+    ({
+      id: 'item-1',
+      contentType: ContentType.POST,
+      contentId: 'post-1',
+      reportedByUserId: 'user-reporter',
+      status: ModerationStatus.PENDING,
+      flagReason: null,
+      toxicityScore: null,
+      comprehendResult: null,
+      reviewedByUserId: null,
+      reviewNote: null,
+      appealReason: null,
+      appealedByUserId: null,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      ...overrides,
+    } as ModerationItem);
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ModerationService,
+        { provide: getRepositoryToken(ModerationItem), useValue: mockItemRepo },
+        { provide: getRepositoryToken(ModerationLog), useValue: mockLogRepo },
+        { provide: ConfigService, useValue: mockConfigService },
+      ],
+    }).compile();
+
+    service = module.get<ModerationService>(ModerationService);
+    // Silence logger noise in test output
+    jest.spyOn((service as any).logger, 'warn').mockImplementation(() => undefined);
+    jest.spyOn((service as any).logger, 'error').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  // ── flagContent ─────────────────────────────────────────────────────────────
+
+  describe('flagContent', () => {
+    const flagDto: FlagContentDto = {
+      contentType: ContentType.POST,
+      contentId: 'post-1',
+      reason: 'Spam',
+    };
+    const userId = 'user-reporter';
+
+    it('creates a new moderation item when content is not already flagged', async () => {
+      const newItem = makeItem();
+      mockItemRepo.findOne.mockResolvedValue(null);
+      mockItemRepo.create.mockReturnValue(newItem);
+      mockItemRepo.save.mockResolvedValue(newItem);
+      mockLogRepo.create.mockReturnValue({});
+      mockLogRepo.save.mockResolvedValue({});
+
+      const result = await service.flagContent(flagDto, userId);
+
+      expect(mockItemRepo.findOne).toHaveBeenCalledWith({
+        where: {
+          contentType: flagDto.contentType,
+          contentId: flagDto.contentId,
+          status: ModerationStatus.PENDING,
+        },
+      });
+      expect(mockItemRepo.create).toHaveBeenCalledWith(
+        expect.objectContaining({ contentId: flagDto.contentId, reportedByUserId: userId }),
+      );
+      expect(result).toEqual(newItem);
+    });
+
+    it('returns existing item when content is already pending review', async () => {
+      const existing = makeItem();
+      mockItemRepo.findOne.mockResolvedValue(existing);
+
+      const result = await service.flagContent(flagDto, userId);
+
+      expect(mockItemRepo.create).not.toHaveBeenCalled();
+      expect(mockItemRepo.save).not.toHaveBeenCalled();
+      expect(result).toEqual(existing);
+    });
+
+    it('logs the flag action on new item creation', async () => {
+      const newItem = makeItem();
+      mockItemRepo.findOne.mockResolvedValue(null);
+      mockItemRepo.create.mockReturnValue(newItem);
+      mockItemRepo.save.mockResolvedValue(newItem);
+      mockLogRepo.create.mockReturnValue({});
+      mockLogRepo.save.mockResolvedValue({});
+
+      await service.flagContent(flagDto, userId);
+
+      expect(mockLogRepo.create).toHaveBeenCalledWith(
+        expect.objectContaining({ action: ModerationAction.FLAG }),
+      );
+      expect(mockLogRepo.save).toHaveBeenCalled();
+    });
+  });
+
+  // ── reviewItem ──────────────────────────────────────────────────────────────
+
+  describe('reviewItem', () => {
+    const adminId = 'admin-1';
+
+    it('approves a pending item', async () => {
+      const item = makeItem({ status: ModerationStatus.PENDING });
+      const saved = makeItem({ status: ModerationStatus.APPROVED, reviewedByUserId: adminId });
+
+      mockItemRepo.findOne.mockResolvedValue(item);
+      mockItemRepo.save.mockResolvedValue(saved);
+      mockLogRepo.create.mockReturnValue({});
+      mockLogRepo.save.mockResolvedValue({});
+
+      const dto: ReviewItemDto = { status: ModerationStatus.APPROVED };
+      const result = await service.reviewItem('item-1', dto, adminId);
+
+      expect(item.status).toBe(ModerationStatus.APPROVED);
+      expect(item.reviewedByUserId).toBe(adminId);
+      expect(result).toEqual(saved);
+    });
+
+    it('rejects a pending item', async () => {
+      const item = makeItem({ status: ModerationStatus.PENDING });
+      const saved = makeItem({ status: ModerationStatus.REJECTED });
+
+      mockItemRepo.findOne.mockResolvedValue(item);
+      mockItemRepo.save.mockResolvedValue(saved);
+      mockLogRepo.create.mockReturnValue({});
+      mockLogRepo.save.mockResolvedValue({});
+
+      const dto: ReviewItemDto = { status: ModerationStatus.REJECTED, note: 'Policy violation' };
+      await service.reviewItem('item-1', dto, adminId);
+
+      expect(item.reviewNote).toBe('Policy violation');
+    });
+
+    it('can review an APPEALED item', async () => {
+      const item = makeItem({ status: ModerationStatus.APPEALED });
+      const saved = makeItem({ status: ModerationStatus.APPROVED });
+
+      mockItemRepo.findOne.mockResolvedValue(item);
+      mockItemRepo.save.mockResolvedValue(saved);
+      mockLogRepo.create.mockReturnValue({});
+      mockLogRepo.save.mockResolvedValue({});
+
+      const dto: ReviewItemDto = { status: ModerationStatus.APPROVED };
+      await expect(service.reviewItem('item-1', dto, adminId)).resolves.toBeDefined();
+    });
+
+    it('throws BadRequestException when item is already approved (not pending)', async () => {
+      const item = makeItem({ status: ModerationStatus.APPROVED });
+      mockItemRepo.findOne.mockResolvedValue(item);
+
+      const dto: ReviewItemDto = { status: ModerationStatus.APPROVED };
+      await expect(service.reviewItem('item-1', dto, adminId)).rejects.toThrow(BadRequestException);
+    });
+
+    it('throws NotFoundException when item does not exist', async () => {
+      mockItemRepo.findOne.mockResolvedValue(null);
+
+      const dto: ReviewItemDto = { status: ModerationStatus.APPROVED };
+      await expect(service.reviewItem('nonexistent', dto, adminId)).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  // ── submitAppeal ────────────────────────────────────────────────────────────
+
+  describe('submitAppeal', () => {
+    const userId = 'content-owner';
+    const appealDto: AppealDto = { reason: 'I believe this was flagged in error' };
+
+    it('submits an appeal on a rejected item', async () => {
+      const item = makeItem({ status: ModerationStatus.REJECTED });
+      const saved = makeItem({ status: ModerationStatus.APPEALED, appealedByUserId: userId });
+
+      mockItemRepo.findOne.mockResolvedValue(item);
+      mockItemRepo.save.mockResolvedValue(saved);
+      mockLogRepo.create.mockReturnValue({});
+      mockLogRepo.save.mockResolvedValue({});
+
+      const result = await service.submitAppeal('item-1', appealDto, userId);
+
+      expect(item.status).toBe(ModerationStatus.APPEALED);
+      expect(item.appealReason).toBe(appealDto.reason);
+      expect(item.appealedByUserId).toBe(userId);
+      expect(result).toEqual(saved);
+    });
+
+    it('throws BadRequestException when item is not rejected', async () => {
+      const item = makeItem({ status: ModerationStatus.PENDING });
+      mockItemRepo.findOne.mockResolvedValue(item);
+
+      await expect(service.submitAppeal('item-1', appealDto, userId)).rejects.toThrow(BadRequestException);
+    });
+
+    it('throws BadRequestException when appeal already submitted', async () => {
+      const item = makeItem({
+        status: ModerationStatus.REJECTED,
+        appealedByUserId: 'existing-appealer',
+      });
+      mockItemRepo.findOne.mockResolvedValue(item);
+
+      await expect(service.submitAppeal('item-1', appealDto, userId)).rejects.toThrow(BadRequestException);
+    });
+
+    it('throws NotFoundException when item does not exist', async () => {
+      mockItemRepo.findOne.mockResolvedValue(null);
+
+      await expect(service.submitAppeal('nonexistent', appealDto, userId)).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  // ── resolveAppeal ───────────────────────────────────────────────────────────
+
+  describe('resolveAppeal', () => {
+    const adminId = 'admin-1';
+
+    it('approves an appeal (approve=true sets status to APPROVED)', async () => {
+      const item = makeItem({ status: ModerationStatus.APPEALED });
+      const saved = makeItem({ status: ModerationStatus.APPROVED });
+
+      mockItemRepo.findOne.mockResolvedValue(item);
+      mockItemRepo.save.mockResolvedValue(saved);
+      mockLogRepo.create.mockReturnValue({});
+      mockLogRepo.save.mockResolvedValue({});
+
+      const result = await service.resolveAppeal('item-1', true, adminId);
+
+      expect(item.status).toBe(ModerationStatus.APPROVED);
+      expect(result).toEqual(saved);
+    });
+
+    it('rejects an appeal (approve=false keeps status REJECTED)', async () => {
+      const item = makeItem({ status: ModerationStatus.APPEALED });
+      const saved = makeItem({ status: ModerationStatus.REJECTED });
+
+      mockItemRepo.findOne.mockResolvedValue(item);
+      mockItemRepo.save.mockResolvedValue(saved);
+      mockLogRepo.create.mockReturnValue({});
+      mockLogRepo.save.mockResolvedValue({});
+
+      const result = await service.resolveAppeal('item-1', false, adminId, 'Still in violation');
+
+      expect(item.status).toBe(ModerationStatus.REJECTED);
+      expect(item.reviewNote).toBe('Still in violation');
+      expect(result).toEqual(saved);
+    });
+
+    it('throws BadRequestException when item is not under appeal', async () => {
+      const item = makeItem({ status: ModerationStatus.REJECTED });
+      mockItemRepo.findOne.mockResolvedValue(item);
+
+      await expect(service.resolveAppeal('item-1', true, adminId)).rejects.toThrow(BadRequestException);
+    });
+
+    it('throws NotFoundException when item does not exist', async () => {
+      mockItemRepo.findOne.mockResolvedValue(null);
+
+      await expect(service.resolveAppeal('nonexistent', true, adminId)).rejects.toThrow(NotFoundException);
+    });
+
+    it('logs APPEAL_APPROVED action when appeal is approved', async () => {
+      const item = makeItem({ status: ModerationStatus.APPEALED });
+      mockItemRepo.findOne.mockResolvedValue(item);
+      mockItemRepo.save.mockResolvedValue(item);
+      mockLogRepo.create.mockReturnValue({});
+      mockLogRepo.save.mockResolvedValue({});
+
+      await service.resolveAppeal('item-1', true, adminId);
+
+      expect(mockLogRepo.create).toHaveBeenCalledWith(
+        expect.objectContaining({ action: ModerationAction.APPEAL_APPROVED }),
+      );
+    });
+
+    it('logs APPEAL_REJECTED action when appeal is rejected', async () => {
+      const item = makeItem({ status: ModerationStatus.APPEALED });
+      mockItemRepo.findOne.mockResolvedValue(item);
+      mockItemRepo.save.mockResolvedValue(item);
+      mockLogRepo.create.mockReturnValue({});
+      mockLogRepo.save.mockResolvedValue({});
+
+      await service.resolveAppeal('item-1', false, adminId);
+
+      expect(mockLogRepo.create).toHaveBeenCalledWith(
+        expect.objectContaining({ action: ModerationAction.APPEAL_REJECTED }),
+      );
+    });
+  });
+
+  // ── getItemOrThrow ──────────────────────────────────────────────────────────
+
+  describe('getItemOrThrow', () => {
+    it('returns item when found', async () => {
+      const item = makeItem();
+      mockItemRepo.findOne.mockResolvedValue(item);
+
+      const result = await service.getItemOrThrow('item-1');
+
+      expect(result).toEqual(item);
+    });
+
+    it('throws NotFoundException when item not found', async () => {
+      mockItemRepo.findOne.mockResolvedValue(null);
+
+      await expect(service.getItemOrThrow('missing')).rejects.toThrow(NotFoundException);
+    });
+  });
+});

--- a/apps/backend/src/notifications/notifications.service.spec.ts
+++ b/apps/backend/src/notifications/notifications.service.spec.ts
@@ -1,0 +1,274 @@
+import { NotFoundException } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { NotificationsService } from './notifications.service';
+import { Notification, NotificationType } from './notification.entity';
+import { NotificationPreference } from './notification-preference.entity';
+import { ScheduledNotification, ScheduledNotificationStatus } from './scheduled-notification.entity';
+import { NotificationsGateway } from './notifications.gateway';
+import { MailService } from '../mail/mail.service';
+
+describe('NotificationsService', () => {
+  let service: NotificationsService;
+
+  const mockNotificationRepo = {
+    create: jest.fn(),
+    save: jest.fn(),
+    find: jest.fn(),
+    findOne: jest.fn(),
+    update: jest.fn(),
+  };
+
+  const mockPrefRepo = {
+    create: jest.fn(),
+    save: jest.fn(),
+    findOne: jest.fn(),
+  };
+
+  const mockScheduledRepo = {
+    create: jest.fn(),
+    save: jest.fn(),
+    findOne: jest.fn(),
+    find: jest.fn(),
+  };
+
+  const mockGateway = {
+    emitToUser: jest.fn(),
+  };
+
+  const mockMailService = {
+    sendMail: jest.fn(),
+  };
+
+  const makePrefs = (overrides: Partial<NotificationPreference> = {}): NotificationPreference =>
+    ({
+      id: 'pref-1',
+      userId: 'user-1',
+      inApp: true,
+      email: true,
+      push: false,
+      enrollment: true,
+      completion: true,
+      credentialIssued: true,
+      coursePublished: true,
+      ...overrides,
+    } as NotificationPreference);
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        NotificationsService,
+        { provide: getRepositoryToken(Notification), useValue: mockNotificationRepo },
+        { provide: getRepositoryToken(NotificationPreference), useValue: mockPrefRepo },
+        { provide: getRepositoryToken(ScheduledNotification), useValue: mockScheduledRepo },
+        { provide: NotificationsGateway, useValue: mockGateway },
+        { provide: MailService, useValue: mockMailService },
+      ],
+    }).compile();
+
+    service = module.get<NotificationsService>(NotificationsService);
+    // Suppress logger noise
+    jest.spyOn((service as any).logger, 'error').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+    jest.restoreAllMocks();
+  });
+
+  // ── create ──────────────────────────────────────────────────────────────────
+
+  describe('create', () => {
+    const userId = 'user-1';
+    const type = NotificationType.ENROLLMENT;
+    const message = 'You have been enrolled in Rust 101';
+
+    it('saves in-app notification and emits WebSocket event when inApp is true', async () => {
+      const prefs = makePrefs({ inApp: true, email: false, push: false });
+      mockPrefRepo.findOne.mockResolvedValue(prefs);
+      const saved = { id: 'notif-1', userId, type, message } as Notification;
+      mockNotificationRepo.create.mockReturnValue(saved);
+      mockNotificationRepo.save.mockResolvedValue(saved);
+      mockNotificationRepo.findOne.mockResolvedValue(saved);
+
+      await service.create(userId, type, message);
+
+      expect(mockNotificationRepo.create).toHaveBeenCalledWith({ userId, type, message });
+      expect(mockNotificationRepo.save).toHaveBeenCalled();
+      expect(mockGateway.emitToUser).toHaveBeenCalledWith(userId, 'notification', saved);
+    });
+
+    it('does not save in-app notification when inApp pref is false', async () => {
+      const prefs = makePrefs({ inApp: false, email: false, push: false });
+      mockPrefRepo.findOne.mockResolvedValue(prefs);
+      mockNotificationRepo.findOne.mockResolvedValue(null);
+
+      await service.create(userId, type, message);
+
+      expect(mockNotificationRepo.create).not.toHaveBeenCalled();
+      expect(mockNotificationRepo.save).not.toHaveBeenCalled();
+      expect(mockGateway.emitToUser).not.toHaveBeenCalledWith(userId, 'notification', expect.anything());
+    });
+
+    it('sends email notification when email pref is true and emailContext provided', async () => {
+      const prefs = makePrefs({ inApp: false, email: true, push: false });
+      mockPrefRepo.findOne.mockResolvedValue(prefs);
+      mockNotificationRepo.findOne.mockResolvedValue(null);
+      mockMailService.sendMail.mockResolvedValue(undefined);
+
+      await service.create(
+        userId,
+        type,
+        message,
+        { to: 'student@example.com', context: { courseName: 'Rust 101' } },
+      );
+
+      expect(mockMailService.sendMail).toHaveBeenCalledWith(
+        expect.objectContaining({ to: 'student@example.com' }),
+      );
+    });
+
+    it('does not send email when email pref is false', async () => {
+      const prefs = makePrefs({ inApp: false, email: false, push: false });
+      mockPrefRepo.findOne.mockResolvedValue(prefs);
+      mockNotificationRepo.findOne.mockResolvedValue(null);
+
+      await service.create(
+        userId,
+        type,
+        message,
+        { to: 'student@example.com', context: { courseName: 'Rust 101' } },
+      );
+
+      expect(mockMailService.sendMail).not.toHaveBeenCalled();
+    });
+
+    it('does not send email when emailContext is not provided', async () => {
+      const prefs = makePrefs({ inApp: false, email: true, push: false });
+      mockPrefRepo.findOne.mockResolvedValue(prefs);
+      mockNotificationRepo.findOne.mockResolvedValue(null);
+
+      await service.create(userId, type, message);
+
+      expect(mockMailService.sendMail).not.toHaveBeenCalled();
+    });
+
+    it('emits push event when push pref is true', async () => {
+      const prefs = makePrefs({ inApp: false, email: false, push: true });
+      mockPrefRepo.findOne.mockResolvedValue(prefs);
+      mockNotificationRepo.findOne.mockResolvedValue(null);
+
+      await service.create(userId, type, message);
+
+      expect(mockGateway.emitToUser).toHaveBeenCalledWith(userId, 'push', { type, message });
+    });
+
+    it('creates default prefs when none exist for user', async () => {
+      const defaultPrefs = makePrefs();
+      mockPrefRepo.findOne.mockResolvedValue(null);
+      mockPrefRepo.create.mockReturnValue(defaultPrefs);
+      mockPrefRepo.save.mockResolvedValue(defaultPrefs);
+      const saved = { id: 'notif-1', userId, type, message } as Notification;
+      mockNotificationRepo.create.mockReturnValue(saved);
+      mockNotificationRepo.save.mockResolvedValue(saved);
+      mockNotificationRepo.findOne.mockResolvedValue(saved);
+
+      await service.create(userId, type, message);
+
+      expect(mockPrefRepo.create).toHaveBeenCalledWith({ userId });
+      expect(mockPrefRepo.save).toHaveBeenCalled();
+    });
+
+    it('does not send email when notification type is disabled in prefs', async () => {
+      const prefs = makePrefs({ email: true, enrollment: false });
+      mockPrefRepo.findOne.mockResolvedValue(prefs);
+      const saved = { id: 'notif-1', userId, type, message } as Notification;
+      mockNotificationRepo.create.mockReturnValue(saved);
+      mockNotificationRepo.save.mockResolvedValue(saved);
+      mockNotificationRepo.findOne.mockResolvedValue(saved);
+
+      await service.create(
+        userId,
+        type,
+        message,
+        { to: 'student@example.com', context: { courseName: 'Rust 101' } },
+      );
+
+      expect(mockMailService.sendMail).not.toHaveBeenCalled();
+    });
+
+    it('continues gracefully when email send fails', async () => {
+      const prefs = makePrefs({ inApp: false, email: true, push: false });
+      mockPrefRepo.findOne.mockResolvedValue(prefs);
+      mockNotificationRepo.findOne.mockResolvedValue(null);
+      mockMailService.sendMail.mockRejectedValue(new Error('SMTP failure'));
+
+      // Should not throw
+      await expect(
+        service.create(userId, type, message, {
+          to: 'student@example.com',
+          context: { courseName: 'Rust 101' },
+        }),
+      ).resolves.not.toThrow();
+    });
+  });
+
+  // ── findByUser ──────────────────────────────────────────────────────────────
+
+  describe('findByUser', () => {
+    it('returns notifications for a user ordered correctly', async () => {
+      const notifications = [
+        { id: 'n1', userId: 'user-1', isRead: false },
+        { id: 'n2', userId: 'user-1', isRead: true },
+      ] as Notification[];
+      mockNotificationRepo.find.mockResolvedValue(notifications);
+
+      const result = await service.findByUser('user-1');
+
+      expect(result).toEqual(notifications);
+      expect(mockNotificationRepo.find).toHaveBeenCalledWith({
+        where: { userId: 'user-1' },
+        order: { isRead: 'ASC', createdAt: 'DESC' },
+      });
+    });
+  });
+
+  // ── markAsRead ──────────────────────────────────────────────────────────────
+
+  describe('markAsRead', () => {
+    it('marks a notification as read', async () => {
+      const notification = { id: 'n1', userId: 'user-1', isRead: false } as Notification;
+      const saved = { ...notification, isRead: true } as Notification;
+
+      mockNotificationRepo.findOne.mockResolvedValue(notification);
+      mockNotificationRepo.save.mockResolvedValue(saved);
+
+      const result = await service.markAsRead('n1');
+
+      expect(notification.isRead).toBe(true);
+      expect(result).toEqual(saved);
+    });
+
+    it('throws NotFoundException when notification not found', async () => {
+      mockNotificationRepo.findOne.mockResolvedValue(null);
+
+      await expect(service.markAsRead('nonexistent')).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  // ── markAllAsRead ───────────────────────────────────────────────────────────
+
+  describe('markAllAsRead', () => {
+    it('bulk-updates all unread notifications for a user', async () => {
+      mockNotificationRepo.update.mockResolvedValue({ affected: 3 });
+
+      const result = await service.markAllAsRead('user-1');
+
+      expect(mockNotificationRepo.update).toHaveBeenCalledWith(
+        { userId: 'user-1', isRead: false },
+        { isRead: true },
+      );
+      expect(result).toEqual({ success: true });
+    });
+  });
+});

--- a/apps/backend/src/progress/progress.service.spec.ts
+++ b/apps/backend/src/progress/progress.service.spec.ts
@@ -1,0 +1,260 @@
+import { NotFoundException } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Not, IsNull } from 'typeorm';
+import { ProgressService } from './progress.service';
+import { Progress } from './progress.entity';
+import { StellarService } from '../stellar/stellar.service';
+import { CredentialsService } from '../credentials/credentials.service';
+import { UsersService } from '../users/users.service';
+import { RecordProgressDto } from './dto/record-progress.dto';
+
+describe('ProgressService', () => {
+  let service: ProgressService;
+
+  const mockRepo = {
+    findOne: jest.fn(),
+    create: jest.fn(),
+    save: jest.fn(),
+    find: jest.fn(),
+    count: jest.fn(),
+  };
+
+  const mockStellarService = {
+    recordProgress: jest.fn(),
+    mintReward: jest.fn(),
+  };
+
+  const mockCredentialsService = {
+    issue: jest.fn(),
+  };
+
+  const mockUsersService = {
+    findById: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ProgressService,
+        { provide: getRepositoryToken(Progress), useValue: mockRepo },
+        { provide: StellarService, useValue: mockStellarService },
+        { provide: CredentialsService, useValue: mockCredentialsService },
+        { provide: UsersService, useValue: mockUsersService },
+      ],
+    }).compile();
+
+    service = module.get<ProgressService>(ProgressService);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('record', () => {
+    const userId = 'user-1';
+    const stellarKey = 'GSTELLAR123';
+    const dto: RecordProgressDto = { courseId: 'course-1', progressPct: 50 };
+
+    it('creates a new progress record when none exists', async () => {
+      const newProgress = { userId, courseId: dto.courseId } as Progress;
+      const saved = { ...newProgress, progressPct: 50, txHash: 'tx123' } as Progress;
+
+      mockRepo.findOne.mockResolvedValue(null);
+      mockRepo.create.mockReturnValue(newProgress);
+      mockStellarService.recordProgress.mockResolvedValue('tx123');
+      mockRepo.save.mockResolvedValue(saved);
+
+      const result = await service.record(userId, dto, stellarKey);
+
+      expect(mockRepo.findOne).toHaveBeenCalledWith({ where: { userId, courseId: dto.courseId } });
+      expect(mockRepo.create).toHaveBeenCalledWith({ userId, courseId: dto.courseId });
+      expect(mockStellarService.recordProgress).toHaveBeenCalledWith(stellarKey, dto.courseId, dto.progressPct);
+      expect(result).toEqual(saved);
+    });
+
+    it('updates an existing progress record', async () => {
+      const existing = { id: 'p1', userId, courseId: dto.courseId, progressPct: 20 } as Progress;
+      const saved = { ...existing, progressPct: 50 } as Progress;
+
+      mockRepo.findOne.mockResolvedValue(existing);
+      mockStellarService.recordProgress.mockResolvedValue('tx123');
+      mockRepo.save.mockResolvedValue(saved);
+
+      const result = await service.record(userId, dto, stellarKey);
+
+      expect(mockRepo.create).not.toHaveBeenCalled();
+      expect(result).toEqual(saved);
+    });
+
+    it('stores progress off-chain when on-chain call fails (non-fatal)', async () => {
+      const newProgress = { userId, courseId: dto.courseId } as Progress;
+      const saved = { ...newProgress, progressPct: 50 } as Progress;
+
+      mockRepo.findOne.mockResolvedValue(null);
+      mockRepo.create.mockReturnValue(newProgress);
+      mockStellarService.recordProgress.mockRejectedValue(new Error('network error'));
+      mockRepo.save.mockResolvedValue(saved);
+
+      // Should not throw even if stellar call fails
+      const result = await service.record(userId, dto, stellarKey);
+
+      expect(result).toEqual(saved);
+      expect(mockRepo.save).toHaveBeenCalled();
+    });
+
+    it('sets completedAt and issues credential at 100%', async () => {
+      const completionDto: RecordProgressDto = { courseId: 'course-1', progressPct: 100 };
+      const newProgress = { userId, courseId: completionDto.courseId } as Progress;
+      const saved = { ...newProgress, progressPct: 100, completedAt: expect.any(Date) } as Progress;
+
+      mockRepo.findOne.mockResolvedValue(null);
+      mockRepo.create.mockReturnValue(newProgress);
+      mockStellarService.recordProgress.mockResolvedValue('tx123');
+      mockRepo.save.mockResolvedValue(saved);
+      mockRepo.count.mockResolvedValue(5); // not first completion
+      mockCredentialsService.issue.mockResolvedValue(undefined);
+
+      await service.record(userId, completionDto, stellarKey);
+
+      expect(mockCredentialsService.issue).toHaveBeenCalledWith(userId, completionDto.courseId, stellarKey);
+      expect(newProgress.completedAt).toBeInstanceOf(Date);
+    });
+
+    it('mints referral reward on first course completion', async () => {
+      const completionDto: RecordProgressDto = { courseId: 'course-1', progressPct: 100 };
+      const newProgress = { userId, courseId: completionDto.courseId } as Progress;
+      const saved = { ...newProgress, progressPct: 100 } as Progress;
+      const referrerId = 'ref-1';
+      const referrerKey = 'GREFERRER456';
+
+      mockRepo.findOne.mockResolvedValue(null);
+      mockRepo.create.mockReturnValue(newProgress);
+      mockStellarService.recordProgress.mockResolvedValue('tx123');
+      mockRepo.save.mockResolvedValue(saved);
+      mockRepo.count.mockResolvedValue(1); // first completion
+      mockCredentialsService.issue.mockResolvedValue(undefined);
+      mockUsersService.findById
+        .mockResolvedValueOnce({ id: userId, referredBy: referrerId }) // the user
+        .mockResolvedValueOnce({ id: referrerId, stellarPublicKey: referrerKey }); // the referrer
+      mockStellarService.mintReward.mockResolvedValue(undefined);
+
+      await service.record(userId, completionDto, stellarKey);
+
+      expect(mockRepo.count).toHaveBeenCalledWith({ where: { userId, completedAt: Not(IsNull()) } });
+      expect(mockStellarService.mintReward).toHaveBeenCalledWith(referrerKey, 50);
+    });
+
+    it('skips referral mint when user has no referrer', async () => {
+      const completionDto: RecordProgressDto = { courseId: 'course-1', progressPct: 100 };
+      const newProgress = { userId, courseId: completionDto.courseId } as Progress;
+      const saved = { ...newProgress, progressPct: 100 } as Progress;
+
+      mockRepo.findOne.mockResolvedValue(null);
+      mockRepo.create.mockReturnValue(newProgress);
+      mockStellarService.recordProgress.mockResolvedValue('tx123');
+      mockRepo.save.mockResolvedValue(saved);
+      mockRepo.count.mockResolvedValue(1);
+      mockCredentialsService.issue.mockResolvedValue(undefined);
+      mockUsersService.findById.mockResolvedValue({ id: userId, referredBy: null });
+
+      await service.record(userId, completionDto, stellarKey);
+
+      expect(mockStellarService.mintReward).not.toHaveBeenCalled();
+    });
+
+    it('skips referral mint when referrer has no stellar key', async () => {
+      const completionDto: RecordProgressDto = { courseId: 'course-1', progressPct: 100 };
+      const newProgress = { userId, courseId: completionDto.courseId } as Progress;
+      const saved = { ...newProgress, progressPct: 100 } as Progress;
+
+      mockRepo.findOne.mockResolvedValue(null);
+      mockRepo.create.mockReturnValue(newProgress);
+      mockStellarService.recordProgress.mockResolvedValue('tx123');
+      mockRepo.save.mockResolvedValue(saved);
+      mockRepo.count.mockResolvedValue(1);
+      mockCredentialsService.issue.mockResolvedValue(undefined);
+      mockUsersService.findById
+        .mockResolvedValueOnce({ id: userId, referredBy: 'ref-1' })
+        .mockResolvedValueOnce({ id: 'ref-1', stellarPublicKey: null }); // no key
+
+      await service.record(userId, completionDto, stellarKey);
+
+      expect(mockStellarService.mintReward).not.toHaveBeenCalled();
+    });
+
+    it('does not issue credential below 100%', async () => {
+      const partialDto: RecordProgressDto = { courseId: 'course-1', progressPct: 99 };
+      const newProgress = { userId, courseId: partialDto.courseId } as Progress;
+      const saved = { ...newProgress, progressPct: 99 } as Progress;
+
+      mockRepo.findOne.mockResolvedValue(null);
+      mockRepo.create.mockReturnValue(newProgress);
+      mockStellarService.recordProgress.mockResolvedValue('tx123');
+      mockRepo.save.mockResolvedValue(saved);
+
+      await service.record(userId, partialDto, stellarKey);
+
+      expect(mockCredentialsService.issue).not.toHaveBeenCalled();
+      expect(mockRepo.count).not.toHaveBeenCalled();
+    });
+
+    it('updates lessonId when provided in dto', async () => {
+      const dtoWithLesson: RecordProgressDto = { courseId: 'course-1', progressPct: 30, lessonId: 'lesson-5' };
+      const existing = { id: 'p1', userId, courseId: dtoWithLesson.courseId, progressPct: 20, lessonId: 'lesson-1' } as Progress;
+      const saved = { ...existing, progressPct: 30, lessonId: 'lesson-5' } as Progress;
+
+      mockRepo.findOne.mockResolvedValue(existing);
+      mockStellarService.recordProgress.mockResolvedValue('tx123');
+      mockRepo.save.mockResolvedValue(saved);
+
+      await service.record(userId, dtoWithLesson, stellarKey);
+
+      expect(existing.lessonId).toBe('lesson-5');
+    });
+  });
+
+  describe('findByCourse', () => {
+    it('returns progress when found', async () => {
+      const progress = { id: 'p1', userId: 'u1', courseId: 'c1' } as Progress;
+      mockRepo.findOne.mockResolvedValue(progress);
+
+      const result = await service.findByCourse('u1', 'c1');
+
+      expect(result).toEqual(progress);
+      expect(mockRepo.findOne).toHaveBeenCalledWith({ where: { userId: 'u1', courseId: 'c1' } });
+    });
+
+    it('throws NotFoundException when progress not found', async () => {
+      mockRepo.findOne.mockResolvedValue(null);
+
+      await expect(service.findByCourse('u1', 'missing-course')).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('findByUser', () => {
+    it('returns all progress records for a user ordered by updatedAt DESC', async () => {
+      const records = [
+        { id: 'p1', userId: 'u1', courseId: 'c1' } as Progress,
+        { id: 'p2', userId: 'u1', courseId: 'c2' } as Progress,
+      ];
+      mockRepo.find.mockResolvedValue(records);
+
+      const result = await service.findByUser('u1');
+
+      expect(result).toEqual(records);
+      expect(mockRepo.find).toHaveBeenCalledWith({
+        where: { userId: 'u1' },
+        order: { updatedAt: 'DESC' },
+      });
+    });
+
+    it('returns empty array when user has no progress', async () => {
+      mockRepo.find.mockResolvedValue([]);
+
+      const result = await service.findByUser('u1');
+
+      expect(result).toEqual([]);
+    });
+  });
+});

--- a/apps/backend/src/quizzes/quizzes.service.spec.ts
+++ b/apps/backend/src/quizzes/quizzes.service.spec.ts
@@ -1,0 +1,206 @@
+import { NotFoundException } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { QuizzesService } from './quizzes.service';
+import { Quiz } from './quiz.entity';
+import { QuizQuestion, QuestionType } from './quiz-question.entity';
+import { QuizAttempt } from './quiz-attempt.entity';
+import { QuizAttemptAnswer } from './quiz-attempt-answer.entity';
+import { QuizAnswer } from './quiz-answer.entity';
+
+describe('QuizzesService', () => {
+  let service: QuizzesService;
+
+  const mockQuizRepo = { create: jest.fn(), save: jest.fn(), findOne: jest.fn() };
+  const mockQuestionRepo = { create: jest.fn(), save: jest.fn() };
+  const mockAttemptRepo = {
+    create: jest.fn(), save: jest.fn(), findOne: jest.fn(),
+    createQueryBuilder: jest.fn(),
+  };
+  const mockAttemptAnswerRepo = { create: jest.fn(), save: jest.fn(), findOne: jest.fn() };
+  const mockAnswerRepo = { create: jest.fn(), save: jest.fn() };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        QuizzesService,
+        { provide: getRepositoryToken(Quiz), useValue: mockQuizRepo },
+        { provide: getRepositoryToken(QuizQuestion), useValue: mockQuestionRepo },
+        { provide: getRepositoryToken(QuizAttempt), useValue: mockAttemptRepo },
+        { provide: getRepositoryToken(QuizAttemptAnswer), useValue: mockAttemptAnswerRepo },
+        { provide: getRepositoryToken(QuizAnswer), useValue: mockAnswerRepo },
+      ],
+    }).compile();
+    service = module.get<QuizzesService>(QuizzesService);
+  });
+
+  afterEach(() => jest.clearAllMocks());
+
+  describe('createQuiz', () => {
+    it('creates and saves a quiz with lessonId', async () => {
+      const quiz = { id: 'q1', lessonId: 'l1', title: 'Quiz 1' } as unknown as Quiz;
+      mockQuizRepo.create.mockReturnValue(quiz);
+      mockQuizRepo.save.mockResolvedValue(quiz);
+
+      const result = await service.createQuiz('l1', { title: 'Quiz 1' });
+
+      expect(mockQuizRepo.create).toHaveBeenCalledWith({ lessonId: 'l1', title: 'Quiz 1' });
+      expect(result).toEqual(quiz);
+    });
+  });
+
+  describe('getQuiz', () => {
+    it('returns quiz with questions and answers when found', async () => {
+      const quiz = { id: 'q1', questions: [] } as unknown as Quiz;
+      mockQuizRepo.findOne.mockResolvedValue(quiz);
+
+      const result = await service.getQuiz('q1');
+
+      expect(mockQuizRepo.findOne).toHaveBeenCalledWith({
+        where: { id: 'q1' },
+        relations: ['questions', 'questions.answers'],
+      });
+      expect(result).toEqual(quiz);
+    });
+
+    it('throws NotFoundException when quiz not found', async () => {
+      mockQuizRepo.findOne.mockResolvedValue(null);
+      await expect(service.getQuiz('missing')).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('submitAttempt', () => {
+    it('throws NotFoundException when quiz not found', async () => {
+      mockQuizRepo.findOne.mockResolvedValue(null);
+      await expect(service.submitAttempt('missing', 'u1', [])).rejects.toThrow(NotFoundException);
+    });
+
+    it('scores a correct multiple-choice answer', async () => {
+      const quiz = {
+        id: 'q1',
+        questions: [
+          {
+            id: 'qn1',
+            type: QuestionType.MULTIPLE_CHOICE,
+            points: 10,
+            answers: [{ id: 'a1', text: 'Paris', isCorrect: true }],
+          },
+        ],
+        passingScore: 60,
+      } as unknown as Quiz;
+
+      const attempt = { id: 'at1', quizId: 'q1', userId: 'u1' } as QuizAttempt;
+      const savedAttempt = { ...attempt, score: 100, isGraded: true } as QuizAttempt;
+
+      mockQuizRepo.findOne.mockResolvedValue(quiz);
+      mockAttemptRepo.create.mockReturnValue(attempt);
+      mockAttemptRepo.save
+        .mockResolvedValueOnce(attempt)    // first save (create attempt)
+        .mockResolvedValueOnce(savedAttempt); // second save (update score)
+      const answerEntity = { attemptId: 'at1', questionId: 'qn1', points: 10 };
+      mockAttemptAnswerRepo.create.mockReturnValue(answerEntity);
+      mockAttemptAnswerRepo.save.mockResolvedValue(answerEntity);
+
+      const result = await service.submitAttempt('q1', 'u1', [
+        { questionId: 'qn1', answer: 'Paris' },
+      ]);
+
+      expect(attempt.score).toBe(100);
+      expect(result).toEqual(savedAttempt);
+    });
+
+    it('scores 0 for wrong answer', async () => {
+      const quiz = {
+        id: 'q1',
+        questions: [
+          {
+            id: 'qn1',
+            type: QuestionType.MULTIPLE_CHOICE,
+            points: 10,
+            answers: [{ id: 'a1', text: 'Paris', isCorrect: true }],
+          },
+        ],
+        passingScore: 60,
+      } as unknown as Quiz;
+
+      const attempt = { id: 'at1', quizId: 'q1', userId: 'u1' } as QuizAttempt;
+      mockQuizRepo.findOne.mockResolvedValue(quiz);
+      mockAttemptRepo.create.mockReturnValue(attempt);
+      mockAttemptRepo.save.mockResolvedValue(attempt);
+      const answerEntity = { attemptId: 'at1', questionId: 'qn1', points: 0 };
+      mockAttemptAnswerRepo.create.mockReturnValue(answerEntity);
+      mockAttemptAnswerRepo.save.mockResolvedValue(answerEntity);
+
+      await service.submitAttempt('q1', 'u1', [{ questionId: 'qn1', answer: 'London' }]);
+
+      expect(attempt.score).toBe(0);
+    });
+
+    it('does not auto-grade essay questions (isGraded stays false)', async () => {
+      const quiz = {
+        id: 'q1',
+        questions: [
+          { id: 'qn1', type: QuestionType.ESSAY, points: 20, answers: [] },
+        ],
+        passingScore: 60,
+      } as unknown as Quiz;
+
+      const attempt = { id: 'at1', quizId: 'q1', userId: 'u1' } as QuizAttempt;
+      mockQuizRepo.findOne.mockResolvedValue(quiz);
+      mockAttemptRepo.create.mockReturnValue(attempt);
+      mockAttemptRepo.save.mockResolvedValue(attempt);
+      const answerEntity = { attemptId: 'at1', questionId: 'qn1' };
+      mockAttemptAnswerRepo.create.mockReturnValue(answerEntity);
+      mockAttemptAnswerRepo.save.mockResolvedValue(answerEntity);
+
+      await service.submitAttempt('q1', 'u1', [{ questionId: 'qn1', answer: 'My essay...' }]);
+
+      expect(attempt.isGraded).toBe(false);
+    });
+
+    it('skips answers for unknown questionIds', async () => {
+      const quiz = {
+        id: 'q1',
+        questions: [
+          { id: 'qn1', type: QuestionType.MULTIPLE_CHOICE, points: 5, answers: [] },
+        ],
+        passingScore: 60,
+      } as unknown as Quiz;
+
+      const attempt = { id: 'at1' } as QuizAttempt;
+      mockQuizRepo.findOne.mockResolvedValue(quiz);
+      mockAttemptRepo.create.mockReturnValue(attempt);
+      mockAttemptRepo.save.mockResolvedValue(attempt);
+
+      // Submit answer for a question that doesn't exist on the quiz
+      await service.submitAttempt('q1', 'u1', [{ questionId: 'unknown-id', answer: 'x' }]);
+
+      expect(mockAttemptAnswerRepo.save).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('gradeEssay', () => {
+    it('updates essay answer points and recalculates attempt score', async () => {
+      const attemptAnswer = { attemptId: 'at1', questionId: 'qn1', points: 0 } as QuizAttemptAnswer;
+      const attempt = {
+        id: 'at1',
+        quiz: { questions: [{ points: 20 }] },
+        answers: [{ points: 15 }],
+        score: 0,
+        isGraded: false,
+      } as unknown as QuizAttempt;
+
+      mockAttemptAnswerRepo.findOne.mockResolvedValue(attemptAnswer);
+      mockAttemptAnswerRepo.save.mockResolvedValue(attemptAnswer);
+      mockAttemptRepo.findOne.mockResolvedValue(attempt);
+      mockAttemptRepo.save.mockResolvedValue({ ...attempt, score: 75, isGraded: true });
+
+      await service.gradeEssay('at1', 'qn1', 15, 'Good work');
+
+      expect(attemptAnswer.points).toBe(15);
+      expect(attempt.score).toBe(75); // 15/20 * 100
+      expect(attempt.isGraded).toBe(true);
+      expect(attempt.feedback).toBe('Good work');
+    });
+  });
+});

--- a/apps/backend/src/webhooks/webhooks.service.spec.ts
+++ b/apps/backend/src/webhooks/webhooks.service.spec.ts
@@ -1,0 +1,204 @@
+import { NotFoundException } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { WebhooksService } from './webhooks.service';
+import { Webhook } from './webhook.entity';
+import { WebhookDelivery, DeliveryStatus } from './webhook-delivery.entity';
+
+describe('WebhooksService', () => {
+  let service: WebhooksService;
+
+  const mockWebhookRepo = {
+    create: jest.fn(),
+    save: jest.fn(),
+    find: jest.fn(),
+    findOne: jest.fn(),
+    remove: jest.fn(),
+    createQueryBuilder: jest.fn(),
+  };
+  const mockDeliveryRepo = {
+    create: jest.fn(),
+    save: jest.fn(),
+    find: jest.fn(),
+    findOne: jest.fn(),
+    createQueryBuilder: jest.fn(),
+  };
+
+  const qb: any = {
+    where: jest.fn().mockReturnThis(),
+    andWhere: jest.fn().mockReturnThis(),
+    getMany: jest.fn().mockResolvedValue([]),
+    orderBy: jest.fn().mockReturnThis(),
+    getOne: jest.fn(),
+  };
+
+  const makeWebhook = (overrides: Partial<Webhook> = {}): Webhook =>
+    ({
+      id: 'wh-1',
+      userId: 'u1',
+      url: 'https://example.com/hook',
+      events: 'enrollment.created',
+      secret: 'old-secret',
+      previousSecret: null,
+      secretRotatedAt: null,
+      isActive: true,
+      ...overrides,
+    } as Webhook);
+
+  beforeEach(async () => {
+    mockWebhookRepo.createQueryBuilder.mockReturnValue(qb);
+    mockDeliveryRepo.createQueryBuilder.mockReturnValue(qb);
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        WebhooksService,
+        { provide: getRepositoryToken(Webhook), useValue: mockWebhookRepo },
+        { provide: getRepositoryToken(WebhookDelivery), useValue: mockDeliveryRepo },
+      ],
+    }).compile();
+
+    service = module.get<WebhooksService>(WebhooksService);
+    jest.spyOn((service as any).logger, 'log').mockImplementation(() => undefined);
+    jest.spyOn((service as any).logger, 'warn').mockImplementation(() => undefined);
+    jest.spyOn((service as any).logger, 'error').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => jest.clearAllMocks());
+
+  // ── register ─────────────────────────────────────────────────────────────────
+
+  describe('register', () => {
+    it('creates a webhook with a generated secret', async () => {
+      const wh = makeWebhook();
+      mockWebhookRepo.create.mockReturnValue(wh);
+      mockWebhookRepo.save.mockResolvedValue(wh);
+
+      const result = await service.register('u1', 'https://example.com/hook', ['enrollment.created']);
+
+      expect(mockWebhookRepo.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          userId: 'u1',
+          url: 'https://example.com/hook',
+          events: 'enrollment.created',
+          secret: expect.any(String),
+        }),
+      );
+      expect(result).toEqual(wh);
+    });
+
+    it('generates a unique secret on each registration', async () => {
+      const secrets: string[] = [];
+      mockWebhookRepo.create.mockImplementation((data: any) => {
+        secrets.push(data.secret);
+        return data;
+      });
+      mockWebhookRepo.save.mockImplementation((wh: any) => Promise.resolve(wh));
+
+      await service.register('u1', 'https://a.com', ['e1']);
+      await service.register('u1', 'https://b.com', ['e2']);
+
+      expect(secrets[0]).not.toBe(secrets[1]);
+    });
+  });
+
+  // ── list ──────────────────────────────────────────────────────────────────────
+
+  describe('list', () => {
+    it('returns all webhooks for the user', async () => {
+      const webhooks = [makeWebhook(), makeWebhook({ id: 'wh-2' })];
+      mockWebhookRepo.find.mockResolvedValue(webhooks);
+
+      const result = await service.list('u1');
+
+      expect(result).toEqual(webhooks);
+      expect(mockWebhookRepo.find).toHaveBeenCalledWith({ where: { userId: 'u1' } });
+    });
+  });
+
+  // ── getWebhookForUser ─────────────────────────────────────────────────────────
+
+  describe('getWebhookForUser', () => {
+    it('returns webhook when found for user', async () => {
+      const wh = makeWebhook();
+      mockWebhookRepo.findOne.mockResolvedValue(wh);
+
+      const result = await service.getWebhookForUser('wh-1', 'u1');
+
+      expect(result).toEqual(wh);
+      expect(mockWebhookRepo.findOne).toHaveBeenCalledWith({ where: { id: 'wh-1', userId: 'u1' } });
+    });
+
+    it('throws NotFoundException when webhook not found for user', async () => {
+      mockWebhookRepo.findOne.mockResolvedValue(null);
+
+      await expect(service.getWebhookForUser('missing', 'u1')).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  // ── delete ────────────────────────────────────────────────────────────────────
+
+  describe('delete', () => {
+    it('removes webhook when it belongs to user', async () => {
+      const wh = makeWebhook();
+      mockWebhookRepo.findOne.mockResolvedValue(wh);
+      mockWebhookRepo.remove.mockResolvedValue(wh);
+
+      await service.delete('u1', 'wh-1');
+
+      expect(mockWebhookRepo.remove).toHaveBeenCalledWith(wh);
+    });
+
+    it('throws NotFoundException when webhook not found', async () => {
+      mockWebhookRepo.findOne.mockResolvedValue(null);
+
+      await expect(service.delete('u1', 'missing')).rejects.toThrow(NotFoundException);
+      expect(mockWebhookRepo.remove).not.toHaveBeenCalled();
+    });
+  });
+
+  // ── rotateSecret ──────────────────────────────────────────────────────────────
+
+  describe('rotateSecret', () => {
+    it('rotates the secret, preserving the old one for the grace period', async () => {
+      const wh = makeWebhook({ secret: 'old-secret' });
+      mockWebhookRepo.findOne.mockResolvedValue(wh);
+      mockWebhookRepo.save.mockImplementation((w: any) => Promise.resolve(w));
+
+      const result = await service.rotateSecret('u1', 'wh-1');
+
+      expect(wh.previousSecret).toBe('old-secret');
+      expect(wh.secret).not.toBe('old-secret');
+      expect(result.secret).toBe(wh.secret);
+      expect(result.previousSecretExpiresAt).toBeInstanceOf(Date);
+    });
+
+    it('throws NotFoundException when webhook not found', async () => {
+      mockWebhookRepo.findOne.mockResolvedValue(null);
+
+      await expect(service.rotateSecret('u1', 'missing')).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  // ── getDlq ────────────────────────────────────────────────────────────────────
+
+  describe('getDlq', () => {
+    it('returns failed deliveries for the webhook', async () => {
+      const wh = makeWebhook();
+      const deliveries = [
+        { id: 'd1', webhookId: 'wh-1', status: DeliveryStatus.FAILED } as WebhookDelivery,
+      ];
+      mockWebhookRepo.findOne.mockResolvedValue(wh);
+      mockDeliveryRepo.find.mockResolvedValue(deliveries);
+
+      const result = await service.getDlq('wh-1', 'u1');
+
+      expect(result).toEqual(deliveries);
+    });
+
+    it('throws NotFoundException when webhook not found', async () => {
+      mockWebhookRepo.findOne.mockResolvedValue(null);
+
+      await expect(service.getDlq('missing', 'u1')).rejects.toThrow(NotFoundException);
+    });
+  });
+});

--- a/contracts/badges/src/lib.rs
+++ b/contracts/badges/src/lib.rs
@@ -248,6 +248,9 @@ impl BadgesContract {
 // =============================================================================
 
 #[cfg(test)]
+mod tests_ext;
+
+#[cfg(test)]
 mod tests {
     use super::*;
     use soroban_sdk::testutils::Address as _;

--- a/contracts/badges/src/tests_ext.rs
+++ b/contracts/badges/src/tests_ext.rs
@@ -1,0 +1,148 @@
+#![cfg(test)]
+//! Additional tests for the badges contract covering:
+//! - burn_badge: happy path, non-admin panics, already-burned panics, not-found panics
+//! - transfer: always panics (soulbound)
+//! - get_badge_type: returns None for missing type
+//! - get_badge: returns None for nonexistent id
+//! - verify_badge: false after burn
+
+use super::*;
+use soroban_sdk::{testutils::Address as _, symbol_short, Env, String};
+
+fn setup() -> (Env, BadgesContractClient<'static>, Address) {
+    let env = Env::default();
+    env.mock_all_auths();
+    let id = env.register_contract(None, BadgesContract);
+    let client = BadgesContractClient::new(&env, &id);
+    let admin = Address::generate(&env);
+    client.initialize(&admin);
+    (env, client, admin)
+}
+
+fn create_type_and_mint(
+    env: &Env,
+    client: &BadgesContractClient,
+    admin: &Address,
+) -> (Address, u64) {
+    let badge_type = symbol_short!("FIRST");
+    let desc = String::from_str(env, "First completion");
+    client.create_badge_type(admin, &badge_type, &desc);
+    let owner = Address::generate(env);
+    let id = client.mint_badge(admin, &owner, &badge_type);
+    (owner, id)
+}
+
+// ── get_badge_type ────────────────────────────────────────────────────────────
+
+#[test]
+fn test_get_badge_type_returns_none_for_missing() {
+    let (env, client, _) = setup();
+    assert!(client.get_badge_type(&symbol_short!("NOPE")).is_none());
+}
+
+#[test]
+fn test_get_badge_type_returns_record_after_creation() {
+    let (env, client, admin) = setup();
+    let badge_type = symbol_short!("FIRST");
+    let desc = String::from_str(&env, "First completion");
+    client.create_badge_type(&admin, &badge_type, &desc);
+
+    let record = client.get_badge_type(&badge_type).unwrap();
+    assert_eq!(record.name, badge_type);
+    assert_eq!(record.total_minted, 0);
+}
+
+#[test]
+fn test_get_badge_type_increments_total_minted_after_mint() {
+    let (env, client, admin) = setup();
+    let badge_type = symbol_short!("FIRST");
+    let desc = String::from_str(&env, "First completion");
+    client.create_badge_type(&admin, &badge_type, &desc);
+    let owner = Address::generate(&env);
+    client.mint_badge(&admin, &owner, &badge_type);
+
+    let record = client.get_badge_type(&badge_type).unwrap();
+    assert_eq!(record.total_minted, 1);
+}
+
+// ── get_badge ─────────────────────────────────────────────────────────────────
+
+#[test]
+fn test_get_badge_returns_none_for_nonexistent_id() {
+    let (_, client, _) = setup();
+    assert!(client.get_badge(&999).is_none());
+}
+
+#[test]
+fn test_get_badge_returns_record_after_mint() {
+    let (env, client, admin) = setup();
+    let (owner, id) = create_type_and_mint(&env, &client, &admin);
+
+    let badge = client.get_badge(&id).unwrap();
+    assert_eq!(badge.owner, owner);
+    assert_eq!(badge.id, id);
+}
+
+// ── transfer (soulbound) ──────────────────────────────────────────────────────
+
+#[test]
+#[should_panic(expected = "soulbound")]
+fn test_transfer_always_panics() {
+    let (env, client, admin) = setup();
+    let (owner, id) = create_type_and_mint(&env, &client, &admin);
+    let recipient = Address::generate(&env);
+    client.transfer(&owner, &recipient, &id);
+}
+
+// ── burn_badge ────────────────────────────────────────────────────────────────
+
+#[test]
+fn test_burn_badge_removes_badge_from_owner_list() {
+    let (env, client, admin) = setup();
+    let (owner, id) = create_type_and_mint(&env, &client, &admin);
+
+    assert_eq!(client.get_badges_by_owner(&owner).len(), 1);
+
+    client.burn_badge(&admin, &id);
+
+    assert_eq!(client.get_badges_by_owner(&owner).len(), 0);
+}
+
+#[test]
+fn test_verify_badge_returns_false_after_burn() {
+    let (env, client, admin) = setup();
+    let badge_type = symbol_short!("FIRST");
+    let desc = String::from_str(&env, "First completion");
+    client.create_badge_type(&admin, &badge_type, &desc);
+    let owner = Address::generate(&env);
+    let id = client.mint_badge(&admin, &owner, &badge_type);
+
+    assert!(client.verify_badge(&owner, &badge_type));
+    client.burn_badge(&admin, &id);
+    assert!(!client.verify_badge(&owner, &badge_type));
+}
+
+#[test]
+#[should_panic(expected = "Unauthorized: admin required")]
+fn test_non_admin_cannot_burn_badge() {
+    let (env, client, admin) = setup();
+    let (_, id) = create_type_and_mint(&env, &client, &admin);
+    let rando = Address::generate(&env);
+    client.burn_badge(&rando, &id);
+}
+
+#[test]
+#[should_panic(expected = "Badge not found")]
+fn test_burn_nonexistent_badge_panics() {
+    let (_, client, admin) = setup();
+    client.burn_badge(&admin, &999);
+}
+
+#[test]
+#[should_panic(expected = "Badge already burned")]
+fn test_burn_same_badge_twice_panics() {
+    let (env, client, admin) = setup();
+    let (_, id) = create_type_and_mint(&env, &client, &admin);
+    client.burn_badge(&admin, &id);
+    client.burn_badge(&admin, &id);
+}

--- a/contracts/certificate/src/lib.rs
+++ b/contracts/certificate/src/lib.rs
@@ -372,6 +372,9 @@ impl CertificateContract {
 mod fuzz_tests;
 
 #[cfg(test)]
+mod tests_ext;
+
+#[cfg(test)]
 mod tests {
     use super::*;
     use soroban_sdk::testutils::Address as _;

--- a/contracts/certificate/src/tests_ext.rs
+++ b/contracts/certificate/src/tests_ext.rs
@@ -1,0 +1,299 @@
+#![cfg(test)]
+//! Additional unit tests for the certificate contract covering:
+//! - enable_transfer and transfer workflow
+//! - is_valid (not-found, revoked, expired, no-expiry)
+//! - set_metadata / get_metadata (admin-only, not-found, update)
+//! - count_certificates and is_transferable queries
+//! - transfer ownership update and list maintenance
+
+use super::*;
+use soroban_sdk::{testutils::Address as _, symbol_short, Env, String};
+
+fn setup() -> (Env, CertificateContractClient<'static>, Address) {
+    let env = Env::default();
+    env.mock_all_auths();
+    let id = env.register_contract(None, CertificateContract);
+    let client = CertificateContractClient::new(&env, &id);
+    let admin = Address::generate(&env);
+    client.initialize(&admin);
+    (env, client, admin)
+}
+
+fn mint_one(env: &Env, client: &CertificateContractClient, admin: &Address) -> (Address, u64) {
+    let owner = Address::generate(env);
+    let course = symbol_short!("RUST101");
+    let url = String::from_str(env, "https://example.com/cert");
+    let id = client.mint_certificate(admin, &owner, &course, &url);
+    (owner, id)
+}
+
+// ── enable_transfer ──────────────────────────────────────────────────────────
+
+#[test]
+fn test_enable_transfer_allows_subsequent_transfer() {
+    let (env, client, admin) = setup();
+    let (owner, cert_id) = mint_one(&env, &client, &admin);
+
+    assert!(!client.is_transferable(&cert_id));
+
+    client.enable_transfer(&admin, &cert_id);
+
+    assert!(client.is_transferable(&cert_id));
+}
+
+#[test]
+#[should_panic(expected = "Unauthorized: admin required")]
+fn test_non_admin_cannot_enable_transfer() {
+    let (env, client, admin) = setup();
+    let (_, cert_id) = mint_one(&env, &client, &admin);
+    let rando = Address::generate(&env);
+    client.enable_transfer(&rando, &cert_id);
+}
+
+#[test]
+#[should_panic(expected = "Certificate not found")]
+fn test_enable_transfer_panics_for_nonexistent_cert() {
+    let (_, client, admin) = setup();
+    client.enable_transfer(&admin, &999);
+}
+
+// ── transfer ─────────────────────────────────────────────────────────────────
+
+#[test]
+fn test_transfer_moves_certificate_to_new_owner() {
+    let (env, client, admin) = setup();
+    let (owner, cert_id) = mint_one(&env, &client, &admin);
+    let recipient = Address::generate(&env);
+
+    client.enable_transfer(&admin, &cert_id);
+    client.transfer(&owner, &recipient, &cert_id);
+
+    let cert = client.get_certificate(&cert_id).unwrap();
+    assert_eq!(cert.owner, recipient);
+}
+
+#[test]
+fn test_transfer_updates_owner_certificate_lists() {
+    let (env, client, admin) = setup();
+    let (owner, cert_id) = mint_one(&env, &client, &admin);
+    let recipient = Address::generate(&env);
+
+    client.enable_transfer(&admin, &cert_id);
+    client.transfer(&owner, &recipient, &cert_id);
+
+    // Original owner list should not contain the cert
+    let owner_certs = client.get_certificates_by_owner(&owner);
+    assert_eq!(owner_certs.len(), 0);
+
+    // Recipient list should contain the cert
+    let recipient_certs = client.get_certificates_by_owner(&recipient);
+    assert_eq!(recipient_certs.len(), 1);
+    assert_eq!(recipient_certs.get(0).unwrap().id, cert_id);
+}
+
+#[test]
+#[should_panic(expected = "Certificate is soulbound and cannot be transferred")]
+fn test_transfer_panics_when_not_transferable() {
+    let (env, client, admin) = setup();
+    let (owner, cert_id) = mint_one(&env, &client, &admin);
+    let recipient = Address::generate(&env);
+    // No enable_transfer call
+    client.transfer(&owner, &recipient, &cert_id);
+}
+
+#[test]
+#[should_panic(expected = "Revoked certificate cannot be transferred")]
+fn test_transfer_panics_when_revoked() {
+    let (env, client, admin) = setup();
+    let (owner, cert_id) = mint_one(&env, &client, &admin);
+    let recipient = Address::generate(&env);
+    let reason = String::from_str(&env, "Fraud");
+
+    client.enable_transfer(&admin, &cert_id);
+    client.revoke_certificate(&admin, &cert_id, &reason);
+    client.transfer(&owner, &recipient, &cert_id);
+}
+
+#[test]
+#[should_panic(expected = "Caller is not the certificate owner")]
+fn test_transfer_panics_when_not_owner() {
+    let (env, client, admin) = setup();
+    let (_, cert_id) = mint_one(&env, &client, &admin);
+    let impostor = Address::generate(&env);
+    let recipient = Address::generate(&env);
+
+    client.enable_transfer(&admin, &cert_id);
+    client.transfer(&impostor, &recipient, &cert_id);
+}
+
+// ── set_metadata / get_metadata ───────────────────────────────────────────────
+
+#[test]
+fn test_set_and_get_metadata() {
+    let (env, client, admin) = setup();
+    let (_, cert_id) = mint_one(&env, &client, &admin);
+
+    client.set_metadata(
+        &admin,
+        &cert_id,
+        &String::from_str(&env, "Brain Storm Institute"),
+        &String::from_str(&env, "Rust,WebAssembly,Blockchain"),
+        &String::from_str(&env, "Distinction"),
+        &0_u64,
+    );
+
+    let meta = client.get_metadata(&cert_id).unwrap();
+    assert_eq!(meta.certificate_id, cert_id);
+    assert_eq!(meta.issuer_name, String::from_str(&env, "Brain Storm Institute"));
+    assert_eq!(meta.grade, String::from_str(&env, "Distinction"));
+    assert_eq!(meta.expiry_timestamp, 0);
+}
+
+#[test]
+fn test_get_metadata_returns_none_when_not_set() {
+    let (env, client, admin) = setup();
+    let (_, cert_id) = mint_one(&env, &client, &admin);
+
+    assert!(client.get_metadata(&cert_id).is_none());
+}
+
+#[test]
+#[should_panic(expected = "Unauthorized: admin required")]
+fn test_non_admin_cannot_set_metadata() {
+    let (env, client, admin) = setup();
+    let (_, cert_id) = mint_one(&env, &client, &admin);
+    let rando = Address::generate(&env);
+
+    client.set_metadata(
+        &rando,
+        &cert_id,
+        &String::from_str(&env, "Issuer"),
+        &String::from_str(&env, "Rust"),
+        &String::from_str(&env, "A"),
+        &0_u64,
+    );
+}
+
+#[test]
+#[should_panic(expected = "Certificate not found")]
+fn test_set_metadata_panics_for_nonexistent_cert() {
+    let (env, client, admin) = setup();
+
+    client.set_metadata(
+        &admin,
+        &999,
+        &String::from_str(&env, "Issuer"),
+        &String::from_str(&env, "Rust"),
+        &String::from_str(&env, "A"),
+        &0_u64,
+    );
+}
+
+#[test]
+fn test_set_metadata_can_overwrite_existing() {
+    let (env, client, admin) = setup();
+    let (_, cert_id) = mint_one(&env, &client, &admin);
+
+    client.set_metadata(
+        &admin,
+        &cert_id,
+        &String::from_str(&env, "First Issuer"),
+        &String::from_str(&env, "Rust"),
+        &String::from_str(&env, "Pass"),
+        &0_u64,
+    );
+    // Overwrite
+    client.set_metadata(
+        &admin,
+        &cert_id,
+        &String::from_str(&env, "Updated Issuer"),
+        &String::from_str(&env, "Rust,Soroban"),
+        &String::from_str(&env, "Distinction"),
+        &0_u64,
+    );
+
+    let meta = client.get_metadata(&cert_id).unwrap();
+    assert_eq!(meta.issuer_name, String::from_str(&env, "Updated Issuer"));
+    assert_eq!(meta.grade, String::from_str(&env, "Distinction"));
+}
+
+// ── is_valid ──────────────────────────────────────────────────────────────────
+
+#[test]
+fn test_is_valid_returns_false_for_nonexistent_cert() {
+    let (_, client, _) = setup();
+    assert!(!client.is_valid(&999));
+}
+
+#[test]
+fn test_is_valid_returns_true_for_active_cert() {
+    let (env, client, admin) = setup();
+    let (_, cert_id) = mint_one(&env, &client, &admin);
+    assert!(client.is_valid(&cert_id));
+}
+
+#[test]
+fn test_is_valid_returns_false_for_revoked_cert() {
+    let (env, client, admin) = setup();
+    let (_, cert_id) = mint_one(&env, &client, &admin);
+    let reason = String::from_str(&env, "Misconduct");
+    client.revoke_certificate(&admin, &cert_id, &reason);
+    assert!(!client.is_valid(&cert_id));
+}
+
+#[test]
+fn test_is_valid_returns_true_when_no_expiry_set() {
+    let (env, client, admin) = setup();
+    let (_, cert_id) = mint_one(&env, &client, &admin);
+
+    // Set metadata with expiry_timestamp = 0 (no expiry)
+    client.set_metadata(
+        &admin,
+        &cert_id,
+        &String::from_str(&env, "Issuer"),
+        &String::from_str(&env, "Skills"),
+        &String::from_str(&env, "A"),
+        &0_u64,
+    );
+
+    assert!(client.is_valid(&cert_id));
+}
+
+// ── count_certificates ────────────────────────────────────────────────────────
+
+#[test]
+fn test_count_certificates_returns_zero_for_new_address() {
+    let (env, client, _) = setup();
+    let owner = Address::generate(&env);
+    assert_eq!(client.count_certificates(&owner), 0);
+}
+
+#[test]
+fn test_count_certificates_increases_with_each_mint() {
+    let (env, client, admin) = setup();
+    let owner = Address::generate(&env);
+    let course = symbol_short!("RUST101");
+    let url = String::from_str(&env, "https://example.com/cert");
+
+    client.mint_certificate(&admin, &owner, &course, &url);
+    assert_eq!(client.count_certificates(&owner), 1);
+
+    client.mint_certificate(&admin, &owner, &course, &url);
+    assert_eq!(client.count_certificates(&owner), 2);
+}
+
+#[test]
+fn test_count_certificates_reflects_transfer() {
+    let (env, client, admin) = setup();
+    let (owner, cert_id) = mint_one(&env, &client, &admin);
+    let recipient = Address::generate(&env);
+
+    assert_eq!(client.count_certificates(&owner), 1);
+    assert_eq!(client.count_certificates(&recipient), 0);
+
+    client.enable_transfer(&admin, &cert_id);
+    client.transfer(&owner, &recipient, &cert_id);
+
+    assert_eq!(client.count_certificates(&owner), 0);
+    assert_eq!(client.count_certificates(&recipient), 1);
+}

--- a/contracts/credential_metadata/src/lib.rs
+++ b/contracts/credential_metadata/src/lib.rs
@@ -309,3 +309,6 @@ impl CredentialMetadataContract {
 
 #[cfg(test)]
 mod tests;
+
+#[cfg(test)]
+mod validation_tests;

--- a/contracts/credential_metadata/src/validation_tests.rs
+++ b/contracts/credential_metadata/src/validation_tests.rs
@@ -1,0 +1,158 @@
+#![cfg(test)]
+//! Unit tests for credential_metadata validation helpers.
+//! These helpers have no existing tests — this module covers all public functions.
+
+use soroban_sdk::{testutils::Address as _, Address, Env, String};
+
+use crate::{CredentialMetadataContract, CredentialMetadataContractClient, DataKey, MetadataRecord};
+use crate::validation::{
+    metadata_exists, get_metadata_checked, get_metadata_or_panic, is_renewable,
+    validate_admin, validate_future_timestamp,
+};
+
+fn setup() -> (Env, CredentialMetadataContractClient<'static>, Address) {
+    let env = Env::default();
+    env.mock_all_auths();
+    let id = env.register_contract(None, CredentialMetadataContract);
+    let client = CredentialMetadataContractClient::new(&env, &id);
+    let admin = Address::generate(&env);
+    client.initialize(&admin);
+    (env, client, admin)
+}
+
+/// Store a sample metadata record via the contract client.
+fn store_sample(
+    env: &Env,
+    client: &CredentialMetadataContractClient,
+    admin: &Address,
+    credential_id: u64,
+    expiry: u64,
+) {
+    client.store_metadata(
+        admin,
+        &credential_id,
+        &String::from_str(env, "Rust Fundamentals"),
+        &1_000,       // completion_date
+        &expiry,      // expiry_timestamp
+        &String::from_str(env, "A"),
+        &String::from_str(env, "QmHash"),
+    );
+}
+
+// ── validate_admin ────────────────────────────────────────────────────────────
+
+#[test]
+fn test_validate_admin_returns_admin_for_correct_caller() {
+    let (env, _, admin) = setup();
+    env.as_contract(&env.register_contract(None, CredentialMetadataContract), || {
+        // Directly set admin in storage to test the helper in isolation.
+        env.storage().instance().set(&DataKey::Admin, &admin);
+        let returned = validate_admin(&env, &admin);
+        assert_eq!(returned, admin);
+    });
+}
+
+#[test]
+#[should_panic(expected = "Only admin can perform this action")]
+fn test_validate_admin_panics_for_wrong_caller() {
+    let (env, _, admin) = setup();
+    env.as_contract(&env.register_contract(None, CredentialMetadataContract), || {
+        env.storage().instance().set(&DataKey::Admin, &admin);
+        let rando = Address::generate(&env);
+        validate_admin(&env, &rando);
+    });
+}
+
+// ── metadata_exists ───────────────────────────────────────────────────────────
+
+#[test]
+fn test_metadata_exists_returns_false_when_not_stored() {
+    let (env, _, _) = setup();
+    env.as_contract(&env.register_contract(None, CredentialMetadataContract), || {
+        assert!(!metadata_exists(&env, 1));
+    });
+}
+
+#[test]
+fn test_metadata_exists_returns_true_after_store() {
+    let (env, client, admin) = setup();
+    store_sample(&env, &client, &admin, 42, 9_999_999);
+
+    // Reach into the same contract storage by invoking via client
+    // and verifying through the public API
+    assert!(client.get_metadata(&42).is_some());
+}
+
+// ── get_metadata_checked ──────────────────────────────────────────────────────
+
+#[test]
+fn test_get_metadata_checked_returns_none_for_missing() {
+    let (env, _, _) = setup();
+    env.as_contract(&env.register_contract(None, CredentialMetadataContract), || {
+        assert!(get_metadata_checked(&env, 99).is_none());
+    });
+}
+
+// ── get_metadata_or_panic ─────────────────────────────────────────────────────
+
+#[test]
+#[should_panic(expected = "Credential metadata not found")]
+fn test_get_metadata_or_panic_panics_for_missing() {
+    let (env, _, _) = setup();
+    env.as_contract(&env.register_contract(None, CredentialMetadataContract), || {
+        get_metadata_or_panic(&env, 999);
+    });
+}
+
+// ── is_renewable ─────────────────────────────────────────────────────────────
+
+#[test]
+fn test_is_renewable_returns_false_when_no_metadata() {
+    let (env, _, _) = setup();
+    env.as_contract(&env.register_contract(None, CredentialMetadataContract), || {
+        // No metadata stored — always false
+        assert!(!is_renewable(&env, 1, 86400));
+    });
+}
+
+// ── validate_future_timestamp ─────────────────────────────────────────────────
+
+#[test]
+#[should_panic(expected = "Timestamp must be in the future")]
+fn test_validate_future_timestamp_panics_for_past() {
+    let (env, _, _) = setup();
+    env.as_contract(&env.register_contract(None, CredentialMetadataContract), || {
+        // ledger timestamp defaults to 0 in test env;
+        // passing 0 means it is NOT in the future (must be > current)
+        validate_future_timestamp(&env, 0);
+    });
+}
+
+#[test]
+fn test_validate_future_timestamp_passes_for_future() {
+    let (env, _, _) = setup();
+    env.as_contract(&env.register_contract(None, CredentialMetadataContract), || {
+        // Any value > 0 is in the future when ledger timestamp = 0
+        validate_future_timestamp(&env, 1_000_000); // should not panic
+    });
+}
+
+// ── Integration: store → exists → get ─────────────────────────────────────────
+
+#[test]
+fn test_store_and_retrieve_via_client() {
+    let (env, client, admin) = setup();
+    store_sample(&env, &client, &admin, 7, 9_999_999);
+
+    let meta = client.get_metadata(&7).unwrap();
+    assert_eq!(meta.credential_id, 7);
+    assert_eq!(meta.grade, String::from_str(&env, "A"));
+    assert_eq!(meta.ipfs_hash, String::from_str(&env, "QmHash"));
+}
+
+#[test]
+fn test_is_expired_returns_false_for_far_future_expiry() {
+    let (env, client, admin) = setup();
+    store_sample(&env, &client, &admin, 10, 9_999_999_999);
+    assert!(!client.is_expired(&10));
+}

--- a/contracts/dispute/src/lib.rs
+++ b/contracts/dispute/src/lib.rs
@@ -237,6 +237,9 @@ impl DisputeContract {
 // ── Tests ─────────────────────────────────────────────────────────────────────
 
 #[cfg(test)]
+mod tests_ext;
+
+#[cfg(test)]
 mod tests {
     use super::*;
     use soroban_sdk::{testutils::Address as _, Env};

--- a/contracts/dispute/src/tests_ext.rs
+++ b/contracts/dispute/src/tests_ext.rs
@@ -1,0 +1,182 @@
+#![cfg(test)]
+//! Additional tests for the dispute contract covering:
+//! - set_arbiter: admin-only, updates arbiter
+//! - get_dispute: returns correct record, None for missing
+//! - open_dispute: zero/negative amount panics, id increments
+//! - settle: before decision panics, double-settle panics
+//! - submit_evidence: only parties can submit, settled dispute panics
+
+use super::*;
+use soroban_sdk::{testutils::Address as _, BytesN, Env};
+
+fn setup() -> (Env, DisputeContractClient<'static>, Address, Address) {
+    let env = Env::default();
+    env.mock_all_auths();
+    let id = env.register_contract(None, DisputeContract);
+    let client = DisputeContractClient::new(&env, &id);
+    let admin = Address::generate(&env);
+    let arbiter = Address::generate(&env);
+    client.initialize(&admin, &arbiter);
+    (env, client, admin, arbiter)
+}
+
+fn open_and_decide(
+    env: &Env,
+    client: &DisputeContractClient,
+    arbiter: &Address,
+    outcome: Outcome,
+) -> u64 {
+    let claimant = Address::generate(env);
+    let respondent = Address::generate(env);
+    let id = client.open_dispute(&claimant, &respondent, &1_000);
+    client.record_decision(arbiter, &id, &outcome);
+    id
+}
+
+// ── set_arbiter ───────────────────────────────────────────────────────────────
+
+#[test]
+fn test_set_arbiter_updates_arbiter() {
+    let (env, client, admin, _) = setup();
+    let new_arbiter = Address::generate(&env);
+    client.set_arbiter(&admin, &new_arbiter);
+    assert_eq!(client.get_arbiter(), new_arbiter);
+}
+
+#[test]
+#[should_panic(expected = "Unauthorized: admin required")]
+fn test_non_admin_cannot_set_arbiter() {
+    let (env, client, _, _) = setup();
+    let rando = Address::generate(&env);
+    let new_arbiter = Address::generate(&env);
+    client.set_arbiter(&rando, &new_arbiter);
+}
+
+// ── get_dispute ───────────────────────────────────────────────────────────────
+
+#[test]
+fn test_get_dispute_returns_none_for_missing() {
+    let (_, client, _, _) = setup();
+    assert!(client.get_dispute(&999).is_none());
+}
+
+#[test]
+fn test_get_dispute_returns_correct_record() {
+    let (env, client, _, _) = setup();
+    let claimant = Address::generate(&env);
+    let respondent = Address::generate(&env);
+
+    let id = client.open_dispute(&claimant, &respondent, &500);
+    let dispute = client.get_dispute(&id).unwrap();
+
+    assert_eq!(dispute.id, id);
+    assert_eq!(dispute.claimant, claimant);
+    assert_eq!(dispute.respondent, respondent);
+    assert_eq!(dispute.amount, 500);
+    assert_eq!(dispute.status, DisputeStatus::Open);
+}
+
+// ── open_dispute validation ───────────────────────────────────────────────────
+
+#[test]
+#[should_panic(expected = "Amount must be positive")]
+fn test_open_dispute_zero_amount_panics() {
+    let (env, client, _, _) = setup();
+    let claimant = Address::generate(&env);
+    let respondent = Address::generate(&env);
+    client.open_dispute(&claimant, &respondent, &0);
+}
+
+#[test]
+fn test_open_dispute_increments_id() {
+    let (env, client, _, _) = setup();
+    let c = Address::generate(&env);
+    let r = Address::generate(&env);
+    let id1 = client.open_dispute(&c, &r, &100);
+    let id2 = client.open_dispute(&c, &r, &200);
+    assert_eq!(id2, id1 + 1);
+}
+
+// ── settle ────────────────────────────────────────────────────────────────────
+
+#[test]
+#[should_panic(expected = "Must be in Decision status")]
+fn test_settle_before_decision_panics() {
+    let (env, client, _, arbiter) = setup();
+    let claimant = Address::generate(&env);
+    let respondent = Address::generate(&env);
+    let id = client.open_dispute(&claimant, &respondent, &1_000);
+    // Skip record_decision — settle should panic
+    client.settle(&arbiter, &id);
+}
+
+#[test]
+#[should_panic(expected = "Must be in Decision status")]
+fn test_double_settle_panics() {
+    let (env, client, _, arbiter) = setup();
+    let id = open_and_decide(&env, &client, &arbiter, Outcome::FavourClaimant);
+    client.settle(&arbiter, &id); // first settle ok
+    client.settle(&arbiter, &id); // second should panic — already Settled
+}
+
+#[test]
+#[should_panic(expected = "Unauthorized: authority required")]
+fn test_non_arbiter_cannot_settle() {
+    let (env, client, _, arbiter) = setup();
+    let id = open_and_decide(&env, &client, &arbiter, Outcome::FavourClaimant);
+    let rando = Address::generate(&env);
+    client.settle(&rando, &id);
+}
+
+#[test]
+fn test_settle_favour_claimant_pays_full_amount() {
+    let (env, client, _, arbiter) = setup();
+    let id = open_and_decide(&env, &client, &arbiter, Outcome::FavourClaimant);
+    let (c, r) = client.settle(&arbiter, &id);
+    assert_eq!(c, 1_000);
+    assert_eq!(r, 0);
+}
+
+#[test]
+fn test_settle_favour_respondent_pays_nothing_to_claimant() {
+    let (env, client, _, arbiter) = setup();
+    let id = open_and_decide(&env, &client, &arbiter, Outcome::FavourRespondent);
+    let (c, r) = client.settle(&arbiter, &id);
+    assert_eq!(c, 0);
+    assert_eq!(r, 1_000);
+}
+
+#[test]
+fn test_settle_marks_dispute_as_settled() {
+    let (env, client, _, arbiter) = setup();
+    let id = open_and_decide(&env, &client, &arbiter, Outcome::Split);
+    client.settle(&arbiter, &id);
+    let dispute = client.get_dispute(&id).unwrap();
+    assert_eq!(dispute.status, DisputeStatus::Settled);
+}
+
+// ── submit_evidence (additional auth check) ───────────────────────────────────
+
+#[test]
+#[should_panic(expected = "Only parties may submit evidence")]
+fn test_third_party_cannot_submit_evidence_on_new_dispute() {
+    let (env, client, _, _) = setup();
+    let claimant = Address::generate(&env);
+    let respondent = Address::generate(&env);
+    let id = client.open_dispute(&claimant, &respondent, &100);
+    let outsider = Address::generate(&env);
+    let hash = BytesN::from_array(&env, &[1u8; 32]);
+    client.submit_evidence(&outsider, &id, &hash);
+}
+
+#[test]
+#[should_panic]
+fn test_submit_evidence_on_settled_dispute_panics() {
+    let (env, client, _, arbiter) = setup();
+    let id = open_and_decide(&env, &client, &arbiter, Outcome::FavourClaimant);
+    client.settle(&arbiter, &id);
+    // Now try to submit evidence to an already-settled dispute
+    let claimant = client.get_dispute(&id).unwrap().claimant;
+    let hash = BytesN::from_array(&env, &[2u8; 32]);
+    client.submit_evidence(&claimant, &id, &hash);
+}

--- a/contracts/grants/src/lib.rs
+++ b/contracts/grants/src/lib.rs
@@ -401,6 +401,9 @@ impl GrantsContract {
 // =============================================================================
 
 #[cfg(test)]
+mod tests_ext;
+
+#[cfg(test)]
 mod tests {
     use super::*;
     use soroban_sdk::testutils::Address as _;

--- a/contracts/grants/src/tests_ext.rs
+++ b/contracts/grants/src/tests_ext.rs
@@ -1,0 +1,277 @@
+#![cfg(test)]
+//! Additional edge-case tests for the grants contract.
+//! The inline tests in lib.rs cover the happy-path lifecycle.
+//! These tests focus on validation errors, auth checks, and boundary conditions.
+
+use super::*;
+use soroban_sdk::{testutils::Address as _, Env, String};
+
+fn setup() -> (Env, GrantsContractClient<'static>, Address, Address) {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, GrantsContract);
+    let client = GrantsContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    let token = Address::generate(&env);
+    client.initialize(&admin, &token);
+    (env, client, admin, token)
+}
+
+// ── Initialization ───────────────────────────────────────────────────────────
+
+#[test]
+#[should_panic(expected = "Already initialized")]
+fn test_double_initialize_panics() {
+    let (_, client, admin, token) = setup();
+    client.initialize(&admin, &token);
+}
+
+// ── apply_for_grant validation ───────────────────────────────────────────────
+
+#[test]
+#[should_panic(expected = "Amount must be positive")]
+fn test_apply_zero_amount_panics() {
+    let (env, client, _, _) = setup();
+    let applicant = Address::generate(&env);
+    client.apply_for_grant(
+        &applicant,
+        &String::from_str(&env, "Grant"),
+        &String::from_str(&env, "Desc"),
+        &0,
+        &1,
+    );
+}
+
+#[test]
+#[should_panic(expected = "Must have at least one milestone")]
+fn test_apply_zero_milestones_panics() {
+    let (env, client, _, _) = setup();
+    let applicant = Address::generate(&env);
+    client.apply_for_grant(
+        &applicant,
+        &String::from_str(&env, "Grant"),
+        &String::from_str(&env, "Desc"),
+        &500,
+        &0,
+    );
+}
+
+#[test]
+fn test_apply_increments_grant_id() {
+    let (env, client, _, _) = setup();
+    let applicant = Address::generate(&env);
+    let t = String::from_str(&env, "T");
+    let d = String::from_str(&env, "D");
+
+    let id1 = client.apply_for_grant(&applicant, &t, &d, &100, &1);
+    let id2 = client.apply_for_grant(&applicant, &t, &d, &200, &1);
+    assert_eq!(id1, 1);
+    assert_eq!(id2, 2);
+}
+
+#[test]
+fn test_get_grant_returns_none_for_nonexistent() {
+    let (_, client, _, _) = setup();
+    assert!(client.get_grant(&999).is_none());
+}
+
+// ── approve / reject auth ────────────────────────────────────────────────────
+
+#[test]
+#[should_panic(expected = "Unauthorized: admin required")]
+fn test_non_admin_cannot_approve_grant() {
+    let (env, client, _, _) = setup();
+    let applicant = Address::generate(&env);
+    let id = client.apply_for_grant(
+        &applicant,
+        &String::from_str(&env, "T"),
+        &String::from_str(&env, "D"),
+        &100,
+        &1,
+    );
+    let rando = Address::generate(&env);
+    client.approve_grant(&rando, &id);
+}
+
+#[test]
+#[should_panic(expected = "Unauthorized: admin required")]
+fn test_non_admin_cannot_reject_grant() {
+    let (env, client, _, _) = setup();
+    let applicant = Address::generate(&env);
+    let id = client.apply_for_grant(
+        &applicant,
+        &String::from_str(&env, "T"),
+        &String::from_str(&env, "D"),
+        &100,
+        &1,
+    );
+    let rando = Address::generate(&env);
+    client.reject_grant(&rando, &id);
+}
+
+#[test]
+#[should_panic(expected = "Grant not pending")]
+fn test_approve_already_approved_grant_panics() {
+    let (env, client, admin, _) = setup();
+    let applicant = Address::generate(&env);
+    let id = client.apply_for_grant(
+        &applicant,
+        &String::from_str(&env, "T"),
+        &String::from_str(&env, "D"),
+        &100,
+        &1,
+    );
+    client.approve_grant(&admin, &id);
+    client.approve_grant(&admin, &id); // second time should panic
+}
+
+#[test]
+#[should_panic(expected = "Grant not pending")]
+fn test_approve_rejected_grant_panics() {
+    let (env, client, admin, _) = setup();
+    let applicant = Address::generate(&env);
+    let id = client.apply_for_grant(
+        &applicant,
+        &String::from_str(&env, "T"),
+        &String::from_str(&env, "D"),
+        &100,
+        &1,
+    );
+    client.reject_grant(&admin, &id);
+    client.approve_grant(&admin, &id); // already rejected
+}
+
+// ── set_milestone validation ─────────────────────────────────────────────────
+
+#[test]
+#[should_panic(expected = "Unauthorized: admin required")]
+fn test_non_admin_cannot_set_milestone() {
+    let (env, client, admin, _) = setup();
+    let applicant = Address::generate(&env);
+    let id = client.apply_for_grant(
+        &applicant,
+        &String::from_str(&env, "T"),
+        &String::from_str(&env, "D"),
+        &100,
+        &1,
+    );
+    client.approve_grant(&admin, &id);
+    let rando = Address::generate(&env);
+    client.set_milestone(&rando, &id, &0, &String::from_str(&env, "Phase 1"), &100);
+}
+
+#[test]
+#[should_panic(expected = "Invalid milestone index")]
+fn test_set_milestone_out_of_range_panics() {
+    let (env, client, admin, _) = setup();
+    let applicant = Address::generate(&env);
+    let id = client.apply_for_grant(
+        &applicant,
+        &String::from_str(&env, "T"),
+        &String::from_str(&env, "D"),
+        &100,
+        &2, // only indices 0 and 1 valid
+    );
+    client.approve_grant(&admin, &id);
+    // index 2 is out of range for milestone_count=2
+    client.set_milestone(&admin, &id, &2, &String::from_str(&env, "Bad"), &50);
+}
+
+#[test]
+#[should_panic(expected = "Amount must be positive")]
+fn test_set_milestone_zero_amount_panics() {
+    let (env, client, admin, _) = setup();
+    let applicant = Address::generate(&env);
+    let id = client.apply_for_grant(
+        &applicant,
+        &String::from_str(&env, "T"),
+        &String::from_str(&env, "D"),
+        &100,
+        &1,
+    );
+    client.approve_grant(&admin, &id);
+    client.set_milestone(&admin, &id, &0, &String::from_str(&env, "Phase 1"), &0);
+}
+
+#[test]
+fn test_get_milestone_returns_none_for_unset() {
+    let (env, client, admin, _) = setup();
+    let applicant = Address::generate(&env);
+    let id = client.apply_for_grant(
+        &applicant,
+        &String::from_str(&env, "T"),
+        &String::from_str(&env, "D"),
+        &100,
+        &2,
+    );
+    client.approve_grant(&admin, &id);
+    // Milestone 0 not yet set
+    assert!(client.get_milestone(&id, &0).is_none());
+}
+
+// ── submit_report auth ───────────────────────────────────────────────────────
+
+#[test]
+#[should_panic(expected = "Only grant applicant can report")]
+fn test_non_applicant_cannot_submit_report() {
+    let (env, client, admin, _) = setup();
+    let applicant = Address::generate(&env);
+    let id = client.apply_for_grant(
+        &applicant,
+        &String::from_str(&env, "T"),
+        &String::from_str(&env, "D"),
+        &100,
+        &1,
+    );
+    client.approve_grant(&admin, &id);
+
+    let impostor = Address::generate(&env);
+    client.submit_report(&impostor, &id, &String::from_str(&env, "Fake report"));
+}
+
+#[test]
+fn test_multiple_reports_accumulate() {
+    let (env, client, admin, _) = setup();
+    let applicant = Address::generate(&env);
+    let id = client.apply_for_grant(
+        &applicant,
+        &String::from_str(&env, "T"),
+        &String::from_str(&env, "D"),
+        &100,
+        &1,
+    );
+    client.approve_grant(&admin, &id);
+
+    client.submit_report(&applicant, &id, &String::from_str(&env, "Report 1"));
+    client.submit_report(&applicant, &id, &String::from_str(&env, "Report 2"));
+
+    let reports = client.get_grant_reports(&id);
+    assert_eq!(reports.len(), 2);
+    assert_eq!(reports.get(0).unwrap().report_idx, 0);
+    assert_eq!(reports.get(1).unwrap().report_idx, 1);
+}
+
+#[test]
+fn test_get_grant_reports_returns_empty_for_no_reports() {
+    let (env, client, admin, _) = setup();
+    let applicant = Address::generate(&env);
+    let id = client.apply_for_grant(
+        &applicant,
+        &String::from_str(&env, "T"),
+        &String::from_str(&env, "D"),
+        &100,
+        &1,
+    );
+    client.approve_grant(&admin, &id);
+
+    let reports = client.get_grant_reports(&id);
+    assert_eq!(reports.len(), 0);
+}
+
+#[test]
+fn test_get_applicant_grants_returns_empty_for_new_address() {
+    let (env, client, _, _) = setup();
+    let applicant = Address::generate(&env);
+    let grants = client.get_applicant_grants(&applicant);
+    assert_eq!(grants.len(), 0);
+}


### PR DESCRIPTION
Add targeted unit tests — P2 second wave
  
  Summary
  
  Second wave of deterministic unit tests addressing the P2-Medium coverage gap.
  Covers 6 high-value untested backend services and 2 Rust smart contracts with
  zero test files. All tests are fully isolated using mocks — no database,
  network, or external service required.
  
  ───────────────────────────────────────────────────────────────────────────────
  
  Backend — NestJS/Jest (6 new spec files)
  
  credentials.service.spec.ts
  
  - issue: returns existing credential without re-issuing (idempotent); issues
  when KYC not required; issues when KYC required and approved; throws
  ForbiddenException when KYC required but not approved; saves credential even
  when mintReward fails (non-fatal)
  - findByUser: correct query with issuedAt DESC ordering
  - findOne: returns with user + course relations; throws NotFoundException
  - verify: returns verified: true on match; verified: false when txHash not
  found
  
  access-control.service.spec.ts
  
  - grantAccess: creates record; passes optional expiry date and IP list through
  to create
  - checkAccess: returns allowed: false — no record, expired subscription, IP not
  in list; returns allowed: true — IP in list, no IP restriction (null), empty IP
  list, future expiry; logs every access check
  - revokeAccess: sets isActive: false for correct course+user
  - updateSubscription: updates expiry date for correct course+user
  
  quizzes.service.spec.ts
  
  - createQuiz: creates with lessonId merged into data
  - getQuiz: returns with questions.answers relations; throws NotFoundException
  - submitAttempt: throws NotFoundException when quiz missing; scores correct MC
  answer at 100%; scores wrong answer at 0%; essay questions not auto-graded
  (isGraded: false); skips answers for unknown questionId
  - gradeEssay: updates answer points, recalculates attempt score, sets isGraded:
  true and feedback
  
  forums.service.spec.ts
  
  - createPost: student can create non-pinned post; instructor/admin can create
  pinned post; student trying to pin throws ForbiddenException; course not found
  throws NotFoundException; moderation analysis called after save
  - createReply: creates reply when post exists; post not found throws
  NotFoundException; student marking answer throws ForbiddenException; instructor
  can mark answer, clears previous answer first
  - findPostsByCourse: throws NotFoundException when course missing; returns
  posts ordered by isPinned DESC, createdAt DESC
  
  bookings.service.spec.ts
  
  - createBooking: creates booking with no conflict; notifies both parties;
  throws ConflictException on overlapping confirmed booking
  - respondToBooking: confirms/rejects pending booking; notifies requester;
  throws NotFoundException, ForbiddenException (wrong worker), ConflictException
   (not pending)
  - cancelBooking: requester can cancel; worker can cancel; notifies other party;
  throws NotFoundException, ForbiddenException (stranger), ConflictException
  (already rejected or cancelled)
  
  webhooks.service.spec.ts
  
  - register: creates webhook with generated secret; each registration produces a
  unique secret
  - list: returns all webhooks for user
  - getWebhookForUser: returns webhook; throws NotFoundException
  - delete: removes webhook; throws NotFoundException
  - rotateSecret: preserves old secret as previousSecret; new secret differs from
  old; returns expiry timestamp; throws NotFoundException
  - getDlq: returns failed deliveries; throws NotFoundException
  
  ───────────────────────────────────────────────────────────────────────────────
  
  Rust contracts — Soroban (2 new test modules)
  
  badges/tests_ext.rs
  
  - get_badge_type: None for missing type; correct record after creation;
  total_minted increments after mint
  - get_badge: None for nonexistent id; correct record after mint
  - transfer: always panics with "soulbound" (no exceptions)
  - burn_badge: removes badge from owner list; verify_badge returns false after
  burn; non-admin panics; nonexistent id panics; double-burn panics with "Badge
  already burned"
  
  dispute/tests_ext.rs
  
  - set_arbiter: updates stored arbiter; non-admin panics
  - get_dispute: None for missing id; correct fields after open
  - open_dispute: zero amount panics; id increments correctly
  - settle: panics when called before record_decision; double-settle panics;
  non-arbiter panics; FavourClaimant pays full amount to claimant;
  FavourRespondent pays full amount to respondent; dispute status is Settled
   after successful settle
  - submit_evidence: third-party submission panics; submission on already-settled
  dispute panics
  
  ───────────────────────────────────────────────────────────────────────────────
  
  Testing
  
  # Backend unit tests
  cd apps/backend && npm test
  
  # Rust contract tests
  cargo test -p brain-storm-badges
  cargo test -p brain-storm-dispute

closes #856 
