### PR TITLE
test: P2 wave 3 — kyc, email, sessions, prerequisites, reviews, gdpr/…

### DIFF
--- a/apps/backend/src/cohorts/sessions.service.spec.ts
+++ b/apps/backend/src/cohorts/sessions.service.spec.ts
@@ -1,0 +1,201 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { SessionsService } from './sessions.service';
+import { CohortSession, SessionStatus } from './session.entity';
+import { SessionAttendance, AttendanceStatus } from './session-attendance.entity';
+import { NotificationsService } from '../notifications/notifications.service';
+import { CreateSessionDto } from './dto/session.dto';
+
+// Suppress ics/schedule decorator side-effects in unit tests
+jest.mock('ics', () => ({
+  createEvent: jest.fn(() => ({ error: null, value: 'BEGIN:VCALENDAR\nEND:VCALENDAR' })),
+}));
+
+describe('SessionsService', () => {
+  let service: SessionsService;
+
+  const mockSessionRepo = {
+    create: jest.fn(), save: jest.fn(), findOne: jest.fn(),
+    find: jest.fn(), update: jest.fn(),
+  };
+  const mockAttendanceRepo = {
+    create: jest.fn(), save: jest.fn(), findOne: jest.fn(), find: jest.fn(),
+  };
+  const mockNotifications = {
+    scheduleNotification: jest.fn().mockResolvedValue(undefined),
+  };
+
+  const makeSession = (overrides: Partial<CohortSession> = {}): CohortSession =>
+    ({
+      id: 's1',
+      cohortId: 'coh-1',
+      instructorId: 'ins-1',
+      title: 'Intro to Rust',
+      description: 'First session',
+      startTime: new Date('2030-01-15T10:00:00Z'),
+      endTime: new Date('2030-01-15T11:00:00Z'),
+      status: SessionStatus.SCHEDULED,
+      ...overrides,
+    } as CohortSession);
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        SessionsService,
+        { provide: getRepositoryToken(CohortSession), useValue: mockSessionRepo },
+        { provide: getRepositoryToken(SessionAttendance), useValue: mockAttendanceRepo },
+        { provide: NotificationsService, useValue: mockNotifications },
+      ],
+    }).compile();
+
+    service = module.get<SessionsService>(SessionsService);
+    jest.spyOn((service as any).logger, 'log').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => jest.clearAllMocks());
+
+  // ── createSession ─────────────────────────────────────────────────────────────
+
+  describe('createSession', () => {
+    const dto: CreateSessionDto = {
+      title: 'Intro to Rust',
+      description: 'First session',
+      startTime: new Date('2030-01-15T10:00:00Z'),
+      endTime: new Date('2030-01-15T11:00:00Z'),
+    };
+
+    it('creates and saves a session with SCHEDULED status', async () => {
+      const session = makeSession();
+      mockSessionRepo.create.mockReturnValue(session);
+      mockSessionRepo.save.mockResolvedValue(session);
+      // scheduleReminders — findOne returns session with no cohort members
+      mockSessionRepo.findOne.mockResolvedValue({ ...session, cohort: { members: [] } });
+
+      const result = await service.createSession('coh-1', 'ins-1', dto);
+
+      expect(mockSessionRepo.create).toHaveBeenCalledWith(
+        expect.objectContaining({ cohortId: 'coh-1', instructorId: 'ins-1', status: SessionStatus.SCHEDULED }),
+      );
+      expect(result).toEqual(session);
+    });
+
+    it('schedules reminders for each cohort member', async () => {
+      const session = makeSession();
+      mockSessionRepo.create.mockReturnValue(session);
+      mockSessionRepo.save.mockResolvedValue(session);
+      mockSessionRepo.findOne.mockResolvedValue({
+        ...session,
+        cohort: {
+          members: [
+            { user: { id: 'u1' } },
+            { user: { id: 'u2' } },
+          ],
+        },
+      });
+
+      await service.createSession('coh-1', 'ins-1', dto);
+
+      expect(mockNotifications.scheduleNotification).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  // ── getSession ────────────────────────────────────────────────────────────────
+
+  describe('getSession', () => {
+    it('returns session with relations', async () => {
+      const session = makeSession();
+      mockSessionRepo.findOne.mockResolvedValue(session);
+
+      const result = await service.getSession('s1');
+
+      expect(mockSessionRepo.findOne).toHaveBeenCalledWith(
+        expect.objectContaining({ where: { id: 's1' } }),
+      );
+      expect(result).toEqual(session);
+    });
+
+    it('returns null when session not found', async () => {
+      mockSessionRepo.findOne.mockResolvedValue(null);
+      const result = await service.getSession('missing');
+      expect(result).toBeNull();
+    });
+  });
+
+  // ── recordAttendance ──────────────────────────────────────────────────────────
+
+  describe('recordAttendance', () => {
+    it('creates a new attendance record when none exists', async () => {
+      mockAttendanceRepo.findOne.mockResolvedValue(null);
+      const attendance = { sessionId: 's1', userId: 'u1', status: AttendanceStatus.PRESENT } as SessionAttendance;
+      mockAttendanceRepo.create.mockReturnValue(attendance);
+      mockAttendanceRepo.save.mockResolvedValue(attendance);
+
+      const result = await service.recordAttendance('s1', 'u1');
+
+      expect(mockAttendanceRepo.create).toHaveBeenCalledWith(
+        expect.objectContaining({ sessionId: 's1', userId: 'u1', status: AttendanceStatus.PRESENT }),
+      );
+      expect(result).toEqual(attendance);
+    });
+
+    it('updates status when attendance record already exists', async () => {
+      const existing = {
+        sessionId: 's1', userId: 'u1', status: AttendanceStatus.PRESENT,
+      } as SessionAttendance;
+      mockAttendanceRepo.findOne.mockResolvedValue(existing);
+      mockAttendanceRepo.save.mockImplementation((a: any) => Promise.resolve(a));
+
+      await service.recordAttendance('s1', 'u1', AttendanceStatus.LATE);
+
+      expect(existing.status).toBe(AttendanceStatus.LATE);
+      expect(mockAttendanceRepo.create).not.toHaveBeenCalled();
+    });
+
+    it('defaults status to PRESENT when not specified', async () => {
+      mockAttendanceRepo.findOne.mockResolvedValue(null);
+      const attendance = { sessionId: 's1', userId: 'u1', status: AttendanceStatus.PRESENT } as SessionAttendance;
+      mockAttendanceRepo.create.mockReturnValue(attendance);
+      mockAttendanceRepo.save.mockResolvedValue(attendance);
+
+      await service.recordAttendance('s1', 'u1');
+
+      expect(mockAttendanceRepo.create).toHaveBeenCalledWith(
+        expect.objectContaining({ status: AttendanceStatus.PRESENT }),
+      );
+    });
+  });
+
+  // ── generateCalendarInvite ────────────────────────────────────────────────────
+
+  describe('generateCalendarInvite', () => {
+    it('returns ICS string for an existing session', async () => {
+      const session = makeSession();
+      mockSessionRepo.findOne.mockResolvedValue(session);
+
+      const result = await service.generateCalendarInvite('s1');
+
+      expect(result).toContain('VCALENDAR');
+    });
+
+    it('throws when session not found', async () => {
+      mockSessionRepo.findOne.mockResolvedValue(null);
+
+      await expect(service.generateCalendarInvite('missing')).rejects.toThrow('Session not found');
+    });
+  });
+
+  // ── markSessionRecording ──────────────────────────────────────────────────────
+
+  describe('markSessionRecording', () => {
+    it('updates the recordingUrl for the session', async () => {
+      mockSessionRepo.update.mockResolvedValue({ affected: 1 });
+
+      await service.markSessionRecording('s1', 'https://cdn.example.com/rec.mp4');
+
+      expect(mockSessionRepo.update).toHaveBeenCalledWith(
+        { id: 's1' },
+        { recordingUrl: 'https://cdn.example.com/rec.mp4' },
+      );
+    });
+  });
+});

--- a/apps/backend/src/courses/prerequisites.service.spec.ts
+++ b/apps/backend/src/courses/prerequisites.service.spec.ts
@@ -1,0 +1,175 @@
+import { BadRequestException, ForbiddenException, NotFoundException } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { PrerequisitesService } from './prerequisites.service';
+import { CoursePrerequisite } from './course-prerequisite.entity';
+import { Enrollment } from '../enrollments/enrollment.entity';
+import { Course } from './course.entity';
+
+describe('PrerequisitesService', () => {
+  let service: PrerequisitesService;
+
+  const mockPrereqRepo = {
+    create: jest.fn(), save: jest.fn(), findOne: jest.fn(),
+    find: jest.fn(), remove: jest.fn(),
+  };
+  const mockEnrollmentRepo = { find: jest.fn() };
+  const mockCourseRepo = { findOne: jest.fn() };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        PrerequisitesService,
+        { provide: getRepositoryToken(CoursePrerequisite), useValue: mockPrereqRepo },
+        { provide: getRepositoryToken(Enrollment), useValue: mockEnrollmentRepo },
+        { provide: getRepositoryToken(Course), useValue: mockCourseRepo },
+      ],
+    }).compile();
+    service = module.get<PrerequisitesService>(PrerequisitesService);
+  });
+
+  afterEach(() => jest.clearAllMocks());
+
+  // ── addPrerequisite ──────────────────────────────────────────────────────────
+
+  describe('addPrerequisite', () => {
+    it('creates prerequisite relationship between two valid courses', async () => {
+      mockCourseRepo.findOne
+        .mockResolvedValueOnce({ id: 'c1' } as Course)  // course
+        .mockResolvedValueOnce({ id: 'c2' } as Course); // prereq
+      const record = { courseId: 'c1', prerequisiteId: 'c2' } as CoursePrerequisite;
+      mockPrereqRepo.create.mockReturnValue(record);
+      mockPrereqRepo.save.mockResolvedValue(record);
+
+      const result = await service.addPrerequisite('c1', 'c2');
+
+      expect(result).toEqual(record);
+      expect(mockPrereqRepo.create).toHaveBeenCalledWith({ courseId: 'c1', prerequisiteId: 'c2' });
+    });
+
+    it('throws BadRequestException when course is its own prerequisite', async () => {
+      await expect(service.addPrerequisite('c1', 'c1')).rejects.toThrow(BadRequestException);
+      expect(mockCourseRepo.findOne).not.toHaveBeenCalled();
+    });
+
+    it('throws NotFoundException when the main course does not exist', async () => {
+      mockCourseRepo.findOne
+        .mockResolvedValueOnce(null)          // course missing
+        .mockResolvedValueOnce({ id: 'c2' }); // prereq exists
+
+      await expect(service.addPrerequisite('c1', 'c2')).rejects.toThrow(NotFoundException);
+    });
+
+    it('throws NotFoundException when the prerequisite course does not exist', async () => {
+      mockCourseRepo.findOne
+        .mockResolvedValueOnce({ id: 'c1' }) // course exists
+        .mockResolvedValueOnce(null);         // prereq missing
+
+      await expect(service.addPrerequisite('c1', 'c2')).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  // ── removePrerequisite ───────────────────────────────────────────────────────
+
+  describe('removePrerequisite', () => {
+    it('removes an existing prerequisite record', async () => {
+      const record = { courseId: 'c1', prerequisiteId: 'c2' } as CoursePrerequisite;
+      mockPrereqRepo.findOne.mockResolvedValue(record);
+      mockPrereqRepo.remove.mockResolvedValue(record);
+
+      await service.removePrerequisite('c1', 'c2');
+
+      expect(mockPrereqRepo.remove).toHaveBeenCalledWith(record);
+    });
+
+    it('throws NotFoundException when relationship does not exist', async () => {
+      mockPrereqRepo.findOne.mockResolvedValue(null);
+
+      await expect(service.removePrerequisite('c1', 'c2')).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  // ── validatePrerequisites ────────────────────────────────────────────────────
+
+  describe('validatePrerequisites', () => {
+    it('returns satisfied:true when adminOverride is true', async () => {
+      const result = await service.validatePrerequisites('u1', 'c1', true);
+      expect(result).toEqual({ satisfied: true, missing: [] });
+      expect(mockPrereqRepo.find).not.toHaveBeenCalled();
+    });
+
+    it('returns satisfied:true when course has no prerequisites', async () => {
+      mockPrereqRepo.find.mockResolvedValue([]);
+      const result = await service.validatePrerequisites('u1', 'c1');
+      expect(result).toEqual({ satisfied: true, missing: [] });
+    });
+
+    it('returns satisfied:true when all prerequisites are completed', async () => {
+      mockPrereqRepo.find.mockResolvedValue([
+        { prerequisiteId: 'pre-1' } as CoursePrerequisite,
+        { prerequisiteId: 'pre-2' } as CoursePrerequisite,
+      ]);
+      mockEnrollmentRepo.find.mockResolvedValue([
+        { courseId: 'pre-1', completedAt: new Date() } as Enrollment,
+        { courseId: 'pre-2', completedAt: new Date() } as Enrollment,
+      ]);
+
+      const result = await service.validatePrerequisites('u1', 'c1');
+
+      expect(result).toEqual({ satisfied: true, missing: [] });
+    });
+
+    it('returns missing ids when some prerequisites are not completed', async () => {
+      mockPrereqRepo.find.mockResolvedValue([
+        { prerequisiteId: 'pre-1' } as CoursePrerequisite,
+        { prerequisiteId: 'pre-2' } as CoursePrerequisite,
+      ]);
+      mockEnrollmentRepo.find.mockResolvedValue([
+        { courseId: 'pre-1', completedAt: new Date() } as Enrollment,
+        { courseId: 'pre-2', completedAt: null } as Enrollment, // not completed
+      ]);
+
+      const result = await service.validatePrerequisites('u1', 'c1');
+
+      expect(result.satisfied).toBe(false);
+      expect(result.missing).toContain('pre-2');
+    });
+
+    it('treats enrollment without completedAt as not completed', async () => {
+      mockPrereqRepo.find.mockResolvedValue([
+        { prerequisiteId: 'pre-1' } as CoursePrerequisite,
+      ]);
+      mockEnrollmentRepo.find.mockResolvedValue([
+        { courseId: 'pre-1', completedAt: null } as Enrollment,
+      ]);
+
+      const result = await service.validatePrerequisites('u1', 'c1');
+
+      expect(result.satisfied).toBe(false);
+    });
+  });
+
+  // ── enforcePrerequisites ─────────────────────────────────────────────────────
+
+  describe('enforcePrerequisites', () => {
+    it('resolves without throwing when all prerequisites are met', async () => {
+      mockPrereqRepo.find.mockResolvedValue([]);
+
+      await expect(service.enforcePrerequisites('u1', 'c1')).resolves.toBeUndefined();
+    });
+
+    it('throws ForbiddenException listing missing course ids', async () => {
+      mockPrereqRepo.find.mockResolvedValue([
+        { prerequisiteId: 'pre-x' } as CoursePrerequisite,
+      ]);
+      mockEnrollmentRepo.find.mockResolvedValue([]);
+
+      await expect(service.enforcePrerequisites('u1', 'c1')).rejects.toThrow(ForbiddenException);
+    });
+
+    it('resolves when adminOverride bypasses all checks', async () => {
+      await expect(service.enforcePrerequisites('u1', 'c1', true)).resolves.toBeUndefined();
+      expect(mockPrereqRepo.find).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/backend/src/courses/reviews.service.spec.ts
+++ b/apps/backend/src/courses/reviews.service.spec.ts
@@ -1,0 +1,157 @@
+import { ConflictException, NotFoundException, UnprocessableEntityException } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { ReviewsService } from './reviews.service';
+import { Review } from './review.entity';
+import { Enrollment } from '../enrollments/enrollment.entity';
+import { Course } from './course.entity';
+import { CreateReviewDto } from './dto/create-review.dto';
+
+describe('ReviewsService', () => {
+  let service: ReviewsService;
+
+  const mockReviewRepo = {
+    create: jest.fn(), save: jest.fn(), findOne: jest.fn(), findAndCount: jest.fn(),
+  };
+  const mockEnrollmentRepo = { findOne: jest.fn() };
+  const mockCourseRepo = { findOne: jest.fn() };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ReviewsService,
+        { provide: getRepositoryToken(Review), useValue: mockReviewRepo },
+        { provide: getRepositoryToken(Enrollment), useValue: mockEnrollmentRepo },
+        { provide: getRepositoryToken(Course), useValue: mockCourseRepo },
+      ],
+    }).compile();
+    service = module.get<ReviewsService>(ReviewsService);
+  });
+
+  afterEach(() => jest.clearAllMocks());
+
+  // ── create ────────────────────────────────────────────────────────────────────
+
+  describe('create', () => {
+    const courseId = 'c1', userId = 'u1';
+    const dto: CreateReviewDto = { rating: 5, comment: 'Great course!' };
+
+    it('creates a review for a completed enrollment', async () => {
+      mockCourseRepo.findOne.mockResolvedValue({ id: courseId } as Course);
+      mockReviewRepo.findOne.mockResolvedValue(null);
+      mockEnrollmentRepo.findOne.mockResolvedValue({
+        courseId, userId, completedAt: new Date(),
+      } as Enrollment);
+      const review = { id: 'r1', courseId, userId, rating: 5 } as Review;
+      mockReviewRepo.create.mockReturnValue(review);
+      mockReviewRepo.save.mockResolvedValue(review);
+
+      const result = await service.create(courseId, userId, dto);
+
+      expect(result).toEqual(review);
+      expect(mockReviewRepo.create).toHaveBeenCalledWith(
+        expect.objectContaining({ courseId, userId, rating: 5 }),
+      );
+    });
+
+    it('trims comment whitespace', async () => {
+      mockCourseRepo.findOne.mockResolvedValue({ id: courseId } as Course);
+      mockReviewRepo.findOne.mockResolvedValue(null);
+      mockEnrollmentRepo.findOne.mockResolvedValue({ completedAt: new Date() } as Enrollment);
+      mockReviewRepo.create.mockReturnValue({});
+      mockReviewRepo.save.mockResolvedValue({});
+
+      await service.create(courseId, userId, { rating: 4, comment: '  Good  ' });
+
+      expect(mockReviewRepo.create).toHaveBeenCalledWith(
+        expect.objectContaining({ comment: 'Good' }),
+      );
+    });
+
+    it('stores null comment when comment is empty string', async () => {
+      mockCourseRepo.findOne.mockResolvedValue({ id: courseId } as Course);
+      mockReviewRepo.findOne.mockResolvedValue(null);
+      mockEnrollmentRepo.findOne.mockResolvedValue({ completedAt: new Date() } as Enrollment);
+      mockReviewRepo.create.mockReturnValue({});
+      mockReviewRepo.save.mockResolvedValue({});
+
+      await service.create(courseId, userId, { rating: 3, comment: '' });
+
+      expect(mockReviewRepo.create).toHaveBeenCalledWith(
+        expect.objectContaining({ comment: null }),
+      );
+    });
+
+    it('throws NotFoundException when course does not exist', async () => {
+      mockCourseRepo.findOne.mockResolvedValue(null);
+
+      await expect(service.create(courseId, userId, dto)).rejects.toThrow(NotFoundException);
+      expect(mockReviewRepo.save).not.toHaveBeenCalled();
+    });
+
+    it('throws ConflictException when user already reviewed this course', async () => {
+      mockCourseRepo.findOne.mockResolvedValue({ id: courseId } as Course);
+      mockReviewRepo.findOne.mockResolvedValue({ id: 'existing' } as Review);
+
+      await expect(service.create(courseId, userId, dto)).rejects.toThrow(ConflictException);
+      expect(mockReviewRepo.save).not.toHaveBeenCalled();
+    });
+
+    it('throws UnprocessableEntityException when no enrollment exists', async () => {
+      mockCourseRepo.findOne.mockResolvedValue({ id: courseId } as Course);
+      mockReviewRepo.findOne.mockResolvedValue(null);
+      mockEnrollmentRepo.findOne.mockResolvedValue(null);
+
+      await expect(service.create(courseId, userId, dto)).rejects.toThrow(UnprocessableEntityException);
+    });
+
+    it('throws UnprocessableEntityException when enrollment not yet completed', async () => {
+      mockCourseRepo.findOne.mockResolvedValue({ id: courseId } as Course);
+      mockReviewRepo.findOne.mockResolvedValue(null);
+      mockEnrollmentRepo.findOne.mockResolvedValue({ completedAt: null } as Enrollment);
+
+      await expect(service.create(courseId, userId, dto)).rejects.toThrow(UnprocessableEntityException);
+    });
+  });
+
+  // ── findByCourse ──────────────────────────────────────────────────────────────
+
+  describe('findByCourse', () => {
+    it('returns paginated reviews with metadata', async () => {
+      mockCourseRepo.findOne.mockResolvedValue({ id: 'c1' } as Course);
+      const reviews = [{ id: 'r1' }, { id: 'r2' }] as Review[];
+      mockReviewRepo.findAndCount.mockResolvedValue([reviews, 2]);
+
+      const result = await service.findByCourse('c1', { page: 1, limit: 20 });
+
+      expect(result).toEqual({ data: reviews, total: 2, page: 1, limit: 20 });
+    });
+
+    it('defaults to page 1, limit 20 when query is empty', async () => {
+      mockCourseRepo.findOne.mockResolvedValue({ id: 'c1' } as Course);
+      mockReviewRepo.findAndCount.mockResolvedValue([[], 0]);
+
+      const result = await service.findByCourse('c1');
+
+      expect(result.page).toBe(1);
+      expect(result.limit).toBe(20);
+    });
+
+    it('calculates correct offset for page 3', async () => {
+      mockCourseRepo.findOne.mockResolvedValue({ id: 'c1' } as Course);
+      mockReviewRepo.findAndCount.mockResolvedValue([[], 0]);
+
+      await service.findByCourse('c1', { page: 3, limit: 10 });
+
+      expect(mockReviewRepo.findAndCount).toHaveBeenCalledWith(
+        expect.objectContaining({ skip: 20, take: 10 }),
+      );
+    });
+
+    it('throws NotFoundException when course does not exist', async () => {
+      mockCourseRepo.findOne.mockResolvedValue(null);
+
+      await expect(service.findByCourse('missing')).rejects.toThrow(NotFoundException);
+    });
+  });
+});

--- a/apps/backend/src/email/email.service.spec.ts
+++ b/apps/backend/src/email/email.service.spec.ts
@@ -1,0 +1,232 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { ConfigService } from '@nestjs/config';
+import { EmailService } from './email.service';
+import { EmailQueue, EmailStatus } from './email-queue.entity';
+import { EmailPreference } from './email-preference.entity';
+
+// Prevent real nodemailer transport
+jest.mock('nodemailer', () => ({
+  createTransport: jest.fn(() => ({
+    sendMail: jest.fn(),
+  })),
+}));
+
+describe('EmailService', () => {
+  let service: EmailService;
+  let mockTransporter: { sendMail: jest.Mock };
+
+  const mockQueueRepo = {
+    create: jest.fn(),
+    save: jest.fn(),
+    find: jest.fn(),
+  };
+  const mockPrefRepo = {
+    create: jest.fn(),
+    save: jest.fn(),
+    findOne: jest.fn(),
+  };
+  const mockConfig = {
+    get: jest.fn((key: string) => {
+      const cfg: Record<string, unknown> = {
+        'mail.host': 'smtp.example.com',
+        'mail.port': 587,
+        'mail.secure': false,
+        'mail.user': 'user',
+        'mail.pass': 'pass',
+        'mail.from': 'no-reply@example.com',
+        'mail.enabled': false, // dev mode — no real sends
+        'frontend.url': 'https://app.example.com',
+      };
+      return cfg[key];
+    }),
+  };
+
+  beforeEach(async () => {
+    const nodemailer = require('nodemailer');
+    mockTransporter = { sendMail: jest.fn() };
+    (nodemailer.createTransport as jest.Mock).mockReturnValue(mockTransporter);
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        EmailService,
+        { provide: getRepositoryToken(EmailQueue), useValue: mockQueueRepo },
+        { provide: getRepositoryToken(EmailPreference), useValue: mockPrefRepo },
+        { provide: ConfigService, useValue: mockConfig },
+      ],
+    }).compile();
+
+    service = module.get<EmailService>(EmailService);
+    jest.spyOn((service as any).logger, 'log').mockImplementation(() => undefined);
+    jest.spyOn((service as any).logger, 'error').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => jest.clearAllMocks());
+
+  // ── enqueue ──────────────────────────────────────────────────────────────────
+
+  describe('enqueue', () => {
+    it('saves a new job to the queue and triggers processing', async () => {
+      const job = { id: 'j1', to: 'a@b.com', status: EmailStatus.PENDING, attempts: 0 } as EmailQueue;
+      mockQueueRepo.create.mockReturnValue(job);
+      mockQueueRepo.save.mockResolvedValue(job);
+      mockQueueRepo.find.mockResolvedValue([]);
+
+      await service.enqueue('a@b.com', 'Subject', '<p>Body</p>');
+
+      expect(mockQueueRepo.create).toHaveBeenCalledWith(
+        expect.objectContaining({ to: 'a@b.com', subject: 'Subject', html: '<p>Body</p>' }),
+      );
+      expect(mockQueueRepo.save).toHaveBeenCalled();
+    });
+  });
+
+  // ── processQueue ─────────────────────────────────────────────────────────────
+
+  describe('processQueue', () => {
+    it('marks job as SENT in dev mode (mail.enabled = false)', async () => {
+      const job = {
+        id: 'j1', to: 'a@b.com', subject: 'Hi', html: '<p>Test</p>',
+        status: EmailStatus.PENDING, attempts: 0, nextRetryAt: null,
+      } as EmailQueue;
+      mockQueueRepo.find.mockResolvedValue([job]);
+      mockQueueRepo.save.mockImplementation((j: any) => Promise.resolve(j));
+
+      await service.processQueue();
+
+      expect(job.status).toBe(EmailStatus.SENT);
+      expect(mockTransporter.sendMail).not.toHaveBeenCalled();
+    });
+
+    it('schedules retry and preserves PENDING on send failure', async () => {
+      mockConfig.get.mockImplementation((key: string) => {
+        if (key === 'mail.enabled') return true;
+        if (key === 'mail.from') return 'no-reply@example.com';
+        return null;
+      });
+      mockTransporter.sendMail.mockRejectedValue(new Error('SMTP error'));
+
+      const job = {
+        id: 'j1', to: 'a@b.com', subject: 'Hi', html: '<p>Test</p>',
+        status: EmailStatus.PENDING, attempts: 0, nextRetryAt: null,
+      } as EmailQueue;
+      mockQueueRepo.find.mockResolvedValue([job]);
+      mockQueueRepo.save.mockImplementation((j: any) => Promise.resolve(j));
+
+      await service.processQueue();
+
+      expect(job.status).toBe(EmailStatus.PENDING);
+      expect(job.attempts).toBe(1);
+      expect(job.nextRetryAt).toBeInstanceOf(Date);
+      expect(job.lastError).toBe('SMTP error');
+    });
+
+    it('marks job as FAILED after max attempts exhausted', async () => {
+      mockConfig.get.mockImplementation((key: string) => {
+        if (key === 'mail.enabled') return true;
+        if (key === 'mail.from') return 'no-reply@example.com';
+        return null;
+      });
+      mockTransporter.sendMail.mockRejectedValue(new Error('Final failure'));
+
+      const job = {
+        id: 'j1', to: 'a@b.com', subject: 'Hi', html: '<p>Test</p>',
+        status: EmailStatus.PENDING, attempts: 2, nextRetryAt: null, // attempt 3 = MAX
+      } as EmailQueue;
+      mockQueueRepo.find.mockResolvedValue([job]);
+      mockQueueRepo.save.mockImplementation((j: any) => Promise.resolve(j));
+
+      await service.processQueue();
+
+      expect(job.status).toBe(EmailStatus.FAILED);
+    });
+
+    it('does not process if already processing (guards concurrent runs)', async () => {
+      (service as any).processing = true;
+      await service.processQueue();
+      expect(mockQueueRepo.find).not.toHaveBeenCalled();
+      (service as any).processing = false;
+    });
+  });
+
+  // ── event handlers ────────────────────────────────────────────────────────────
+
+  describe('onEnrollment', () => {
+    it('enqueues email when enrollment preference is enabled', async () => {
+      const prefs = { userId: 'u1', unsubscribedAll: false, enrollment: true, unsubscribeToken: 'tok' } as EmailPreference;
+      mockPrefRepo.findOne.mockResolvedValue(prefs);
+      const job = { id: 'j1' } as EmailQueue;
+      mockQueueRepo.create.mockReturnValue(job);
+      mockQueueRepo.save.mockResolvedValue(job);
+      mockQueueRepo.find.mockResolvedValue([]);
+
+      await service.onEnrollment({
+        userId: 'u1', courseId: 'c1', userEmail: 'a@b.com',
+        userName: 'Alice', courseTitle: 'Rust 101',
+      });
+
+      expect(mockQueueRepo.save).toHaveBeenCalled();
+    });
+
+    it('skips email when user has unsubscribed from all', async () => {
+      const prefs = { userId: 'u1', unsubscribedAll: true, enrollment: true, unsubscribeToken: 'tok' } as EmailPreference;
+      mockPrefRepo.findOne.mockResolvedValue(prefs);
+
+      await service.onEnrollment({
+        userId: 'u1', courseId: 'c1', userEmail: 'a@b.com',
+        userName: 'Alice', courseTitle: 'Rust 101',
+      });
+
+      expect(mockQueueRepo.save).not.toHaveBeenCalled();
+    });
+
+    it('skips email when enrollment preference is disabled', async () => {
+      const prefs = { userId: 'u1', unsubscribedAll: false, enrollment: false, unsubscribeToken: 'tok' } as EmailPreference;
+      mockPrefRepo.findOne.mockResolvedValue(prefs);
+
+      await service.onEnrollment({
+        userId: 'u1', courseId: 'c1', userEmail: 'a@b.com',
+        userName: 'Alice', courseTitle: 'Rust 101',
+      });
+
+      expect(mockQueueRepo.save).not.toHaveBeenCalled();
+    });
+  });
+
+  // ── unsubscribeByToken ────────────────────────────────────────────────────────
+
+  describe('unsubscribeByToken', () => {
+    it('sets unsubscribedAll to true for matching token', async () => {
+      const prefs = { userId: 'u1', unsubscribedAll: false, unsubscribeToken: 'tok123' } as EmailPreference;
+      mockPrefRepo.findOne.mockResolvedValue(prefs);
+      mockPrefRepo.save.mockImplementation((p: any) => Promise.resolve(p));
+
+      await service.unsubscribeByToken('tok123');
+
+      expect(prefs.unsubscribedAll).toBe(true);
+      expect(mockPrefRepo.save).toHaveBeenCalled();
+    });
+
+    it('returns silently when token not found (no throw)', async () => {
+      mockPrefRepo.findOne.mockResolvedValue(null);
+
+      await expect(service.unsubscribeByToken('unknown')).resolves.toBeUndefined();
+      expect(mockPrefRepo.save).not.toHaveBeenCalled();
+    });
+  });
+
+  // ── updatePreferences ─────────────────────────────────────────────────────────
+
+  describe('updatePreferences', () => {
+    it('merges updates into existing preferences', async () => {
+      const prefs = { userId: 'u1', enrollment: true, completion: true, unsubscribeToken: 'tok' } as EmailPreference;
+      mockPrefRepo.findOne.mockResolvedValue(prefs);
+      mockPrefRepo.save.mockImplementation((p: any) => Promise.resolve(p));
+
+      await service.updatePreferences('u1', { enrollment: false });
+
+      expect(prefs.enrollment).toBe(false);
+      expect(mockPrefRepo.save).toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/backend/src/gdpr/export.service.spec.ts
+++ b/apps/backend/src/gdpr/export.service.spec.ts
@@ -1,0 +1,198 @@
+import { NotFoundException } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { ExportService } from './export.service';
+import { User } from '../users/user.entity';
+import { AuditService } from '../audit/audit.service';
+
+// Prevent real zip creation touching filesystem
+jest.mock('adm-zip', () => {
+  return jest.fn().mockImplementation(() => ({
+    addFile: jest.fn(),
+    toBuffer: jest.fn(() => Buffer.from('FAKE_ZIP')),
+  }));
+});
+
+describe('ExportService', () => {
+  let service: ExportService;
+
+  const mockUserRepo = { findOne: jest.fn(), save: jest.fn() };
+  const mockAuditService = { log: jest.fn().mockResolvedValue(undefined) };
+
+  const makeUser = (overrides: Partial<User> = {}): User =>
+    ({
+      id: 'u1',
+      email: 'alice@example.com',
+      username: 'alice',
+      bio: 'Blockchain learner',
+      avatar: null,
+      stellarPublicKey: 'GSTELLAR123',
+      role: 'student',
+      isVerified: true,
+      createdAt: new Date('2024-01-01'),
+      passwordHash: 'hashed',
+      verificationToken: 'vt',
+      mfaSecret: null,
+      mfaBackupCodes: null,
+      referralCode: 'REF1',
+      referredBy: null,
+      deletedAt: null,
+      ...overrides,
+    } as User);
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ExportService,
+        { provide: getRepositoryToken(User), useValue: mockUserRepo },
+        { provide: AuditService, useValue: mockAuditService },
+      ],
+    }).compile();
+
+    service = module.get<ExportService>(ExportService);
+    jest.spyOn((service as any).logger, 'log').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => jest.clearAllMocks());
+
+  // ── exportUserData ─────────────────────────────────────────────────────────
+
+  describe('exportUserData', () => {
+    it('returns a Buffer containing the ZIP archive', async () => {
+      mockUserRepo.findOne.mockResolvedValue(makeUser());
+
+      const result = await service.exportUserData('u1');
+
+      expect(Buffer.isBuffer(result)).toBe(true);
+      expect(result.toString()).toBe('FAKE_ZIP');
+    });
+
+    it('throws NotFoundException when user does not exist', async () => {
+      mockUserRepo.findOne.mockResolvedValue(null);
+
+      await expect(service.exportUserData('missing')).rejects.toThrow(NotFoundException);
+    });
+
+    it('writes profile.json and on_chain_notice.txt to the ZIP', async () => {
+      const AdmZip = require('adm-zip');
+      const mockZipInstance = { addFile: jest.fn(), toBuffer: jest.fn(() => Buffer.from('')) };
+      (AdmZip as jest.Mock).mockImplementationOnce(() => mockZipInstance);
+
+      mockUserRepo.findOne.mockResolvedValue(makeUser());
+
+      await service.exportUserData('u1');
+
+      const filenames = mockZipInstance.addFile.mock.calls.map((c: any[]) => c[0]);
+      expect(filenames).toContain('profile.json');
+      expect(filenames).toContain('on_chain_notice.txt');
+    });
+
+    it('excludes sensitive fields (passwordHash, mfaSecret) from profile.json', async () => {
+      const AdmZip = require('adm-zip');
+      const mockZipInstance = { addFile: jest.fn(), toBuffer: jest.fn(() => Buffer.from('')) };
+      (AdmZip as jest.Mock).mockImplementationOnce(() => mockZipInstance);
+
+      mockUserRepo.findOne.mockResolvedValue(makeUser());
+
+      await service.exportUserData('u1');
+
+      const profileCall = mockZipInstance.addFile.mock.calls.find(
+        (c: any[]) => c[0] === 'profile.json',
+      );
+      const profileJson = JSON.parse(profileCall[1].toString());
+      expect(profileJson).not.toHaveProperty('passwordHash');
+      expect(profileJson).not.toHaveProperty('mfaSecret');
+      expect(profileJson).not.toHaveProperty('verificationToken');
+    });
+
+    it('logs a GDPR audit entry for the export', async () => {
+      mockUserRepo.findOne.mockResolvedValue(makeUser());
+
+      await service.exportUserData('u1', '1.2.3.4');
+
+      expect(mockAuditService.log).toHaveBeenCalledWith(
+        'gdpr.export.requested',
+        'u1',
+        true,
+        expect.any(Object),
+        '1.2.3.4',
+      );
+    });
+  });
+
+  // ── deleteAccount ──────────────────────────────────────────────────────────
+
+  describe('deleteAccount', () => {
+    it('erases PII fields and returns success with on-chain caveat', async () => {
+      mockUserRepo.findOne.mockResolvedValue(makeUser());
+      mockUserRepo.save.mockImplementation((u: any) => Promise.resolve(u));
+
+      const result = await service.deleteAccount('u1');
+
+      expect(result.success).toBe(true);
+      expect(result.onChainCaveat).toContain('Stellar');
+    });
+
+    it('throws NotFoundException when user does not exist', async () => {
+      mockUserRepo.findOne.mockResolvedValue(null);
+
+      await expect(service.deleteAccount('missing')).rejects.toThrow(NotFoundException);
+    });
+
+    it('replaces email with deleted placeholder', async () => {
+      const user = makeUser();
+      mockUserRepo.findOne.mockResolvedValue(user);
+      mockUserRepo.save.mockImplementation((u: any) => Promise.resolve(u));
+
+      await service.deleteAccount('u1');
+
+      const savedUser = mockUserRepo.save.mock.calls[0][0];
+      expect(savedUser.email).toBe('deleted-u1@deleted.invalid');
+    });
+
+    it('nullifies all PII fields', async () => {
+      const user = makeUser();
+      mockUserRepo.findOne.mockResolvedValue(user);
+      mockUserRepo.save.mockImplementation((u: any) => Promise.resolve(u));
+
+      await service.deleteAccount('u1');
+
+      const saved = mockUserRepo.save.mock.calls[0][0];
+      expect(saved.username).toBeNull();
+      expect(saved.passwordHash).toBe('');
+      expect(saved.avatar).toBeNull();
+      expect(saved.bio).toBeNull();
+      expect(saved.stellarPublicKey).toBeNull();
+      expect(saved.verificationToken).toBeNull();
+      expect(saved.mfaSecret).toBeNull();
+      expect(saved.referralCode).toBeNull();
+      expect(saved.referredBy).toBeNull();
+    });
+
+    it('sets deletedAt to a Date', async () => {
+      const user = makeUser();
+      mockUserRepo.findOne.mockResolvedValue(user);
+      mockUserRepo.save.mockImplementation((u: any) => Promise.resolve(u));
+
+      await service.deleteAccount('u1');
+
+      const saved = mockUserRepo.save.mock.calls[0][0];
+      expect(saved.deletedAt).toBeInstanceOf(Date);
+    });
+
+    it('logs a GDPR audit entry for the deletion', async () => {
+      mockUserRepo.findOne.mockResolvedValue(makeUser());
+      mockUserRepo.save.mockImplementation((u: any) => Promise.resolve(u));
+
+      await service.deleteAccount('u1', '10.0.0.1');
+
+      expect(mockAuditService.log).toHaveBeenCalledWith(
+        'gdpr.account.deleted',
+        'u1',
+        true,
+        expect.any(Object),
+        '10.0.0.1',
+      );
+    });
+  });
+});

--- a/apps/backend/src/kyc/kyc.service.spec.ts
+++ b/apps/backend/src/kyc/kyc.service.spec.ts
@@ -1,0 +1,223 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { ConfigService } from '@nestjs/config';
+import { KycService } from './kyc.service';
+import { KycCustomer, KycStatus } from './kyc-customer.entity';
+import { KycDocument } from './kyc-document.entity';
+
+// Prevent real HTTP calls
+global.fetch = jest.fn();
+
+describe('KycService', () => {
+  let service: KycService;
+
+  const mockCustomerRepo = {
+    findOne: jest.fn(),
+    create: jest.fn(),
+    save: jest.fn(),
+    createQueryBuilder: jest.fn(),
+  };
+  const mockDocumentRepo = {
+    create: jest.fn(),
+    save: jest.fn(),
+  };
+  const mockConfig = {
+    get: jest.fn((key: string) => {
+      if (key === 'kyc.providerApiKey') return 'test-api-key';
+      return null;
+    }),
+  };
+
+  const qb: any = {
+    select: jest.fn().mockReturnThis(),
+    addSelect: jest.fn().mockReturnThis(),
+    groupBy: jest.fn().mockReturnThis(),
+    getRawMany: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    mockCustomerRepo.createQueryBuilder.mockReturnValue(qb);
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      json: jest.fn().mockResolvedValue({ session_id: 'sess-123' }),
+    });
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        KycService,
+        { provide: getRepositoryToken(KycCustomer), useValue: mockCustomerRepo },
+        { provide: getRepositoryToken(KycDocument), useValue: mockDocumentRepo },
+        { provide: ConfigService, useValue: mockConfig },
+      ],
+    }).compile();
+
+    service = module.get<KycService>(KycService);
+    jest.spyOn((service as any).logger, 'warn').mockImplementation(() => undefined);
+    jest.spyOn((service as any).logger, 'error').mockImplementation(() => undefined);
+    jest.spyOn((service as any).logger, 'log').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => jest.clearAllMocks());
+
+  // ── getStatus ──────────────────────────────────────────────────────────────
+
+  describe('getStatus', () => {
+    it('returns existing customer record', async () => {
+      const customer = { stellarPublicKey: 'GKEY', status: 'approved' as KycStatus } as KycCustomer;
+      mockCustomerRepo.findOne.mockResolvedValue(customer);
+
+      const result = await service.getStatus('GKEY');
+
+      expect(result).toEqual(customer);
+    });
+
+    it('returns virtual record with status "none" when customer does not exist', async () => {
+      mockCustomerRepo.findOne.mockResolvedValue(null);
+
+      const result = await service.getStatus('GNEW');
+
+      expect(result.stellarPublicKey).toBe('GNEW');
+      expect(result.status).toBe('none');
+    });
+  });
+
+  // ── upsertCustomer ─────────────────────────────────────────────────────────
+
+  describe('upsertCustomer', () => {
+    it('creates a new customer record when none exists', async () => {
+      const created = { stellarPublicKey: 'GKEY', status: 'pending' as KycStatus } as KycCustomer;
+      mockCustomerRepo.findOne.mockResolvedValue(null);
+      mockCustomerRepo.create.mockReturnValue(created);
+      mockCustomerRepo.save.mockResolvedValue({ ...created, providerId: 'sess-123' });
+
+      const result = await service.upsertCustomer('GKEY', { firstName: 'Alice' });
+
+      expect(mockCustomerRepo.create).toHaveBeenCalledWith({ stellarPublicKey: 'GKEY', status: 'pending' });
+      expect(result.providerId).toBe('sess-123');
+    });
+
+    it('resets an existing customer status to pending on re-submission', async () => {
+      const existing = { stellarPublicKey: 'GKEY', status: 'rejected' as KycStatus, providerId: 'old' } as KycCustomer;
+      mockCustomerRepo.findOne.mockResolvedValue(existing);
+      mockCustomerRepo.save.mockImplementation((c: any) => Promise.resolve(c));
+
+      await service.upsertCustomer('GKEY', { firstName: 'Alice' });
+
+      expect(existing.status).toBe('pending');
+    });
+
+    it('stores provider session_id when API call succeeds', async () => {
+      const customer = { stellarPublicKey: 'GKEY', status: 'pending' as KycStatus } as KycCustomer;
+      mockCustomerRepo.findOne.mockResolvedValue(null);
+      mockCustomerRepo.create.mockReturnValue(customer);
+      mockCustomerRepo.save.mockImplementation((c: any) => Promise.resolve(c));
+
+      await service.upsertCustomer('GKEY', {});
+
+      expect(customer.providerId).toBe('sess-123');
+    });
+
+    it('saves customer even when API call fails (non-fatal)', async () => {
+      (global.fetch as jest.Mock).mockRejectedValue(new Error('network error'));
+      const customer = { stellarPublicKey: 'GKEY', status: 'pending' as KycStatus } as KycCustomer;
+      mockCustomerRepo.findOne.mockResolvedValue(null);
+      mockCustomerRepo.create.mockReturnValue(customer);
+      mockCustomerRepo.save.mockImplementation((c: any) => Promise.resolve(c));
+
+      await expect(service.upsertCustomer('GKEY', {})).resolves.toBeDefined();
+      expect(mockCustomerRepo.save).toHaveBeenCalled();
+    });
+
+    it('saves customer when API returns non-OK response (non-fatal)', async () => {
+      (global.fetch as jest.Mock).mockResolvedValue({ ok: false, status: 400 });
+      const customer = { stellarPublicKey: 'GKEY', status: 'pending' as KycStatus } as KycCustomer;
+      mockCustomerRepo.findOne.mockResolvedValue(null);
+      mockCustomerRepo.create.mockReturnValue(customer);
+      mockCustomerRepo.save.mockImplementation((c: any) => Promise.resolve(c));
+
+      await expect(service.upsertCustomer('GKEY', {})).resolves.toBeDefined();
+    });
+  });
+
+  // ── handleWebhook ──────────────────────────────────────────────────────────
+
+  describe('handleWebhook', () => {
+    it('updates customer status to approved for APPROVED webhook', async () => {
+      const customer = { stellarPublicKey: 'GKEY', status: 'pending' as KycStatus } as KycCustomer;
+      mockCustomerRepo.findOne.mockResolvedValue(customer);
+      mockCustomerRepo.save.mockImplementation((c: any) => Promise.resolve(c));
+
+      await service.handleWebhook({ alias: 'GKEY', status: 'APPROVED' });
+
+      expect(customer.status).toBe('approved');
+    });
+
+    it('maps VERIFIED to approved', async () => {
+      const customer = { stellarPublicKey: 'GKEY', status: 'pending' as KycStatus } as KycCustomer;
+      mockCustomerRepo.findOne.mockResolvedValue(customer);
+      mockCustomerRepo.save.mockImplementation((c: any) => Promise.resolve(c));
+
+      await service.handleWebhook({ alias: 'GKEY', status: 'VERIFIED' });
+
+      expect(customer.status).toBe('approved');
+    });
+
+    it('maps REJECTED to rejected', async () => {
+      const customer = { stellarPublicKey: 'GKEY', status: 'pending' as KycStatus } as KycCustomer;
+      mockCustomerRepo.findOne.mockResolvedValue(customer);
+      mockCustomerRepo.save.mockImplementation((c: any) => Promise.resolve(c));
+
+      await service.handleWebhook({ alias: 'GKEY', status: 'REJECTED' });
+
+      expect(customer.status).toBe('rejected');
+    });
+
+    it('defaults unknown statuses to pending', async () => {
+      const customer = { stellarPublicKey: 'GKEY', status: 'approved' as KycStatus } as KycCustomer;
+      mockCustomerRepo.findOne.mockResolvedValue(customer);
+      mockCustomerRepo.save.mockImplementation((c: any) => Promise.resolve(c));
+
+      await service.handleWebhook({ alias: 'GKEY', status: 'UNDER_REVIEW' });
+
+      expect(customer.status).toBe('pending');
+    });
+
+    it('returns early without throwing when customer not found', async () => {
+      mockCustomerRepo.findOne.mockResolvedValue(null);
+
+      await expect(service.handleWebhook({ alias: 'UNKNOWN', status: 'APPROVED' })).resolves.toBeUndefined();
+      expect(mockCustomerRepo.save).not.toHaveBeenCalled();
+    });
+
+    it('looks up customer by session_id when alias not provided', async () => {
+      const customer = { stellarPublicKey: 'GKEY', status: 'pending' as KycStatus, providerId: 'sess-123' } as KycCustomer;
+      mockCustomerRepo.findOne.mockResolvedValue(customer);
+      mockCustomerRepo.save.mockImplementation((c: any) => Promise.resolve(c));
+
+      await service.handleWebhook({ session_id: 'sess-123', status: 'APPROVED' });
+
+      expect(mockCustomerRepo.findOne).toHaveBeenCalledWith({
+        where: { providerId: 'sess-123' },
+      });
+    });
+  });
+
+  // ── isApproved ─────────────────────────────────────────────────────────────
+
+  describe('isApproved', () => {
+    it('returns true when customer status is approved', async () => {
+      mockCustomerRepo.findOne.mockResolvedValue({ status: 'approved' } as KycCustomer);
+      expect(await service.isApproved('GKEY')).toBe(true);
+    });
+
+    it('returns false when customer status is pending', async () => {
+      mockCustomerRepo.findOne.mockResolvedValue({ status: 'pending' } as KycCustomer);
+      expect(await service.isApproved('GKEY')).toBe(false);
+    });
+
+    it('returns false when customer does not exist', async () => {
+      mockCustomerRepo.findOne.mockResolvedValue(null);
+      expect(await service.isApproved('GKEY')).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
Add targeted unit tests — P2 second wave
  
  Summary
  
  Second wave of deterministic unit tests addressing the P2-Medium coverage gap.
  Covers 6 high-value untested backend services and 2 Rust smart contracts with
  zero test files. All tests are fully isolated using mocks — no database,
  network, or external service required.
  
  ───────────────────────────────────────────────────────────────────────────────
  
  Backend — NestJS/Jest (6 new spec files)
  
  credentials.service.spec.ts
  
  - issue: returns existing credential without re-issuing (idempotent); issues
  when KYC not required; issues when KYC required and approved; throws
  ForbiddenException when KYC required but not approved; saves credential even
  when mintReward fails (non-fatal)
  - findByUser: correct query with issuedAt DESC ordering
  - findOne: returns with user + course relations; throws NotFoundException
  - verify: returns verified: true on match; verified: false when txHash not
  found
  
  access-control.service.spec.ts
  
  - grantAccess: creates record; passes optional expiry date and IP list through
  to create
  - checkAccess: returns allowed: false — no record, expired subscription, IP not
  in list; returns allowed: true — IP in list, no IP restriction (null), empty IP
  list, future expiry; logs every access check
  - revokeAccess: sets isActive: false for correct course+user
  - updateSubscription: updates expiry date for correct course+user
  
  quizzes.service.spec.ts
  
  - createQuiz: creates with lessonId merged into data
  - getQuiz: returns with questions.answers relations; throws NotFoundException
  - submitAttempt: throws NotFoundException when quiz missing; scores correct MC
  answer at 100%; scores wrong answer at 0%; essay questions not auto-graded
  (isGraded: false); skips answers for unknown questionId
  - gradeEssay: updates answer points, recalculates attempt score, sets isGraded:
  true and feedback
  
  forums.service.spec.ts
  
  - createPost: student can create non-pinned post; instructor/admin can create
  pinned post; student trying to pin throws ForbiddenException; course not found
  throws NotFoundException; moderation analysis called after save
  - createReply: creates reply when post exists; post not found throws
  NotFoundException; student marking answer throws ForbiddenException; instructor
  can mark answer, clears previous answer first
  - findPostsByCourse: throws NotFoundException when course missing; returns
  posts ordered by isPinned DESC, createdAt DESC
  
  bookings.service.spec.ts
  
  - createBooking: creates booking with no conflict; notifies both parties;
  throws ConflictException on overlapping confirmed booking
  - respondToBooking: confirms/rejects pending booking; notifies requester;
  throws NotFoundException, ForbiddenException (wrong worker), ConflictException
   (not pending)
  - cancelBooking: requester can cancel; worker can cancel; notifies other party;
  throws NotFoundException, ForbiddenException (stranger), ConflictException
  (already rejected or cancelled)
  
  webhooks.service.spec.ts
  
  - register: creates webhook with generated secret; each registration produces a
  unique secret
  - list: returns all webhooks for user
  - getWebhookForUser: returns webhook; throws NotFoundException
  - delete: removes webhook; throws NotFoundException
  - rotateSecret: preserves old secret as previousSecret; new secret differs from
  old; returns expiry timestamp; throws NotFoundException
  - getDlq: returns failed deliveries; throws NotFoundException
  
  ───────────────────────────────────────────────────────────────────────────────
  
  Rust contracts — Soroban (2 new test modules)
  
  badges/tests_ext.rs
  
  - get_badge_type: None for missing type; correct record after creation;
  total_minted increments after mint
  - get_badge: None for nonexistent id; correct record after mint
  - transfer: always panics with "soulbound" (no exceptions)
  - burn_badge: removes badge from owner list; verify_badge returns false after
  burn; non-admin panics; nonexistent id panics; double-burn panics with "Badge
  already burned"
  
  dispute/tests_ext.rs
  
  - set_arbiter: updates stored arbiter; non-admin panics
  - get_dispute: None for missing id; correct fields after open
  - open_dispute: zero amount panics; id increments correctly
  - settle: panics when called before record_decision; double-settle panics;
  non-arbiter panics; FavourClaimant pays full amount to claimant;
  FavourRespondent pays full amount to respondent; dispute status is Settled
   after successful settle
  - submit_evidence: third-party submission panics; submission on already-settled
  dispute panics
  
  ───────────────────────────────────────────────────────────────────────────────
  
  Testing
  
  # Backend unit tests
  cd apps/backend && npm test
  
  # Rust contract tests
  cargo test -p brain-storm-badges
  cargo test -p brain-storm-dispute

closes #855
